### PR TITLE
Fix QML error spam from MyStackViewPage and PlayspacePage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
  >   * [Installer](#installer)
  >   * [Standalone](#standalone)
  >   * [Command Line Arguments](#command_line_arguments)
- >   * [Desktop mode](#desktop_mode)
+ >   * [Logging Config](#logging_config)
  >   * [Preview Builds](#preview_builds)
  > * [Documentation](#documentation)
  >   * [Top Page](#top_page)
@@ -84,20 +84,22 @@ To upgrade an existing installation first stop SteamVR and delete the old applic
 
 The application (`AdvancedSettings.exe`) can be run with the following five optional arguments:
 
-`"-desktop"`: Creates a settings window on the desktop.
+`"-desktop"`: Creates a settings window on the desktop as well as in VR. Running `startdesktopmode.bat` in the install directory has the same effect.
 
 `"-nosound"`: Forces sound effects off.
 
-`"-nomanifest"`: Forces not creating a `.vrmanifest`.
+`"-nomanifest"`: Forces not using a `.vrmanifest`.
 
-`"-installmanifest"`: Force installs the `.vrmanifest`.
+`"-installmanifest"`: Force installs the `.vrmanifest` and adds the application to autostart. If you're having issues with autostart not working try running the program once with this set. The program will exit early when this flag is set.
 
-`"-removemanifest"`: Force uninstalls the `.vrmanifest`.
+`"-removemanifest"`: Force uninstalls the `.vrmanifest`. This should be done every time the application is uninstalled. On Windows it is automatically done by the uninstaller. The program will exit early when this flag is set.
 
-<a name="desktop_mode"></a>
-## Desktop mode
+In addition, the application can receive the command line arguments from the [Easylogging++ library](https://github.com/zuhd-org/easyloggingpp#application-arguments).
 
-Executing startdesktopmode.bat from the application folder shows a window on the desktop instead of a vr overlay. Desktop mode can be used alongside an already running vr overlay instance.
+<a name="logging_config"></a>
+## Logging Config
+
+The logging output of the [Easylogging++ library](https://github.com/zuhd-org/easyloggingpp#application-arguments) can be customized by placing a file called `logging.conf` in the directory of the binary. This should be considered for advanced users only and it is not recommended.
 
 <a name="preview_builds"></a>
 ## Preview builds

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@ void myQtMessageHandler( QtMsgType type,
 
 namespace manifest
 {
+constexpr auto kVRManifestName = "manifest.vrmanifest";
+
 void enableApplicationAutostart()
 {
     const auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
@@ -138,7 +140,7 @@ void reinstallApplicationManifest( const QString manifestPath )
 
         const auto oldManifestPath
             = QDir::cleanPath( QDir( oldApplicationWorkingDir )
-                                   .absoluteFilePath( "manifest.vrmanifest" ) );
+                                   .absoluteFilePath( kVRManifestName ) );
 
         removeApplicationManifest( manifestPath );
     }
@@ -158,7 +160,7 @@ void reinstallApplicationManifest( const QString manifestPath )
         {
             const auto manifestPath = QDir::cleanPath(
                 QDir( QCoreApplication::applicationDirPath() )
-                    .absoluteFilePath( "manifest.vrmanifest" ) );
+                    .absoluteFilePath( kVRManifestName ) );
 
             if ( install_manifest )
             {
@@ -387,7 +389,7 @@ int main( int argc, char* argv[] )
             {
                 const auto manifestPath = QDir::cleanPath(
                     QDir( QCoreApplication::applicationDirPath() )
-                        .absoluteFilePath( "manifest.vrmanifest" ) );
+                        .absoluteFilePath( manifest::kVRManifestName ) );
                 manifest::installApplicationManifest( manifestPath );
             }
             catch ( std::exception& e )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,10 +360,11 @@ int main( int argc, char* argv[] )
     try
     {
         MyQApplication a( argc, argv );
-        a.setOrganizationName( "matzman666" );
-        a.setApplicationName( "OpenVRAdvancedSettings" );
+        a.setOrganizationName(
+            advsettings::OverlayController::applicationOrganizationName );
+        a.setApplicationName( advsettings::OverlayController::applicationName );
         a.setApplicationDisplayName(
-            advsettings::OverlayController::applicationName );
+            advsettings::OverlayController::applicationDisplayName );
         a.setApplicationVersion(
             advsettings::OverlayController::applicationVersionString );
 
@@ -393,9 +394,10 @@ int main( int argc, char* argv[] )
                          << std::endl;
         }
         auto quickObj = component.create();
-        controller->SetWidget( qobject_cast<QQuickItem*>( quickObj ),
-                               advsettings::OverlayController::applicationName,
-                               advsettings::OverlayController::applicationKey );
+        controller->SetWidget(
+            qobject_cast<QQuickItem*>( quickObj ),
+            advsettings::OverlayController::applicationDisplayName,
+            advsettings::OverlayController::applicationKey );
 
         if ( !desktopMode && !noManifest )
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ void installManifest( bool cleaninstall = false )
     {
         if ( cleaninstall )
         {
-            char buffer[1024];
+            char buffer[1024] = { 0 };
             auto appError = vr::VRApplicationError_None;
             vr::VRApplications()->GetApplicationPropertyString(
                 advsettings::OverlayController::applicationKey,
@@ -92,6 +92,7 @@ void installManifest( bool cleaninstall = false )
             alreadyInstalled = true;
         }
     }
+
     auto apperror = vr::VRApplications()->AddApplicationManifest(
         QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
     if ( apperror != vr::VRApplicationError_None )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,8 @@ void myQtMessageHandler( QtMsgType type,
     }
 }
 
+namespace manifest
+{
 void handleManifestInstallationLogic( const bool cleaninstall,
                                       const QString manifestPath )
 {
@@ -183,6 +185,7 @@ void removeManifest( const QString manifestPath )
     vr::VR_Shutdown();
     exit( exit_code );
 }
+} // namespace manifest
 
 // Sets up the logging library and outputs startup logging data.
 // argc and argv are necessary for the START_EASYLOGGINGPP() call.
@@ -330,7 +333,7 @@ int main( int argc, char* argv[] )
     {
         // The function does not return, it exits inside the function
         // with an appropriate exit code.
-        handleManifests( install_manifest, remove_manifest );
+        manifest::handleManifests( install_manifest, remove_manifest );
     }
 
     try
@@ -380,7 +383,8 @@ int main( int argc, char* argv[] )
                 const auto manifestPath = QDir::cleanPath(
                     QDir( QCoreApplication::applicationDirPath() )
                         .absoluteFilePath( "manifest.vrmanifest" ) );
-                handleManifestInstallationLogic( false, manifestPath );
+                manifest::handleManifestInstallationLogic( false,
+                                                           manifestPath );
             }
             catch ( std::exception& e )
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,27 +166,27 @@ void reinstallApplicationManifest( const QString manifestPath )
             {
                 reinstallApplicationManifest( manifestPath );
                 enableApplicationAutostart();
+                LOG( INFO ) << "Manifest reinstalled.";
             }
             else if ( removeManifest )
             {
                 removeApplicationManifest( manifestPath );
+                LOG( INFO ) << "Manifest removed.";
             }
         }
         catch ( std::exception& e )
         {
             exit_code = ReturnErrorCode::GENERAL_FAILURE;
-            std::cerr << e.what() << std::endl;
+            LOG( ERROR ) << e.what();
         }
     }
     else
     {
         exit_code = ReturnErrorCode::OPENVR_INIT_ERROR;
-        std::cerr << std::string(
-                         "Failed to initialize OpenVR: "
-                         + std::string(
-                               vr::VR_GetVRInitErrorAsEnglishDescription(
-                                   openvr_init_status ) ) )
-                  << std::endl;
+        LOG( ERROR ) << std::string(
+            "Failed to initialize OpenVR: "
+            + std::string( vr::VR_GetVRInitErrorAsEnglishDescription(
+                  openvr_init_status ) ) );
     }
 
     vr::VR_Shutdown();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,10 +297,12 @@ int main( int argc, char* argv[] )
             {
                 if ( install_manifest )
                 {
+                    LOG( INFO ) << "Install manifest enabled.";
                     installManifest( true );
                 }
                 else if ( remove_manifest )
                 {
+                    LOG( INFO ) << "Remove manifest enabled.";
                     removeManifest();
                 }
             }
@@ -325,6 +327,10 @@ int main( int argc, char* argv[] )
         exit( exit_code );
     }
 
+    LOG_IF( desktop_mode, INFO ) << "Desktop mode enabled.";
+    LOG_IF( no_sound, INFO ) << "Sound effects disabled.";
+    LOG_IF( no_manifest, INFO ) << "vrmanifest disabled.";
+
     try
     {
         MyQApplication a( argc, argv );
@@ -336,19 +342,6 @@ int main( int argc, char* argv[] )
             advsettings::OverlayController::applicationVersionString );
 
         qInstallMessageHandler( myQtMessageHandler );
-
-        if ( desktop_mode )
-        {
-            LOG( INFO ) << "Desktop mode enabled.";
-        }
-        if ( no_sound )
-        {
-            LOG( INFO ) << "Sound effects disabled.";
-        }
-        if ( no_manifest )
-        {
-            LOG( INFO ) << "vrmanifest disabled.";
-        }
 
         QSettings appSettings( QSettings::IniFormat,
                                QSettings::UserScope,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,76 +47,73 @@ void installManifest( bool cleaninstall = false )
     auto manifestQPath
         = QDir::cleanPath( QDir( QCoreApplication::applicationDirPath() )
                                .absoluteFilePath( "manifest.vrmanifest" ) );
-    if ( QFile::exists( manifestQPath ) )
-    {
-        bool alreadyInstalled = false;
-        if ( vr::VRApplications()->IsApplicationInstalled(
-                 advsettings::OverlayController::applicationKey ) )
-        {
-            if ( cleaninstall )
-            {
-                char buffer[1024];
-                auto appError = vr::VRApplicationError_None;
-                vr::VRApplications()->GetApplicationPropertyString(
-                    advsettings::OverlayController::applicationKey,
-                    vr::VRApplicationProperty_WorkingDirectory_String,
-                    buffer,
-                    1024,
-                    &appError );
-                if ( appError == vr::VRApplicationError_None )
-                {
-                    auto oldManifestQPath
-                        = QDir::cleanPath( QDir( buffer ).absoluteFilePath(
-                            "manifest.vrmanifest" ) );
-                    if ( oldManifestQPath.compare( manifestQPath,
-                                                   Qt::CaseInsensitive )
-                         != 0 )
-                    {
-                        vr::VRApplications()->RemoveApplicationManifest(
-                            QDir::toNativeSeparators( oldManifestQPath )
-                                .toStdString()
-                                .c_str() );
-                    }
-                    else
-                    {
-                        alreadyInstalled = true;
-                    }
-                }
-            }
-            else
-            {
-                alreadyInstalled = true;
-            }
-        }
-        auto apperror = vr::VRApplications()->AddApplicationManifest(
-            QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
-        if ( apperror != vr::VRApplicationError_None )
-        {
-            throw std::runtime_error(
-                std::string( "Could not add application manifest: " )
-                + std::string(
-                      vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                          apperror ) ) );
-        }
-        else if ( !alreadyInstalled || cleaninstall )
-        {
-            auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
-                advsettings::OverlayController::applicationKey, true );
-            if ( app_error != vr::VRApplicationError_None )
-            {
-                throw std::runtime_error(
-                    std::string( "Could not set auto start: " )
-                    + std::string( vr::VRApplications()
-                                       ->GetApplicationsErrorNameFromEnum(
-                                           apperror ) ) );
-            }
-        }
-    }
-    else
+    if ( !QFile::exists( manifestQPath ) )
     {
         throw std::runtime_error(
             std::string( "Could not find application manifest: " )
             + manifestQPath.toStdString() );
+    }
+
+    bool alreadyInstalled = false;
+    if ( vr::VRApplications()->IsApplicationInstalled(
+             advsettings::OverlayController::applicationKey ) )
+    {
+        if ( cleaninstall )
+        {
+            char buffer[1024];
+            auto appError = vr::VRApplicationError_None;
+            vr::VRApplications()->GetApplicationPropertyString(
+                advsettings::OverlayController::applicationKey,
+                vr::VRApplicationProperty_WorkingDirectory_String,
+                buffer,
+                1024,
+                &appError );
+            if ( appError == vr::VRApplicationError_None )
+            {
+                auto oldManifestQPath = QDir::cleanPath(
+                    QDir( buffer ).absoluteFilePath( "manifest.vrmanifest" ) );
+                if ( oldManifestQPath.compare( manifestQPath,
+                                               Qt::CaseInsensitive )
+                     != 0 )
+                {
+                    vr::VRApplications()->RemoveApplicationManifest(
+                        QDir::toNativeSeparators( oldManifestQPath )
+                            .toStdString()
+                            .c_str() );
+                }
+                else
+                {
+                    alreadyInstalled = true;
+                }
+            }
+        }
+        else
+        {
+            alreadyInstalled = true;
+        }
+    }
+    auto apperror = vr::VRApplications()->AddApplicationManifest(
+        QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
+    if ( apperror != vr::VRApplicationError_None )
+    {
+        throw std::runtime_error(
+            std::string( "Could not add application manifest: " )
+            + std::string(
+                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                      apperror ) ) );
+    }
+    else if ( !alreadyInstalled || cleaninstall )
+    {
+        auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
+            advsettings::OverlayController::applicationKey, true );
+        if ( app_error != vr::VRApplicationError_None )
+        {
+            throw std::runtime_error(
+                std::string( "Could not set auto start: " )
+                + std::string(
+                      vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                          apperror ) ) );
+        }
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,8 +420,10 @@ int main( int argc, char* argv[] )
             m_pWindow->setGeometry(
                 0,
                 0,
-                qobject_cast<QQuickItem*>( quickObj )->width(),
-                qobject_cast<QQuickItem*>( quickObj )->height() );
+                static_cast<int>(
+                    qobject_cast<QQuickItem*>( quickObj )->width() ),
+                static_cast<int>(
+                    qobject_cast<QQuickItem*>( quickObj )->height() ) );
             m_pWindow->show();
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,8 +148,8 @@ void reinstallApplicationManifest( const QString manifestPath )
     installApplicationManifest( manifestPath );
 }
 
-[[noreturn]] void handleManifests( const bool install_manifest,
-                                   const bool remove_manifest )
+[[noreturn]] void handleManifests( const bool installManifest,
+                                   const bool removeManifest )
 {
     int exit_code = ReturnErrorCode::SUCCESS;
     auto openvr_init_status = vr::VRInitError_None;
@@ -162,12 +162,12 @@ void reinstallApplicationManifest( const QString manifestPath )
                 QDir( QCoreApplication::applicationDirPath() )
                     .absoluteFilePath( kVRManifestName ) );
 
-            if ( install_manifest )
+            if ( installManifest )
             {
                 reinstallApplicationManifest( manifestPath );
                 enableApplicationAutostart();
             }
-            else if ( remove_manifest )
+            else if ( removeManifest )
             {
                 removeApplicationManifest( manifestPath );
             }
@@ -305,42 +305,42 @@ bool CheckCommandLineArgument( int argc,
     return false;
 }
 
-constexpr auto DESKTOP_MODE = "-desktop";
-constexpr auto NO_SOUND = "-nosound";
-constexpr auto NO_MANIFEST = "-nomanifest";
-constexpr auto INSTALL_MANIFEST = "-installmanifest";
-constexpr auto REMOVE_MANIFEST = "-removemanifest";
+constexpr auto kDesktopMode = "-desktop";
+constexpr auto kNoSound = "-nosound";
+constexpr auto kNoManifest = "-nomanifest";
+constexpr auto kInstallManifest = "-installmanifest";
+constexpr auto kRemoveManifest = "-removemanifest";
 } // namespace argument
 
 int main( int argc, char* argv[] )
 {
     setUpLogging( argc, argv );
 
-    const bool desktop_mode = argument::CheckCommandLineArgument(
-        argc, argv, argument::DESKTOP_MODE );
-    const bool no_sound
-        = argument::CheckCommandLineArgument( argc, argv, argument::NO_SOUND );
-    const bool no_manifest = argument::CheckCommandLineArgument(
-        argc, argv, argument::NO_MANIFEST );
-    const bool install_manifest = argument::CheckCommandLineArgument(
-        argc, argv, argument::INSTALL_MANIFEST );
-    const bool remove_manifest = argument::CheckCommandLineArgument(
-        argc, argv, argument::REMOVE_MANIFEST );
+    const bool desktopMode = argument::CheckCommandLineArgument(
+        argc, argv, argument::kDesktopMode );
+    const bool noSound
+        = argument::CheckCommandLineArgument( argc, argv, argument::kNoSound );
+    const bool noManifest = argument::CheckCommandLineArgument(
+        argc, argv, argument::kNoManifest );
+    const bool installManifest = argument::CheckCommandLineArgument(
+        argc, argv, argument::kInstallManifest );
+    const bool removeManifest = argument::CheckCommandLineArgument(
+        argc, argv, argument::kRemoveManifest );
 
     // If a command line arg is set, make sure the logs reflect that.
-    LOG_IF( desktop_mode, INFO ) << "Desktop mode enabled.";
-    LOG_IF( no_sound, INFO ) << "Sound effects disabled.";
-    LOG_IF( no_manifest, INFO ) << "vrmanifest disabled.";
-    LOG_IF( install_manifest, INFO ) << "Install manifest enabled.";
-    LOG_IF( remove_manifest, INFO ) << "Remove manifest enabled.";
+    LOG_IF( desktopMode, INFO ) << "Desktop mode enabled.";
+    LOG_IF( noSound, INFO ) << "Sound effects disabled.";
+    LOG_IF( noManifest, INFO ) << "vrmanifest disabled.";
+    LOG_IF( installManifest, INFO ) << "Install manifest enabled.";
+    LOG_IF( removeManifest, INFO ) << "Remove manifest enabled.";
 
     // It is important that either install_manifest or remove_manifest are true,
     // otherwise the handleManifests function will not behave properly.
-    if ( install_manifest || remove_manifest )
+    if ( installManifest || removeManifest )
     {
         // The function does not return, it exits inside the function
         // with an appropriate exit code.
-        manifest::handleManifests( install_manifest, remove_manifest );
+        manifest::handleManifests( installManifest, removeManifest );
     }
 
     try
@@ -366,8 +366,8 @@ int main( int argc, char* argv[] )
         QQmlEngine qmlEngine;
 
         advsettings::OverlayController* controller
-            = advsettings::OverlayController::createInstance( desktop_mode,
-                                                              no_sound );
+            = advsettings::OverlayController::createInstance( desktopMode,
+                                                              noSound );
         controller->Init( &qmlEngine );
 
         QQmlComponent component(
@@ -383,7 +383,7 @@ int main( int argc, char* argv[] )
                                advsettings::OverlayController::applicationName,
                                advsettings::OverlayController::applicationKey );
 
-        if ( !desktop_mode && !no_manifest )
+        if ( !desktopMode && !noManifest )
         {
             try
             {
@@ -398,7 +398,7 @@ int main( int argc, char* argv[] )
             }
         }
 
-        if ( desktop_mode )
+        if ( desktopMode )
         {
             auto m_pWindow = new QQuickWindow();
             qobject_cast<QQuickItem*>( quickObj )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,7 @@ void enableApplicationAutostart()
 
 // Installs the application manifest. If a manifest with the same application
 // key is already installed, nothing will happen.
+// OpenVR must be initialized before calling this function.
 void installApplicationManifest( const QString manifestPath )
 {
     if ( vr::VRApplications()->IsApplicationInstalled(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,34 @@ void myQtMessageHandler( QtMsgType type,
 
 namespace manifest
 {
+void enableApplicationAutostart()
+{
+    const auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
+        advsettings::OverlayController::applicationKey, true );
+    if ( app_error != vr::VRApplicationError_None )
+    {
+        throw std::runtime_error(
+            std::string( "Could not set auto start: " )
+            + std::string(
+                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                      app_error ) ) );
+    }
+}
+
+void installApplicationManifest( const QString manifestPath )
+{
+    const auto app_error = vr::VRApplications()->AddApplicationManifest(
+        QDir::toNativeSeparators( manifestPath ).toStdString().c_str() );
+    if ( app_error != vr::VRApplicationError_None )
+    {
+        throw std::runtime_error(
+            std::string( "Could not add application manifest: " )
+            + std::string(
+                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                      app_error ) ) );
+    }
+}
+
 void handleManifestInstallationLogic( const bool cleaninstall,
                                       const QString manifestPath )
 {
@@ -100,28 +128,11 @@ void handleManifestInstallationLogic( const bool cleaninstall,
         }
     }
 
-    auto apperror = vr::VRApplications()->AddApplicationManifest(
-        QDir::toNativeSeparators( manifestPath ).toStdString().c_str() );
-    if ( apperror != vr::VRApplicationError_None )
+    installApplicationManifest( manifestPath );
+
+    if ( !alreadyInstalled || cleaninstall )
     {
-        throw std::runtime_error(
-            std::string( "Could not add application manifest: " )
-            + std::string(
-                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                      apperror ) ) );
-    }
-    else if ( !alreadyInstalled || cleaninstall )
-    {
-        auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
-            advsettings::OverlayController::applicationKey, true );
-        if ( app_error != vr::VRApplicationError_None )
-        {
-            throw std::runtime_error(
-                std::string( "Could not set auto start: " )
-                + std::string(
-                      vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                          apperror ) ) );
-        }
+        enableApplicationAutostart();
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,8 +51,10 @@ void myQtMessageHandler( QtMsgType type,
 
 namespace manifest
 {
+// File name of the manifest. Is placed in the same directory as the binary.
 constexpr auto kVRManifestName = "manifest.vrmanifest";
 
+// Enables autostart of OpenVR Advanced Settings.
 void enableApplicationAutostart()
 {
     const auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
@@ -67,6 +69,8 @@ void enableApplicationAutostart()
     }
 }
 
+// Installs the application manifest. If a manifest with the same application
+// key is already installed, nothing will happen.
 void installApplicationManifest( const QString manifestPath )
 {
     if ( vr::VRApplications()->IsApplicationInstalled(
@@ -88,6 +92,7 @@ void installApplicationManifest( const QString manifestPath )
     }
 }
 
+// Removes the application manifest.
 void removeApplicationManifest( const QString manifestPath )
 {
     if ( !QFile::exists( manifestPath ) )
@@ -105,6 +110,7 @@ void removeApplicationManifest( const QString manifestPath )
     }
 }
 
+// Removes and then installs the application manifest.
 void reinstallApplicationManifest( const QString manifestPath )
 {
     if ( !QFile::exists( manifestPath ) )
@@ -148,6 +154,14 @@ void reinstallApplicationManifest( const QString manifestPath )
     installApplicationManifest( manifestPath );
 }
 
+// Initializes OpenVR and calls the relevant manifest functions.
+// The .vrmanifest is used by SteamVR however the exact functiontionality is not
+// documented in the official documentation.
+// The manifest is installed upon using the NSIS installer for windows (this
+// program is called with "-installmanifest" by the installer) and every time
+// the program is launched without both "-desktop" and "-nomanifest".
+// The OpenVR initialization is necessary for both removing and installing
+// manifests.
 [[noreturn]] void handleManifests( const bool installManifest,
                                    const bool removeManifest )
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,16 +49,13 @@ void myQtMessageHandler( QtMsgType type,
     }
 }
 
-void installManifest( bool cleaninstall = false )
+void installManifest( const bool cleaninstall, const QString manifestPath )
 {
-    auto manifestQPath
-        = QDir::cleanPath( QDir( QCoreApplication::applicationDirPath() )
-                               .absoluteFilePath( "manifest.vrmanifest" ) );
-    if ( !QFile::exists( manifestQPath ) )
+    if ( !QFile::exists( manifestPath ) )
     {
         throw std::runtime_error(
             std::string( "Could not find application manifest: " )
-            + manifestQPath.toStdString() );
+            + manifestPath.toStdString() );
     }
 
     bool alreadyInstalled = false;
@@ -79,7 +76,7 @@ void installManifest( bool cleaninstall = false )
             {
                 auto oldManifestQPath = QDir::cleanPath(
                     QDir( buffer ).absoluteFilePath( "manifest.vrmanifest" ) );
-                if ( oldManifestQPath.compare( manifestQPath,
+                if ( oldManifestQPath.compare( manifestPath,
                                                Qt::CaseInsensitive )
                      != 0 )
                 {
@@ -101,7 +98,7 @@ void installManifest( bool cleaninstall = false )
     }
 
     auto apperror = vr::VRApplications()->AddApplicationManifest(
-        QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
+        QDir::toNativeSeparators( manifestPath ).toStdString().c_str() );
     if ( apperror != vr::VRApplicationError_None )
     {
         throw std::runtime_error(
@@ -125,23 +122,20 @@ void installManifest( bool cleaninstall = false )
     }
 }
 
-void removeManifest()
+void removeManifest( const QString manifestPath )
 {
-    auto manifestQPath
-        = QDir::cleanPath( QDir( QCoreApplication::applicationDirPath() )
-                               .absoluteFilePath( "manifest.vrmanifest" ) );
-    if ( !QFile::exists( manifestQPath ) )
+    if ( !QFile::exists( manifestPath ) )
     {
         throw std::runtime_error(
             std::string( "Could not find application manifest: " )
-            + manifestQPath.toStdString() );
+            + manifestPath.toStdString() );
     }
 
     if ( vr::VRApplications()->IsApplicationInstalled(
              advsettings::OverlayController::applicationKey ) )
     {
         vr::VRApplications()->RemoveApplicationManifest(
-            QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
+            QDir::toNativeSeparators( manifestPath ).toStdString().c_str() );
     }
 }
 
@@ -155,13 +149,17 @@ void removeManifest()
     {
         try
         {
+            const auto manifestPath = QDir::cleanPath(
+                QDir( QCoreApplication::applicationDirPath() )
+                    .absoluteFilePath( "manifest.vrmanifest" ) );
+
             if ( install_manifest )
             {
-                installManifest( true );
+                installManifest( true, manifestPath );
             }
             else if ( remove_manifest )
             {
-                removeManifest();
+                removeManifest( manifestPath );
             }
         }
         catch ( std::exception& e )
@@ -378,7 +376,10 @@ int main( int argc, char* argv[] )
         {
             try
             {
-                installManifest();
+                const auto manifestPath = QDir::cleanPath(
+                    QDir( QCoreApplication::applicationDirPath() )
+                        .absoluteFilePath( "manifest.vrmanifest" ) );
+                installManifest( false, manifestPath );
             }
             catch ( std::exception& e )
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,10 +287,8 @@ int main( int argc, char* argv[] )
     if ( install_manifest || remove_manifest )
     {
         int exit_code = ReturnErrorCode::SUCCESS;
-        QCoreApplication coreApp( argc, argv );
         auto openvr_init_status = vr::VRInitError_None;
         vr::VR_Init( &openvr_init_status, vr::VRApplication_Utility );
-
         if ( openvr_init_status == vr::VRInitError_None )
         {
             try

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,22 +130,18 @@ void removeManifest()
     auto manifestQPath
         = QDir::cleanPath( QDir( QCoreApplication::applicationDirPath() )
                                .absoluteFilePath( "manifest.vrmanifest" ) );
-    if ( QFile::exists( manifestQPath ) )
-    {
-        if ( vr::VRApplications()->IsApplicationInstalled(
-                 advsettings::OverlayController::applicationKey ) )
-        {
-            vr::VRApplications()->RemoveApplicationManifest(
-                QDir::toNativeSeparators( manifestQPath )
-                    .toStdString()
-                    .c_str() );
-        }
-    }
-    else
+    if ( !QFile::exists( manifestQPath ) )
     {
         throw std::runtime_error(
             std::string( "Could not find application manifest: " )
             + manifestQPath.toStdString() );
+    }
+
+    if ( vr::VRApplications()->IsApplicationInstalled(
+             advsettings::OverlayController::applicationKey ) )
+    {
+        vr::VRApplications()->RemoveApplicationManifest(
+            QDir::toNativeSeparators( manifestQPath ).toStdString().c_str() );
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,35 +19,34 @@ enum ReturnErrorCode
     OPENVR_INIT_ERROR = -2,
 };
 
-void myQtMessageHandler( QtMsgType type,
-                         const QMessageLogContext& context,
-                         const QString& msg )
+namespace argument
 {
-    QByteArray localMsg = msg.toLocal8Bit();
-    switch ( type )
+// Checks whether a specific string was passed as a launch argument.
+bool CheckCommandLineArgument( int argc,
+                               char* argv[],
+                               const std::string parameter )
+{
+    // The old way was one giant loop that tested every single parameter.
+    // Having an individual loop for all args most likely has a very small
+    // performance penalty compared to the original solution, but the gains in
+    // readability and ease of extension of not having a hundred line+ for loop
+    // are worth it.
+    for ( int i = 0; i < argc; i++ )
     {
-    case QtDebugMsg:
-        LOG( DEBUG ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
-        break;
-    case QtInfoMsg:
-        LOG( INFO ) << localMsg.constData() << " (" << context.file << ":"
-                    << context.line << ")";
-        break;
-    case QtWarningMsg:
-        LOG( WARNING ) << localMsg.constData() << " (" << context.file << ":"
-                       << context.line << ")";
-        break;
-    case QtCriticalMsg:
-        LOG( ERROR ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
-        break;
-    case QtFatalMsg:
-        LOG( FATAL ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
-        break;
+        if ( std::string( argv[i] ) == parameter )
+        {
+            return true;
+        }
     }
+    return false;
 }
+
+constexpr auto kDesktopMode = "-desktop";
+constexpr auto kNoSound = "-nosound";
+constexpr auto kNoManifest = "-nomanifest";
+constexpr auto kInstallManifest = "-installmanifest";
+constexpr auto kRemoveManifest = "-removemanifest";
+} // namespace argument
 
 namespace manifest
 {
@@ -297,34 +296,35 @@ public:
     }
 };
 
-namespace argument
+void myQtMessageHandler( QtMsgType type,
+                         const QMessageLogContext& context,
+                         const QString& msg )
 {
-// Checks whether a specific string was passed as a launch argument.
-bool CheckCommandLineArgument( int argc,
-                               char* argv[],
-                               const std::string parameter )
-{
-    // The old way was one giant loop that tested every single parameter.
-    // Having an individual loop for all args most likely has a very small
-    // performance penalty compared to the original solution, but the gains in
-    // readability and ease of extension of not having a hundred line+ for loop
-    // are worth it.
-    for ( int i = 0; i < argc; i++ )
+    QByteArray localMsg = msg.toLocal8Bit();
+    switch ( type )
     {
-        if ( std::string( argv[i] ) == parameter )
-        {
-            return true;
-        }
+    case QtDebugMsg:
+        LOG( DEBUG ) << localMsg.constData() << " (" << context.file << ":"
+                     << context.line << ")";
+        break;
+    case QtInfoMsg:
+        LOG( INFO ) << localMsg.constData() << " (" << context.file << ":"
+                    << context.line << ")";
+        break;
+    case QtWarningMsg:
+        LOG( WARNING ) << localMsg.constData() << " (" << context.file << ":"
+                       << context.line << ")";
+        break;
+    case QtCriticalMsg:
+        LOG( ERROR ) << localMsg.constData() << " (" << context.file << ":"
+                     << context.line << ")";
+        break;
+    case QtFatalMsg:
+        LOG( FATAL ) << localMsg.constData() << " (" << context.file << ":"
+                     << context.line << ")";
+        break;
     }
-    return false;
 }
-
-constexpr auto kDesktopMode = "-desktop";
-constexpr auto kNoSound = "-nosound";
-constexpr auto kNoManifest = "-nomanifest";
-constexpr auto kInstallManifest = "-installmanifest";
-constexpr auto kRemoveManifest = "-removemanifest";
-} // namespace argument
 
 int main( int argc, char* argv[] )
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,8 @@ void myQtMessageHandler( QtMsgType type,
     }
 }
 
-void installManifest( const bool cleaninstall, const QString manifestPath )
+void handleManifestInstallationLogic( const bool cleaninstall,
+                                      const QString manifestPath )
 {
     if ( !QFile::exists( manifestPath ) )
     {
@@ -155,7 +156,7 @@ void removeManifest( const QString manifestPath )
 
             if ( install_manifest )
             {
-                installManifest( true, manifestPath );
+                handleManifestInstallationLogic( true, manifestPath );
             }
             else if ( remove_manifest )
             {
@@ -379,7 +380,7 @@ int main( int argc, char* argv[] )
                 const auto manifestPath = QDir::cleanPath(
                     QDir( QCoreApplication::applicationDirPath() )
                         .absoluteFilePath( "manifest.vrmanifest" ) );
-                installManifest( false, manifestPath );
+                handleManifestInstallationLogic( false, manifestPath );
             }
             catch ( std::exception& e )
             {

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -45,8 +45,10 @@ class OverlayController : public QObject
     Q_PROPERTY( bool desktopMode READ isDesktopMode )
 
 public:
+    static constexpr auto applicationOrganizationName = "matzman666";
+    static constexpr auto applicationName = "OpenVRAdvancedSettings";
     static constexpr const char* applicationKey = "matzman666.AdvancedSettings";
-    static constexpr const char* applicationName = "Advanced Settings";
+    static constexpr const char* applicationDisplayName = "Advanced Settings";
     static constexpr const char* applicationVersionString = "v2.8.0";
 
 private:

--- a/src/res/qml/MyStackViewPage.qml
+++ b/src/res/qml/MyStackViewPage.qml
@@ -51,7 +51,6 @@ Rectangle {
                 id: headerTitle
                 text: headerText
                 font.pointSize: 30
-                anchors.verticalCenter: headerBackButton.verticalCenter
                 Layout.leftMargin: 32
             }
         }

--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -318,7 +318,6 @@ MyStackViewPage {
             }
             ColumnLayout {
                 RowLayout {
-                    anchors.fill: parent
 
                     MyToggleButton {
                         id: moveShortcutLeft


### PR DESCRIPTION
Bug described in issue #22.

Besides MyStackViewPage, PlayspacePage also gave the following error:
```
QML RowLayout: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
```

Removing the anchor tags fixed the error spam, without changing the appearance of the pages.