### PR TITLE
Refactor Media Control Keys QML into smaller bits

### DIFF
--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -140,4 +140,5 @@ DISTFILES += \
     src/res/qml/StatisticsPage.qml \
     src/res/qml/SteamVRPage.qml \
     src/res/qml/UtilitiesPage.qml \
-    src/res/qml/media_keys/*
+    src/res/qml/media_keys/* \
+    src/res/qml/LineSeparator.qml

--- a/src/res/qml/LineSeparator.qml
+++ b/src/res/qml/LineSeparator.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import matzman666.advsettings 1.0
+// Necessary for the project specific Components.
+import ".."
+
+// Insert inside a ColumnLayout containing this and a RowLayout
+// to neatly separate header and buttons.
+Rectangle {
+    color: "#ffffff"
+    height: 1
+    Layout.fillWidth: true
+    Layout.bottomMargin: 5
+}

--- a/src/res/qml/UtilitiesPage.qml
+++ b/src/res/qml/UtilitiesPage.qml
@@ -2,7 +2,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import matzman666.advsettings 1.0
-
+import "media_keys"
 
 MyStackViewPage {
     headerText: "Utilities"
@@ -320,153 +320,8 @@ MyStackViewPage {
             }
         }
 
-        GroupBox {
+        MediaControllerKeys {
             id: mediaKeysGroupBox
-            Layout.fillWidth: true
-
-            label: MyText {
-                leftPadding: 10
-                text: "Media Control Keys"
-                bottomPadding: -10
-            }
-            background: Rectangle {
-                color: "transparent"
-                border.color: "#ffffff"
-                radius: 8
-            }
-            ColumnLayout {
-                anchors.fill: parent
-
-                Rectangle {
-                    color: "#ffffff"
-                    height: 1
-                    Layout.fillWidth: true
-                    Layout.bottomMargin: 5
-                }
-
-
-                RowLayout {
-                    property bool playButtonIsPlay: false
-                    MyPushButton2 {
-                        id: previousSongButton
-                        Layout.preferredHeight: 48
-                        Layout.preferredWidth: 48
-                        contentItem: Image {
-                            source: "media_keys/outline_skip_previous_white_24dp.svg"
-                            sourceSize: Qt.size( imgSP.sourceSize.width*2, imgSP.sourceSize.height*2 )
-                            Image{
-                                id: imgSP
-                                source: parent.source
-                                width:0
-                                height:0
-                            }
-                            anchors.fill: parent
-                        }
-                        onClicked: {
-                            UtilitiesTabController.sendMediaPreviousSong()
-                        }
-
-                        background: Rectangle {
-                            opacity: parent.down ? 1.0 : (parent.activeFocus ? 0.5 : 0.0)
-                            color: "#406288"
-                            radius: 4
-                            anchors.fill: parent
-                        }
-                    }
-                    MyPushButton2 {
-                        id: stopSongButton
-                        Layout.preferredHeight: 48
-                        Layout.preferredWidth: 48
-
-                        contentItem: Image {
-                            source: "media_keys/outline_stop_white_24dp.svg"
-                            sourceSize: Qt.size( imgS.sourceSize.width*2, imgS.sourceSize.height*2 )
-                            Image{
-                                id: imgS
-                                source: parent.source
-                                width:0
-                                height:0
-                            }
-                            anchors.fill: parent
-                        }
-                        onClicked: {
-                            UtilitiesTabController.sendMediaStopSong()
-                            playPauseSongButton.contentItem.source = "media_keys/outline_play_arrow_white_24dp.svg"
-                            parent.playButtonIsPlay = true
-                        }
-
-                        background: Rectangle {
-                            opacity: parent.down ? 1.0 : (parent.activeFocus ? 0.5 : 0.0)
-                            color: "#406288"
-                            radius: 4
-                            anchors.fill: parent
-                        }
-                    }
-                    MyPushButton2 {
-                        id: playPauseSongButton
-                        Layout.preferredHeight: 48
-                        Layout.preferredWidth: 48
-                        contentItem: Image {
-                            // Assume that music is playing when people enter VR.
-                            source: "media_keys/outline_pause_white_24dp.svg"
-                            sourceSize: Qt.size( imgP.sourceSize.width*2, imgP.sourceSize.height*2 )
-                            Image{
-                                id: imgP
-                                source: parent.source
-                                width:0
-                                height:0
-                            }
-
-                            anchors.fill: parent
-                        }
-                        onClicked: {
-                            UtilitiesTabController.sendMediaPausePlay()
-                            if (parent.playButtonIsPlay) {
-                                playPauseSongButton.contentItem.source = "media_keys/outline_pause_white_24dp.svg"
-                                parent.playButtonIsPlay = false
-                            } else {
-                                playPauseSongButton.contentItem.source = "media_keys/outline_play_arrow_white_24dp.svg"
-                                parent.playButtonIsPlay = true
-                            }
-
-                        }
-
-                        background: Rectangle {
-                            opacity: parent.down ? 1.0 : (parent.activeFocus ? 0.5 : 0.0)
-                            color: "#406288"
-                            radius: 4
-                            anchors.fill: parent
-                        }
-                    }
-                    MyPushButton2 {
-                        id: nextSongButton
-                        Layout.preferredHeight: 48
-                        Layout.preferredWidth: 48
-
-                        contentItem: Image {
-                            source: "media_keys/outline_skip_next_white_24dp.svg"
-                            sourceSize: Qt.size( imgSN.sourceSize.width*2, imgSN.sourceSize.height*2 )
-                            Image{
-                                id: imgSN
-                                source: parent.source
-                                width:0
-                                height:0
-                            }
-                            anchors.fill: parent
-                        }
-                        onClicked: {
-                            UtilitiesTabController.sendMediaNextSong()
-                        }
-
-                        background: Rectangle {
-                            opacity: parent.down ? 1.0 : (parent.activeFocus ? 0.5 : 0.0)
-                            color: "#406288"
-                            radius: 4
-                            anchors.fill: parent
-                        }
-                    }
-                }
-            }
         }
 
         Item {

--- a/src/res/qml/media_keys/MediaButton.qml
+++ b/src/res/qml/media_keys/MediaButton.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import matzman666.advsettings 1.0
+// Necessary for the project specific Components.
+import ".."
+
+MyPushButton2 {
+    // Public properties
+    id: mediaButton
+    onClicked: {
+        // Overload this
+    }
+    property string imagePath: ""
+
+    // Private properties
+    Layout.preferredHeight: 48
+    Layout.preferredWidth: 48
+    contentItem: Image {
+        source: parent.imagePath
+        sourceSize: Qt.size( imgSP.sourceSize.width*2, imgSP.sourceSize.height*2 )
+        Image{
+            id: imgSP
+            source: parent.source
+            width:0
+            height:0
+        }
+        anchors.fill: parent
+    }
+
+    background: Rectangle {
+        // Provides feedback for mousing over and clicking buttons.
+        opacity: parent.down ? 1.0 : (parent.activeFocus ? 0.5 : 0.0)
+        color: "#406288"
+        radius: 4
+        anchors.fill: parent
+    }
+}

--- a/src/res/qml/media_keys/MediaControllerKeys.qml
+++ b/src/res/qml/media_keys/MediaControllerKeys.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import matzman666.advsettings 1.0
+// Necessary for the project specific Components.
+import ".."
+
+GroupBox {
+    id: mediaKeysGroupBox
+    Layout.fillWidth: true
+
+    label: MyText {
+        leftPadding: 10
+        text: "Media Control Keys"
+        bottomPadding: -10
+    }
+    background: Rectangle {
+        color: "transparent"
+        border.color: "#ffffff"
+        radius: 8
+    }
+    ColumnLayout {
+        anchors.fill: parent
+
+        LineSeparator {
+        }
+
+        RowLayout {
+            property bool playButtonIsPlay: false
+
+            property string playButtonPath: "outline_play_arrow_white_24dp.svg"
+            property string pauseButtonPath: "outline_pause_white_24dp.svg"
+            property string stopButtonPath: "outline_stop_white_24dp.svg"
+            property string previousButtonPath: "outline_skip_previous_white_24dp.svg"
+            property string nextButtonPath: "outline_skip_next_white_24dp.svg"
+
+            MediaButton {
+                id: previousSongButton
+                imagePath: parent.previousButtonPath
+                onClicked: {
+                    UtilitiesTabController.sendMediaPreviousSong()
+                }
+            }
+
+            MediaButton {
+                id: stopSongButton
+                imagePath: parent.stopButtonPath
+                onClicked: {
+                    UtilitiesTabController.sendMediaStopSong()
+                    playPauseSongButton.contentItem.source = parent.playButtonPath
+                    parent.playButtonIsPlay = true
+                }
+            }
+
+            MediaButton {
+                id: playPauseSongButton
+                imagePath: parent.pauseButtonPath
+                onClicked: {
+                    UtilitiesTabController.sendMediaPausePlay()
+                    if (parent.playButtonIsPlay) {
+                        playPauseSongButton.contentItem.source = parent.pauseButtonPath
+                        parent.playButtonIsPlay = false
+                    } else {
+                        playPauseSongButton.contentItem.source = parent.playButtonPath
+                        parent.playButtonIsPlay = true
+                    }
+
+                }
+            }
+
+            MediaButton {
+                id: nextSongButton
+                imagePath: parent.nextButtonPath
+                onClicked: {
+                    UtilitiesTabController.sendMediaNextSong()
+                }
+            }
+        }
+    }
+}

--- a/src/res/qml/media_keys/MediaControllerKeys.qml
+++ b/src/res/qml/media_keys/MediaControllerKeys.qml
@@ -26,10 +26,7 @@ GroupBox {
         }
 
         RowLayout {
-            property bool playButtonIsPlay: false
-
-            property string playButtonPath: "outline_play_arrow_white_24dp.svg"
-            property string pauseButtonPath: "outline_pause_white_24dp.svg"
+            property string playPauseButtonPath: "outline_play_pause_white_24dp.svg"
             property string stopButtonPath: "outline_stop_white_24dp.svg"
             property string previousButtonPath: "outline_skip_previous_white_24dp.svg"
             property string nextButtonPath: "outline_skip_next_white_24dp.svg"
@@ -47,24 +44,14 @@ GroupBox {
                 imagePath: parent.stopButtonPath
                 onClicked: {
                     UtilitiesTabController.sendMediaStopSong()
-                    playPauseSongButton.contentItem.source = parent.playButtonPath
-                    parent.playButtonIsPlay = true
                 }
             }
 
             MediaButton {
                 id: playPauseSongButton
-                imagePath: parent.pauseButtonPath
+                imagePath: parent.playPauseButtonPath
                 onClicked: {
                     UtilitiesTabController.sendMediaPausePlay()
-                    if (parent.playButtonIsPlay) {
-                        playPauseSongButton.contentItem.source = parent.pauseButtonPath
-                        parent.playButtonIsPlay = false
-                    } else {
-                        playPauseSongButton.contentItem.source = parent.playButtonPath
-                        parent.playButtonIsPlay = true
-                    }
-
                 }
             }
 

--- a/src/res/qml/media_keys/outline_pause_white_24dp.svg
+++ b/src/res/qml/media_keys/outline_pause_white_24dp.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path fill="white" d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>

--- a/src/res/qml/media_keys/outline_play_arrow_white_24dp.svg
+++ b/src/res/qml/media_keys/outline_play_arrow_white_24dp.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path fill="white" d="M10 8.64L15.27 12 10 15.36V8.64M8 5v14l11-7L8 5z"/></svg>

--- a/src/res/qml/media_keys/outline_play_pause_white_24dp.svg
+++ b/src/res/qml/media_keys/outline_play_pause_white_24dp.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M0,0h24v24H0V0z"/>
+<path class="st1" d="M5,8.6l5.3,3.4L5,15.4V8.6 M3,5v14l11-7L3,5z"/>
+<path class="st1" d="M14,19h2.3V5H14V19z M18.7,5v14H21V5H18.7z"/>
+</svg>


### PR DESCRIPTION
The old QML was a giant mess of implementation details and logic.
Reducing the buttons to only 2 essential properties allows the MediaControllerKeys object to be more easily understood.

Moving the MediaControllerKeys into its own QML file allows the resulting page to be more easily understood and individual pieces swapped in and out.

The current QML directory structure is non-existent, breaking parts down into cohesive folders will allow for easier understanding of the bigger picture.