### PR TITLE
Rename version strings to 2.8.0-dev

### DIFF
--- a/build_scripts/win/common.py
+++ b/build_scripts/win/common.py
@@ -11,7 +11,7 @@ import distutils.dir_util
 #Const globals
 #Version string must be bumped every release.
 #TODO: See developer documentation.
-VERSION_STRING = "2-8-0"
+VERSION_STRING = "2-8-0-dev"
 
 EXIT_CODE_SUCCESS = 0
 EXIT_CODE_FAILURE_BUILD_APP = 1

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -11,7 +11,7 @@
 		!define THIRDDIR "..\third-party"
         !define PACKAGEDIR "..\src\package_files"
         !define PROJECTDIR "..\"
-        !define VERSION_STRING "2-8-0"
+        !define VERSION_STRING "2-8-0-dev"
 
 	;Name and file
 	Name "OpenVR Advanced Settings"

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -49,7 +49,7 @@ public:
     static constexpr auto applicationName = "OpenVRAdvancedSettings";
     static constexpr const char* applicationKey = "matzman666.AdvancedSettings";
     static constexpr const char* applicationDisplayName = "Advanced Settings";
-    static constexpr const char* applicationVersionString = "v2.8.0";
+    static constexpr const char* applicationVersionString = "v2.8.0-dev";
 
 private:
     vr::VROverlayHandle_t m_ulOverlayHandle = vr::k_ulOverlayHandleInvalid;


### PR DESCRIPTION
Since version strings are displayed in logs and on the main screen, this
will prevent situations where the master branch is confused with the
2.8.0-release branch.

The 2-8-0-release file was a one time thing because the version numbers
were already changed, it should not be created for future releases.