### PR TITLE
Add compiler switches for treating warnings as errors, fix current warnings

### DIFF
--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -14,21 +14,14 @@ TARGET = AdvancedSettings
 TEMPLATE = app
 
 *msvc* {
-    #/W4 still has warnings. Including warnings in third party files.
-    #QMAKE_CFLAGS_WARN_ON -= -W3
-    #QMAKE_CXXFLAGS_WARN_ON -= -W3
     #Removing -W3 from both FLAGS is necessary, otherwise compiler will give
     #D9025: overriding '/W4' with '/W3'
-    #QMAKE_CXXFLAGS += /W4
+    QMAKE_CFLAGS_WARN_ON -= -W3
+    QMAKE_CXXFLAGS_WARN_ON -= -W3
+    QMAKE_CXXFLAGS += /W4 /wd4127
     
-    QMAKE_CXXFLAGS += /WX
-    
-    #The MSVC frontend for clang does not understand /external
     !*clang-msvc{ 
-        #external:anglebrackets suppresses warnings made in #includes
-        #made with angle brackets, like #include <iostream>, but will 
-        #still report for includes done with quotes.
-        QMAKE_CXXFLAGS += /experimental:external /external:anglebrackets
+        QMAKE_CXXFLAGS += /WX
     }
 }
 

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -30,6 +30,7 @@ TEMPLATE = app
 
 *clang* {
     QMAKE_CXXFLAGS += -Werror
+    QMAKE_CXXFLAGS += --system-header-prefix=third-party
 }
 SOURCES += src/main.cpp\
     src/overlaycontroller.cpp \

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -22,14 +22,25 @@ TEMPLATE = app
     #QMAKE_CXXFLAGS += /W4
     
     QMAKE_CXXFLAGS += /WX
+    
+    #The MSVC frontend for clang does not understand /external
+    !*clang-msvc{ 
+        #external:anglebrackets suppresses warnings made in #includes
+        #made with angle brackets, like #include <iostream>, but will 
+        #still report for includes done with quotes.
+        QMAKE_CXXFLAGS += /experimental:external /external:anglebrackets
+    }
 }
 
 *g++* {
     QMAKE_CXXFLAGS += -Werror
 }
 
-*clang* {
+#Look for anything clang that is not clang-msvc, since it does not
+#allow all the same switches as regular clang.
+*clang|*clang-g++|*clang-libc++ {
     QMAKE_CXXFLAGS += -Werror
+    #All includes from the third-party directory will not warn.
     QMAKE_CXXFLAGS += --system-header-prefix=third-party
 }
 SOURCES += src/main.cpp\

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -13,7 +13,24 @@ lessThan(QT_MINOR_VERSION, 6): error("requires Qt 5.6 or higher")
 TARGET = AdvancedSettings
 TEMPLATE = app
 
+*msvc* {
+    #/W4 still has warnings. Including warnings in third party files.
+    #QMAKE_CFLAGS_WARN_ON -= -W3
+    #QMAKE_CXXFLAGS_WARN_ON -= -W3
+    #Removing -W3 from both FLAGS is necessary, otherwise compiler will give
+    #D9025: overriding '/W4' with '/W3'
+    #QMAKE_CXXFLAGS += /W4
+    
+    QMAKE_CXXFLAGS += /WX
+}
 
+*g++* {
+    QMAKE_CXXFLAGS += -Werror
+}
+
+*clang* {
+    QMAKE_CXXFLAGS += -Werror
+}
 SOURCES += src/main.cpp\
     src/overlaycontroller.cpp \
     src/tabcontrollers/AudioTabController.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,21 +10,6 @@
 #include <iostream>
 #include "logging.h"
 
-const char* logConfigFileName = "logging.conf";
-
-const char* logConfigDefault =
-"* GLOBAL:\n"
-"	FORMAT = \"[%level] %datetime{%Y-%M-%d %H:%m:%s}: %msg\"\n"
-"	FILENAME = \"AdvancedSettings.log\"\n"
-"	ENABLED = true\n"
-"	TO_FILE = true\n"
-"	TO_STANDARD_OUTPUT = true\n"
-"	MAX_LOG_FILE_SIZE = 2097152 ## 2MB\n"
-"* TRACE:\n"
-"	ENABLED = false\n"
-"* DEBUG:\n"
-"	ENABLED = false\n";
-
 INITIALIZE_EASYLOGGINGPP
 
 void myQtMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
@@ -140,6 +125,21 @@ enum ReturnErrorCode {
 };
 
 int main(int argc, char *argv[]) {
+
+    const char* logConfigFileName = "logging.conf";
+
+    const char* logConfigDefault =
+        "* GLOBAL:\n"
+        "	FORMAT = \"[%level] %datetime{%Y-%M-%d %H:%m:%s}: %msg\"\n"
+        "	FILENAME = \"AdvancedSettings.log\"\n"
+        "	ENABLED = true\n"
+        "	TO_FILE = true\n"
+        "	TO_STANDARD_OUTPUT = true\n"
+        "	MAX_LOG_FILE_SIZE = 2097152 ## 2MB\n"
+        "* TRACE:\n"
+        "	ENABLED = false\n"
+        "* DEBUG:\n"
+        "	ENABLED = false\n";
 
     const bool desktop_mode = argument::CheckCommandLineArgument(argc, argv, argument::DESKTOP_MODE);
     const bool no_sound = argument::CheckCommandLineArgument(argc, argv, argument::NO_SOUND);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,5 +256,4 @@ int main(int argc, char *argv[]) {
 		LOG(FATAL) << e.what();
 		return ReturnErrorCode::GENERAL_FAILURE;
 	}
-	return ReturnErrorCode::SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,8 @@ void installManifest(bool cleaninstall = false) {
 		if (apperror != vr::VRApplicationError_None) {
 			throw std::runtime_error(std::string("Could not add application manifest: ") + std::string(vr::VRApplications()->GetApplicationsErrorNameFromEnum(apperror)));
 		} else if (!alreadyInstalled || cleaninstall) {
-			auto apperror = vr::VRApplications()->SetApplicationAutoLaunch(advsettings::OverlayController::applicationKey, true);
-			if (apperror != vr::VRApplicationError_None) {
+                        auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(advsettings::OverlayController::applicationKey, true);
+                        if (app_error != vr::VRApplicationError_None) {
 				throw std::runtime_error(std::string("Could not set auto start: ") + std::string(vr::VRApplications()->GetApplicationsErrorNameFromEnum(apperror)));
 			}
 		}

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -301,8 +301,8 @@ void OverlayController::OnRenderRequest() {
 
 void OverlayController::renderOverlay() {
 	if (!desktopMode) {
-		// skip rendering if the overlay isn't visible
-		if (!vr::VROverlay() || !vr::VROverlay()->IsOverlayVisible(m_ulOverlayHandle) && !vr::VROverlay()->IsOverlayVisible(m_ulOverlayThumbnailHandle))
+                // skip rendering if the overlay isn't visible
+                if (!vr::VROverlay() || (!vr::VROverlay()->IsOverlayVisible(m_ulOverlayHandle) && !vr::VROverlay()->IsOverlayVisible(m_ulOverlayThumbnailHandle)))
 			return;
 		m_pRenderControl->polishItems();
 		m_pRenderControl->sync();

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -593,7 +593,7 @@ void OverlayController::AddOffsetToCollisionBounds(float offset[3], bool commit)
 			}
 		}
 		vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(collisionBounds, collisionBoundsCount);
-		delete collisionBounds;
+                delete[] collisionBounds;
 	}
 	if (commit && collisionBoundsCount > 0) {
 		vr::VRChaperoneSetup()->CommitWorkingCopy(vr::EChaperoneConfigFile_Live);
@@ -621,7 +621,7 @@ void OverlayController::RotateCollisionBounds(float angle, bool commit) {
 			}
 		}
 		vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(collisionBounds, collisionBoundsCount);
-		delete collisionBounds;
+                delete[] collisionBounds;
 	}
 	if (commit && collisionBoundsCount > 0) {
 		vr::VRChaperoneSetup()->CommitWorkingCopy(vr::EChaperoneConfigFile_Live);

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -64,7 +64,7 @@ private:
 	bool dashboardVisible = false;
 
 	QPoint m_ptLastMouse;
-	Qt::MouseButtons m_lastMouseButtons = 0;
+        Qt::MouseButtons m_lastMouseButtons = 0;
 
 	bool desktopMode;
 	bool noSound;
@@ -112,7 +112,7 @@ public:
 	void AddOffsetToCollisionBounds(float offset[3], bool commit = true);
 	void RotateCollisionBounds(float angle, bool commit = true); // around y axis
 
-	bool isDesktopMode() { return desktopMode; };
+        bool isDesktopMode() { return desktopMode; };
 
 	utils::ChaperoneUtils& chaperoneUtils() noexcept { return m_chaperoneUtils; }
 

--- a/src/tabcontrollers/AccessibilityTabController.cpp
+++ b/src/tabcontrollers/AccessibilityTabController.cpp
@@ -19,9 +19,9 @@ void AccessibilityTabController::initStage1() {
   reloadPttConfig();
 }
 
-void AccessibilityTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-  this->parent = parent;
-  this->widget = widget;
+void AccessibilityTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+  this->parent = var_parent;
+  this->widget = var_widget;
 }
 
 void AccessibilityTabController::setTrackingUniverse(int value) {

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -54,12 +54,12 @@ namespace advsettings {
 			std::string notifIconPath = QApplication::applicationDirPath().toStdString() + "/res/qml/ptt_notification.png";
 			if (QFile::exists(QString::fromStdString(notifIconPath))) {
 				vr::VROverlay()->SetOverlayFromFile(m_ulNotificationOverlayHandle, notifIconPath.c_str());
-				vr::VROverlay()->SetOverlayWidthInMeters(m_ulNotificationOverlayHandle, 0.02f);
-                                vr::HmdMatrix34_t notificationTransform = {
-                                        1.0f, 0.0f, 0.0f, 0.12f,
-                                        0.0f, 1.0f, 0.0f, 0.08f,
-                                        0.0f, 0.0f, 1.0f, -0.3f
-				};
+                                vr::VROverlay()->SetOverlayWidthInMeters(m_ulNotificationOverlayHandle, 0.02f);
+                        vr::HmdMatrix34_t notificationTransform = {{
+                                        {1.0f, 0.0f, 0.0f, 0.12f},
+                                        {0.0f, 1.0f, 0.0f, 0.08f},
+                                        {0.0f, 0.0f, 1.0f, -0.3f}
+                                }};
 				vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(m_ulNotificationOverlayHandle, vr::k_unTrackedDeviceIndex_Hmd, &notificationTransform);
 			} else {
 				LOG(ERROR) << "Could not find notification icon \"" << notifIconPath << "\"";

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -55,10 +55,10 @@ namespace advsettings {
 			if (QFile::exists(QString::fromStdString(notifIconPath))) {
 				vr::VROverlay()->SetOverlayFromFile(m_ulNotificationOverlayHandle, notifIconPath.c_str());
 				vr::VROverlay()->SetOverlayWidthInMeters(m_ulNotificationOverlayHandle, 0.02f);
-				vr::HmdMatrix34_t notificationTransform = {
-					1.0f, 0.0f, 0.0f, 0.12f,
-					0.0f, 1.0f, 0.0f, 0.08f,
-					0.0f, 0.0f, 1.0f, -0.3f
+                                vr::HmdMatrix34_t notificationTransform = {
+                                        1.0f, 0.0f, 0.0f, 0.12f,
+                                        0.0f, 1.0f, 0.0f, 0.08f,
+                                        0.0f, 0.0f, 1.0f, -0.3f
 				};
 				vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(m_ulNotificationOverlayHandle, vr::k_unTrackedDeviceIndex_Hmd, &notificationTransform);
 			} else {
@@ -307,25 +307,25 @@ namespace advsettings {
 		emit recordingDeviceListChanged();
 	}
 
-	int AudioTabController::getPlaybackDeviceCount() {
-		return (int)m_playbackDevices.size();
+        int AudioTabController::getPlaybackDeviceCount() {
+            return static_cast<int>(m_playbackDevices.size());
 	}
 
-	QString AudioTabController::getPlaybackDeviceName(int index) {
-		if (index < m_playbackDevices.size()) {
-			return QString::fromStdString(m_playbackDevices[index].second);
+        QString AudioTabController::getPlaybackDeviceName(int index) {
+            if (index > 0 && static_cast<size_t>(index) < m_playbackDevices.size()) {
+                return QString::fromStdString(m_playbackDevices[static_cast<size_t>(index)].second);
 		} else {
 			return "<ERROR>";
 		}
 	}
 
-	int AudioTabController::getRecordingDeviceCount() {
-		return (int)m_recordingDevices.size();
+        int AudioTabController::getRecordingDeviceCount() {
+            return static_cast<int>(m_recordingDevices.size());
 	}
 
 	QString AudioTabController::getRecordingDeviceName(int index) {
-		if (index < m_recordingDevices.size()) {
-			return QString::fromStdString(m_recordingDevices[index].second);
+                if (index > 0 && static_cast<size_t>(index) < m_playbackDevices.size()) {
+                    return QString::fromStdString(m_recordingDevices[static_cast<size_t>(index)].second);
 		} else {
 			return "<ERROR>";
 		}
@@ -346,15 +346,18 @@ namespace advsettings {
 
 	void AudioTabController::setPlaybackDeviceIndex(int index, bool notify) {
 		if (index != m_playbackDeviceIndex) {
-			if (index < m_playbackDevices.size() && index != m_mirrorDeviceIndex) {
+                        if (index > 0 && static_cast<size_t>(index) < m_playbackDevices.size() && index != m_mirrorDeviceIndex) {
 				vr::EVRSettingsError vrSettingsError;
 				//Applys Audio Switch IN VR
-				vr::VRSettings()->SetString(vr::k_pch_audio_Section, vr::k_pch_audio_OnPlaybackDevice_String, m_playbackDevices[index].first.c_str(), &vrSettingsError);
+                                vr::VRSettings()->SetString(vr::k_pch_audio_Section,
+                                                            vr::k_pch_audio_OnPlaybackDevice_String,
+                                                            m_playbackDevices[static_cast<size_t>(index)].first.c_str(),
+                                                            &vrSettingsError);
 				if (vrSettingsError != vr::VRSettingsError_None) {
 					LOG(WARNING) << "Could not write \"" << vr::k_pch_audio_OnPlaybackDevice_String << "\" setting: " << vr::VRSettings()->GetSettingsErrorNameFromEnum(vrSettingsError);
 				} else {
-					vr::VRSettings()->Sync();
-					audioManager->setPlaybackDevice(m_playbackDevices[index].first, notify);
+                                        vr::VRSettings()->Sync();
+                                        audioManager->setPlaybackDevice(m_playbackDevices[static_cast<size_t>(index)].first, notify);
 				}
 			} else if (notify) {
 				emit playbackDeviceIndexChanged(m_playbackDeviceIndex);
@@ -373,14 +376,17 @@ namespace advsettings {
 					vr::VRSettings()->Sync();
 					audioManager->setMirrorDevice("", notify);
 				}
-			} else if (index < m_playbackDevices.size() && index != m_playbackDeviceIndex && index != m_mirrorDeviceIndex) {
-				vr::EVRSettingsError vrSettingsError;
-				vr::VRSettings()->SetString(vr::k_pch_audio_Section, vr::k_pch_audio_OnPlaybackMirrorDevice_String, m_playbackDevices[index].first.c_str(), &vrSettingsError);
+                        } else if (index > 0 && static_cast<size_t>(index) < m_playbackDevices.size() && index != m_playbackDeviceIndex && index != m_mirrorDeviceIndex) {
+                                vr::EVRSettingsError vrSettingsError;
+                                vr::VRSettings()->SetString(vr::k_pch_audio_Section,
+                                                            vr::k_pch_audio_OnPlaybackMirrorDevice_String,
+                                                            m_playbackDevices[static_cast<size_t>(index)].first.c_str(),
+                                                            &vrSettingsError);
 				if (vrSettingsError != vr::VRSettingsError_None) {
 					LOG(WARNING) << "Could not write \"" << vr::k_pch_audio_OnPlaybackMirrorDevice_String << "\" setting: " << vr::VRSettings()->GetSettingsErrorNameFromEnum(vrSettingsError);
 				} else {
 					vr::VRSettings()->Sync();
-					audioManager->setMirrorDevice(m_playbackDevices[index].first, notify);
+                                        audioManager->setMirrorDevice(m_playbackDevices[static_cast<size_t>(index)].first, notify);
 				}
 			} else if (notify) {
 				emit mirrorDeviceIndexChanged(m_mirrorDeviceIndex);
@@ -390,14 +396,14 @@ namespace advsettings {
 
 	void AudioTabController::setMicDeviceIndex(int index, bool notify) {
 		if (index != m_recordingDeviceIndex) {
-			if (index < m_recordingDevices.size()) {
-				vr::EVRSettingsError vrSettingsError;
-				vr::VRSettings()->SetString(vr::k_pch_audio_Section, vr::k_pch_audio_OnRecordDevice_String, m_recordingDevices[index].first.c_str(), &vrSettingsError);
+                        if (index > 0 && static_cast<size_t>(index) < m_recordingDevices.size()) {
+                                vr::EVRSettingsError vrSettingsError;
+                                vr::VRSettings()->SetString(vr::k_pch_audio_Section, vr::k_pch_audio_OnRecordDevice_String, m_recordingDevices[static_cast<size_t>(index)].first.c_str(), &vrSettingsError);
 				if (vrSettingsError != vr::VRSettingsError_None) {
 					LOG(WARNING) << "Could not write \"" << vr::k_pch_audio_OnRecordDevice_String << "\" setting: " << vr::VRSettings()->GetSettingsErrorNameFromEnum(vrSettingsError);
 				} else {
-					vr::VRSettings()->Sync();
-					audioManager->setMicDevice(m_recordingDevices[index].first, notify);
+                                        vr::VRSettings()->Sync();
+                                        audioManager->setMicDevice(m_recordingDevices[static_cast<size_t>(index)].first, notify);
 				}
 			} else if (notify) {
 				emit micDeviceIndexChanged(m_recordingDeviceIndex);
@@ -496,8 +502,8 @@ namespace advsettings {
 		auto profileCount = settings->beginReadArray("audioProfiles");
 		for (int i = 0; i < profileCount; i++) {
 			settings->setArrayIndex(i);
-			audioProfiles.emplace_back();
-			auto& entry = audioProfiles[i];
+                        audioProfiles.emplace_back();
+                        auto& entry = audioProfiles[static_cast<size_t>(i)];
 			entry.profileName = settings->value("profileName").toString().toStdString();
 			entry.playbackName = settings->value("playbackName").toString().toStdString();
 			entry.micName = settings->value("micName").toString().toStdString();
@@ -528,9 +534,9 @@ namespace advsettings {
 		auto settings = OverlayController::appSettings();
 		settings->beginGroup(getSettingsName());
 		settings->beginWriteArray("audioProfiles");
-		unsigned i = 0;
-		for (auto& p : audioProfiles) {
-			settings->setArrayIndex(i);
+                int i = 0;
+                for (auto& p : audioProfiles) {
+                    settings->setArrayIndex(i);
 			settings->setValue("profileName", QString::fromStdString(p.profileName));
 			settings->setValue("playbackName", QString::fromStdString(p.playbackName));
 			settings->setValue("micName", QString::fromStdString(p.micName));
@@ -657,9 +663,9 @@ namespace advsettings {
 	}
 
 
-	unsigned AudioTabController::getAudioProfileCount() {
-		return (unsigned)audioProfiles.size();
-	}
+        unsigned AudioTabController::getAudioProfileCount() {
+            return static_cast<unsigned int>(audioProfiles.size());
+        }
 
 	QString AudioTabController::getAudioProfileName(unsigned index) {
 		if (index < audioProfiles.size()) {
@@ -676,28 +682,31 @@ namespace advsettings {
 
 		description: Gets proper index value for selecting specific devices.
 	*/
-	int AudioTabController::getPlaybackIndex(std::string str) {
-		for (int i = 0; i < m_playbackDevices.size(); i++) {
-			if (str.compare(m_playbackDevices[i].second)==0) {
-				return i;
+        int AudioTabController::getPlaybackIndex(std::string str) {
+            //Unsigned to avoid two casts. i won't be negative because we only increment it.
+            for (unsigned int i = 0; i < m_playbackDevices.size(); i++) {
+                if (str.compare(m_playbackDevices[i].second)==0) {
+                    return static_cast<int>(i);
 			}
 		}
 		return m_playbackDeviceIndex;
 	}
 
-	int AudioTabController::getRecordingIndex(std::string str) {
-		for (int i = 0; i < m_recordingDevices.size(); i++) {
-			if (str.compare(m_recordingDevices[i].second) == 0) {
-				return i;
+        int AudioTabController::getRecordingIndex(std::string str) {
+            //Unsigned to avoid two casts. i won't be negative because we only increment it.
+            for (unsigned int i = 0; i < m_recordingDevices.size(); i++) {
+                if (str.compare(m_recordingDevices[i].second) == 0) {
+                    return static_cast<int>(i);
 			}
 		}
 		return m_recordingDeviceIndex;
 	}
 
 	int AudioTabController::getMirrorIndex(std::string str) {
-		for (int i = 0; i < m_playbackDevices.size(); i++) {
-			if (str.compare(m_playbackDevices[i].second) == 0) {
-				return i;
+                //Unsigned to avoid two casts. i won't be negative because we only increment it.
+                for (unsigned int i = 0; i < m_playbackDevices.size(); i++) {
+                        if (str.compare(m_playbackDevices[i].second) == 0) {
+                            return static_cast<int>(i);
 			}
 		}
 	return -1;

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -44,9 +44,9 @@ namespace advsettings {
 	}
 
 
-	void AudioTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-		this->parent = parent;
-		this->widget = widget;
+        void AudioTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+                this->parent = var_parent;
+                this->widget = var_widget;
 
 		std::string notifKey = std::string(OverlayController::applicationKey) + ".pptnotification";
 		vr::VROverlayError overlayError = vr::VROverlay()->CreateOverlay(notifKey.c_str(), notifKey.c_str(), &m_ulNotificationOverlayHandle);

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -32,9 +32,9 @@ void ChaperoneTabController::initStage1() {
 }
 
 
-void ChaperoneTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void ChaperoneTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -486,7 +486,7 @@ void ChaperoneTabController::setHeight(float value, bool notify) {
 			}
 			vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(collisionBounds, collisionBoundsCount);
 			vr::VRChaperoneSetup()->CommitWorkingCopy(vr::EChaperoneConfigFile_Live);
-			delete collisionBounds;
+                        delete[] collisionBounds;
 		}
 		if (notify) {
 			emit heightChanged(m_fadeDistance);
@@ -1006,7 +1006,7 @@ float ChaperoneTabController::getBoundsMaxY() {
 				result = collisionBounds[b].vCorners[ci].v[1];
 			}
 		}
-		delete collisionBounds;
+                delete[] collisionBounds;
 	}
 	return result;
 }

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -9,9 +9,9 @@ namespace advsettings {
 void FixFloorTabController::initStage1() {
 }
 
-void FixFloorTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void FixFloorTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 void FixFloorTabController::eventLoopTick(vr::TrackedDevicePose_t* devicePoses) {

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -57,9 +57,9 @@ void MoveCenterTabController::initStage1() {
     lastMoveButtonClick[0] = lastMoveButtonClick[1] = clock::now();
 }
 
-void MoveCenterTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void MoveCenterTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -54,7 +54,7 @@ void MoveCenterTabController::initStage1() {
 		m_lockZToggle = value.toBool();
 	}
 	settings->endGroup();
-    lastMoveButtonClick[0] = lastMoveButtonClick[0] = clock::now();
+    lastMoveButtonClick[0] = lastMoveButtonClick[1] = clock::now();
 }
 
 void MoveCenterTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {

--- a/src/tabcontrollers/ReviveTabController.cpp
+++ b/src/tabcontrollers/ReviveTabController.cpp
@@ -167,9 +167,9 @@ namespace advsettings {
 		}
 	}
 
-	void ReviveTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-		this->parent = parent;
-		this->widget = widget;
+        void ReviveTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+                this->parent = var_parent;
+                this->widget = var_widget;
 	}
 
 	void ReviveTabController::eventLoopTick() {

--- a/src/tabcontrollers/SettingsTabController.cpp
+++ b/src/tabcontrollers/SettingsTabController.cpp
@@ -17,9 +17,9 @@ void SettingsTabController::initStage1() {
 	}
 }
 
-void SettingsTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void SettingsTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 void SettingsTabController::eventLoopTick() {

--- a/src/tabcontrollers/StatisticsTabController.cpp
+++ b/src/tabcontrollers/StatisticsTabController.cpp
@@ -8,9 +8,9 @@ namespace advsettings {
 void StatisticsTabController::initStage1() {
 }
 
-void StatisticsTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void StatisticsTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 void StatisticsTabController::eventLoopTick(vr::TrackedDevicePose_t* devicePoses, float leftSpeed, float rightSpeed) {

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -10,6 +10,13 @@ namespace vr {
 // application namespace
 namespace advsettings {
 
+// openvr's github repo hasn't been updated yet to reflect changes in beta 1477423729.
+//static const char* vrsettings_steamvr_allowAsyncReprojection = "allowAsyncReprojection";
+//static const char* vrsettings_steamvr_allowInterleavedReprojection = "allowInterleavedReprojection";
+
+static const char* vrsettings_steamvr_supersampleScale = "supersampleScale";
+static const char* vrsettings_steamvr_allowSupersampleFiltering = "allowSupersampleFiltering";
+static const char* vrsettings_compositor_category = "compositor";
 
 void SteamVRTabController::initStage1() {
 	eventLoopTick();

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -24,9 +24,9 @@ void SteamVRTabController::initStage1() {
 }
 
 
-void SteamVRTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-	this->parent = parent;
-	this->widget = widget;
+void SteamVRTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+        this->parent = var_parent;
+        this->widget = var_widget;
 }
 
 

--- a/src/tabcontrollers/SteamVRTabController.h
+++ b/src/tabcontrollers/SteamVRTabController.h
@@ -3,12 +3,6 @@
 
 #include <QObject>
 
-// openvr's github repo hasn't been updated yet to reflect changes in beta 1477423729.
-//static const char* vrsettings_steamvr_allowAsyncReprojection = "allowAsyncReprojection";
-//static const char* vrsettings_steamvr_allowInterleavedReprojection = "allowInterleavedReprojection";
-static const char* vrsettings_compositor_category = "compositor";
-static const char* vrsettings_steamvr_supersampleScale = "supersampleScale";
-static const char* vrsettings_steamvr_allowSupersampleFiltering = "allowSupersampleFiltering";
 
 
 class QQuickWindow;

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -48,9 +48,9 @@ namespace advsettings {
 
 	}
 
-	void UtilitiesTabController::initStage2(OverlayController * parent, QQuickWindow * widget) {
-		this->parent = parent;
-		this->widget = widget;
+        void UtilitiesTabController::initStage2(OverlayController * var_parent, QQuickWindow * var_widget) {
+                this->parent = var_parent;
+                this->widget = var_widget;
 	}
 
 	void UtilitiesTabController::sendKeyboardInput(QString input) {

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -210,11 +210,11 @@ namespace advsettings {
             if (QFile::exists(QString::fromStdString(batteryIconPath))) {
                 vr::VROverlay()->SetOverlayFromFile(handle, batteryIconPath.c_str());
                 vr::VROverlay()->SetOverlayWidthInMeters(handle, 0.05f);
-                vr::HmdMatrix34_t notificationTransform = {
-                    1.0f, 0.0f, 0.0f, 0.00f,
-                    0.0f, -1.0f, 0.0f, 0.01f,
-                    0.0f, 0.0f, -1.0f, -0.013f
-                };
+            vr::HmdMatrix34_t notificationTransform = {{
+                    {1.0f, 0.0f, 0.0f, 0.00f},
+                    {0.0f, -1.0f, 0.0f, 0.01f},
+                    {0.0f, 0.0f, -1.0f, -0.013f}
+                }};
                 vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(handle, index, &notificationTransform);
                  LOG(INFO) << "Created battery overlay for device " << index;
             } else {

--- a/src/tabcontrollers/audiomanager/AudioManagerDummy.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerDummy.cpp
@@ -1,7 +1,8 @@
 #include "AudioManagerDummy.h"
 
 // Used to get the compiler to shut up about C4100: unreferenced formal parameter.
-#define UNREFERENCED_PARAMETER(P) (P)
+// The cast is to get GCC to shut up about it.
+#define UNREFERENCED_PARAMETER(P) static_cast<void>((P))
 
 // application namespace
 namespace advsettings {

--- a/src/tabcontrollers/audiomanager/AudioManagerDummy.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerDummy.cpp
@@ -1,16 +1,22 @@
 #include "AudioManagerDummy.h"
 
+// Used to get the compiler to shut up about C4100: unreferenced formal parameter.
+#define UNREFERENCED_PARAMETER(P) (P)
+
 // application namespace
 namespace advsettings {
 
 void AudioManagerDummy::init(AudioTabController *controller)
 {
     // noop
+    UNREFERENCED_PARAMETER(controller);
 }
 
 void AudioManagerDummy::setPlaybackDevice(const std::string &id, bool notify)
 {
     // noop
+    UNREFERENCED_PARAMETER(id);
+    UNREFERENCED_PARAMETER(notify);
 }
 
 std::string AudioManagerDummy::getPlaybackDevName()
@@ -26,6 +32,8 @@ std::string AudioManagerDummy::getPlaybackDevId()
 void AudioManagerDummy::setMirrorDevice(const std::string &id, bool notify)
 {
     // noop
+    UNREFERENCED_PARAMETER(id);
+    UNREFERENCED_PARAMETER(notify);
 }
 
 bool AudioManagerDummy::isMirrorValid()
@@ -50,6 +58,7 @@ float AudioManagerDummy::getMirrorVolume()
 
 bool AudioManagerDummy::setMirrorVolume(float value)
 {
+    UNREFERENCED_PARAMETER(value);
     return false;
 }
 
@@ -60,6 +69,7 @@ bool AudioManagerDummy::getMirrorMuted()
 
 bool AudioManagerDummy::setMirrorMuted(bool value)
 {
+    UNREFERENCED_PARAMETER(value);
     return false;
 }
 
@@ -71,6 +81,8 @@ bool AudioManagerDummy::isMicValid()
 void AudioManagerDummy::setMicDevice(const std::string &id, bool notify)
 {
     // noop
+    UNREFERENCED_PARAMETER(id);
+    UNREFERENCED_PARAMETER(notify);
 }
 
 std::string AudioManagerDummy::getMicDevName()
@@ -90,6 +102,7 @@ float AudioManagerDummy::getMicVolume()
 
 bool AudioManagerDummy::setMicVolume(float value)
 {
+    UNREFERENCED_PARAMETER(value);
     return false;
 }
 
@@ -100,6 +113,7 @@ bool AudioManagerDummy::getMicMuted()
 
 bool AudioManagerDummy::setMicMuted(bool value)
 {
+    UNREFERENCED_PARAMETER(value);
     return false;
 }
 

--- a/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
@@ -31,7 +31,7 @@ AudioManagerWindows::~AudioManagerWindows() {
 	audioDeviceEnumerator->Release();
 }
 
-void AudioManagerWindows::init(AudioTabController* controller) {
+void AudioManagerWindows::init(AudioTabController* var_controller) {
 	std::lock_guard<std::recursive_mutex> lock(_mutex);
 	audioDeviceEnumerator = getAudioDeviceEnumerator();
 	if (!audioDeviceEnumerator) {
@@ -47,7 +47,7 @@ void AudioManagerWindows::init(AudioTabController* controller) {
 	} else {
 		LOG(WARNING) << "Could not find a default recording device.";
 	}
-	this->controller = controller;
+        this->controller = var_controller;
 	audioDeviceEnumerator->RegisterEndpointNotificationCallback((IMMNotificationClient*)this);
 	policyConfig = getPolicyConfig();
 	if (!policyConfig) {

--- a/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
@@ -277,20 +277,20 @@ IMMDeviceEnumerator* AudioManagerWindows::getAudioDeviceEnumerator() {
 }
 
 IPolicyConfig * AudioManagerWindows::getPolicyConfig() {
-	IPolicyConfig* policyConfig = nullptr;
+        IPolicyConfig* var_policyConfig = nullptr;
 	// for Win 10
-	auto hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig2, (LPVOID *)&policyConfig);
+        auto hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig2, (LPVOID *)&var_policyConfig);
 	if (hr != S_OK) {
-		hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig1, (LPVOID *)&policyConfig);
+                hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig1, (LPVOID *)&var_policyConfig);
 	}
 	// for Win Vista, 7, 8, 8.1
 	if (hr != S_OK) {
-		hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig0, (LPVOID *)&policyConfig);
+                hr = CoCreateInstance(__uuidof(CPolicyConfigClient), NULL, CLSCTX_INPROC, IID_IPolicyConfig0, (LPVOID *)&var_policyConfig);
 	}
 	if (hr != S_OK) {
 		return nullptr;
 	} else {
-		return policyConfig;
+                return var_policyConfig;
 	}
 }
 

--- a/src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
@@ -1,10 +1,14 @@
 #include "KeyboardInputDummy.h"
 
+// Used to get the compiler to shut up about C4100: unreferenced formal parameter.
+#define UNREFERENCED_PARAMETER(P) (P)
+
 namespace advsettings {
 
 void KeyboardInputDummy::sendKeyboardInput(QString input)
 {
     // noop
+    UNREFERENCED_PARAMETER(input);
 }
 
 void KeyboardInputDummy::sendKeyboardEnter()
@@ -15,6 +19,7 @@ void KeyboardInputDummy::sendKeyboardEnter()
 void KeyboardInputDummy::sendKeyboardBackspace(int count)
 {
     // noop
+    UNREFERENCED_PARAMETER(count);
 }
 
 void KeyboardInputDummy::sendKeyboardAltTab()

--- a/src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
@@ -1,7 +1,8 @@
 #include "KeyboardInputDummy.h"
 
 // Used to get the compiler to shut up about C4100: unreferenced formal parameter.
-#define UNREFERENCED_PARAMETER(P) (P)
+// The cast is to get GCC to shut up about it.
+#define UNREFERENCED_PARAMETER(P) static_cast<void>((P))
 
 namespace advsettings {
 

--- a/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
@@ -22,12 +22,12 @@ void sendKeyboardInputRaw(int inputCount, LPINPUT input) {
         char *err;
         auto errCode = GetLastError();
         if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-                NULL,
+                nullptr,
                 errCode,
                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // default language
                 (LPTSTR)&err,
                 0,
-                NULL)){
+                nullptr)){
             LOG(ERROR) << "Error calling SendInput(): Could not get error message (" << errCode << ")";
         } else {
             LOG(ERROR) << "Error calling SendInput(): " << err;

--- a/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
@@ -25,7 +25,7 @@ void sendKeyboardInputRaw(int inputCount, LPINPUT input) {
                 nullptr,
                 errCode,
                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // default language
-                (LPTSTR)&err,
+                reinterpret_cast<LPTSTR>(&err),
                 0,
                 nullptr)){
             LOG(ERROR) << "Error calling SendInput(): Could not get error message (" << errCode << ")";

--- a/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
@@ -18,7 +18,7 @@ void fillKiStruct(INPUT& ip, WORD scanCode, bool keyup) {
 };
 
 void sendKeyboardInputRaw(int inputCount, LPINPUT input) {
-    if (!SendInput(inputCount, input, sizeof(INPUT))) {
+    if ((inputCount > 0) && !SendInput(static_cast<UINT>(inputCount), input, sizeof(INPUT))) {
         char *err;
         auto errCode = GetLastError();
         if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -39,8 +39,8 @@ void KeyboardInputWindows::sendKeyboardInput(QString input)
 {
     int len = input.length();
     if (len > 0) {
-        LPINPUT ips = new INPUT[len * 5 + 3];
-        unsigned ii = 0;
+        LPINPUT ips = new INPUT[static_cast<unsigned int>(len) * 5 + 3];
+        int ii = 0;
         bool shiftPressed = false;
         bool ctrlPressed = false;
         bool altPressed = false;
@@ -106,7 +106,8 @@ void KeyboardInputWindows::sendKeyboardEnter()
 void KeyboardInputWindows::sendKeyboardBackspace(int count)
 {
     if (count > 0) {
-        LPINPUT ips = new INPUT[count * 2];
+        // We ensure that count is nonnegative, therefore safe cast.
+        LPINPUT ips = new INPUT[static_cast<unsigned int>(count) * 2];
         for (int i = 0; i < count; i++) {
             fillKiStruct(ips[2 * i], VK_BACK, false);
             fillKiStruct(ips[2 * i + 1], VK_BACK, true);

--- a/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
@@ -89,7 +89,7 @@ void KeyboardInputWindows::sendKeyboardInput(QString input)
         }
 
         sendKeyboardInputRaw(ii, ips);
-        delete ips;
+        delete[] ips;
     }
 }
 
@@ -100,7 +100,7 @@ void KeyboardInputWindows::sendKeyboardEnter()
     fillKiStruct(ips[1], VK_RETURN, true);
 
     sendKeyboardInputRaw(2, ips);
-    delete ips;
+    delete[] ips;
 }
 
 void KeyboardInputWindows::sendKeyboardBackspace(int count)
@@ -114,7 +114,7 @@ void KeyboardInputWindows::sendKeyboardBackspace(int count)
         }
 
         sendKeyboardInputRaw(count * 2, ips);
-        delete ips;
+        delete[] ips;
     }
 }
 
@@ -128,7 +128,7 @@ void KeyboardInputWindows::sendKeyboardAltTab()
     fillKiStruct(ips[3], VK_MENU, true);
 
     sendKeyboardInputRaw(4, ips);
-    delete ips;
+    delete[] ips;
 }
 
 }


### PR DESCRIPTION
Treating warnings as errors ensures that important compiler warnings aren't ignored.

With relatively few fixes, the /WX switch on MSVC and the -Werror switch on GCC/Clang can be enabled.

It is worth noting that GCC/Clang have a significantly larger amount of warnings than MSVC on /W3. It is not feasible to enable the /W4 (warning level 4, current is 3) switch on MSVC yet, since a very large amount of warnings are from third party files. Finding a solution to this should bring MSVC warning levels up to parity with GCC/Clang.

Compiling with clang-cl.exe on Windows still gives a large amount of errors. Most of them from the third party `easylogging++.h` file. The rest are relatively easy `-Wmismatched-new-delete` and `-Wmissing-braces` warnings. There are also still large amount of old C style casts, which should give warnings on higher warning levels on all three compilers.

It also seems like the Travis CI is running `g++` instead of `clang++` on the Clang build, despite visible settings setting it to `clang++`. 

[Clang](https://travis-ci.org/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/jobs/472630875):

```
export TRAVIS_COMPILER=clang
$ export CXX=clang++
$ export CXX_FOR_BUILD=clang++
$ export CC=clang
$ export CC_FOR_BUILD=clang
$ clang --version
clang version 7.0.0 (tags/RELEASE_700/final)
[...]
$ make
g++ [...] -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -o main.o ../src/main.cpp

```

[GCC](https://travis-ci.org/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/jobs/472630876):

``` 
$ export TRAVIS_COMPILER=gcc
$ export CXX=g++
$ export CXX_FOR_BUILD=g++
$ export CC=gcc
$ export CC_FOR_BUILD=gcc
$ gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609
[...]
$ make
g++ [...] -I. -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -o main.o ../src/main.cpp
```


EDIT: I've gotten clang to work on my machine. I'll fix the remaining errors and push them to this PR.