### PR TITLE
Fixed audio devices swapping on device hw changes

### DIFF
--- a/src/res/qml/AudioPage.qml
+++ b/src/res/qml/AudioPage.qml
@@ -160,7 +160,7 @@ MyStackViewPage {
                 Layout.maximumWidth: 850
                 Layout.minimumWidth: 850
                 Layout.preferredWidth: 850
-                onCurrentIndexChanged: {
+                onActivated: {
                     if (componentCompleted) {
                         AudioTabController.setPlaybackDeviceIndex(currentIndex)
                     }
@@ -180,7 +180,7 @@ MyStackViewPage {
                     Layout.maximumWidth: 850
                     Layout.minimumWidth: 850
                     Layout.preferredWidth: 850
-                    onCurrentIndexChanged: {
+                    onActivated: {
                         if (componentCompleted) {
                             AudioTabController.setMirrorDeviceIndex(currentIndex - 1)
                         }
@@ -263,7 +263,7 @@ MyStackViewPage {
                     Layout.maximumWidth: 850
                     Layout.minimumWidth: 850
                     Layout.preferredWidth: 850
-                    onCurrentIndexChanged: {
+                    onActivated: {
                         if (componentCompleted) {
                             AudioTabController.setMicDeviceIndex(currentIndex)
                         }


### PR DESCRIPTION
When audio devices connected or disconnected from the system, the default audio device swapped around. This was because of QML setting index 0 on ComboBox.model changes. onCurrentIndexChanged was calling setPlaybackDeviceIndex() / mirrorDevice/ micDevice etc... in the audio tab controller and actively setting the audio device index to 0 momentarily. Changing onCurrentIndexChanged to onActivated allows the ComboBox to only actively command the audio tab controller in direct response to user interaction.