### PR TITLE
Improved Valve Knuckles PTT trigger feel

### DIFF
--- a/src/tabcontrollers/PttController.cpp
+++ b/src/tabcontrollers/PttController.cpp
@@ -232,10 +232,7 @@ void PttController::checkPttStatus()
         if ( config->triggerMode )
         {
             if ( state.ulButtonPressed
-                     & vr::ButtonMaskFromId( vr::k_EButton_SteamVR_Trigger )
-                 || state.ulButtonTouched
-                        & vr::ButtonMaskFromId(
-                              vr::k_EButton_SteamVR_Trigger ) )
+                 & vr::ButtonMaskFromId( vr::k_EButton_SteamVR_Trigger ) )
             {
                 return true;
             }


### PR DESCRIPTION
Improved the trigger binding for push to talk on Valve Knuckles controllers by removing the "touched" condition. The capacitive touch sensor on the knuckles caused a hair-trigger that didn't feel right.