### PR TITLE
fixed default audio profile display

### DIFF
--- a/src/res/qml/AudioPage.qml
+++ b/src/res/qml/AudioPage.qml
@@ -659,6 +659,9 @@ MyStackViewPage {
             onPttProfileAdded:{
                 pttProfileComboBox.currentIndex = AudioTabController.getPttProfileCount()
             }
+            onDefaultProfileDisplay:{
+                audioProfileComboBox.currentIndex = AudioTabController.getDefaultAudioProfileIndex() + 1
+            }
 
 
             onPlaybackDeviceListChanged: {

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -101,7 +101,7 @@ void AudioTabController::initStage2( OverlayController* var_parent,
                      << vr::VROverlay()->GetOverlayErrorNameFromEnum(
                             overlayError );
     }
-	emit defaultProfileDisplay();
+    emit defaultProfileDisplay();
 }
 
 void AudioTabController::reloadAudioSettings()
@@ -1042,14 +1042,15 @@ void AudioTabController::applyDefaultProfile()
         if ( profile.defaultProfile )
         {
             applyAudioProfile( i );
-			m_defaultProfileIndex = i;
+            m_defaultProfileIndex = i;
             break;
         }
     }
 }
 
-int AudioTabController::getDefaultAudioProfileIndex() {
-	return m_defaultProfileIndex;
+int AudioTabController::getDefaultAudioProfileIndex()
+{
+    return m_defaultProfileIndex;
 }
 
 /* ---------------------------*/

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -101,6 +101,7 @@ void AudioTabController::initStage2( OverlayController* var_parent,
                      << vr::VROverlay()->GetOverlayErrorNameFromEnum(
                             overlayError );
     }
+	emit defaultProfileDisplay();
 }
 
 void AudioTabController::reloadAudioSettings()
@@ -852,9 +853,8 @@ void AudioTabController::addAudioProfile( QString name )
     profile->defaultProfile = m_isDefaultAudioProfile;
     if ( m_isDefaultAudioProfile )
     {
-        removeDefaultProfile( name );
+        removeOtherDefaultProfiles( name );
 
-        // to prevent confusion, resets checkbox
         setAudioProfileDefault( false );
     }
     saveAudioProfiles();
@@ -1004,14 +1004,14 @@ int AudioTabController::getMirrorIndex( std::string str )
 }
 
 /*
-Name: removeDefaultProfile
+Name: removeOtherDefaultProfiles
 
 input: QString name - name of new default profile
 output: none
 
 description: checks all profiles and removes any OTHERS that are set as default.
 */
-void AudioTabController::removeDefaultProfile( QString name )
+void AudioTabController::removeOtherDefaultProfiles( QString name )
 {
     AudioProfile* profile = nullptr;
     for ( auto& p : audioProfiles )
@@ -1042,9 +1042,14 @@ void AudioTabController::applyDefaultProfile()
         if ( profile.defaultProfile )
         {
             applyAudioProfile( i );
+			m_defaultProfileIndex = i;
             break;
         }
     }
+}
+
+int AudioTabController::getDefaultAudioProfileIndex() {
+	return m_defaultProfileIndex;
 }
 
 /* ---------------------------*/

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -70,7 +70,7 @@ private:
     bool m_micReversePtt = false;
     bool m_isDefaultAudioProfile = false;
 
-	int m_defaultProfileIndex = -1;
+    int m_defaultProfileIndex = -1;
 
     unsigned settingsUpdateCounter = 0;
 
@@ -139,7 +139,7 @@ public:
 
     Q_INVOKABLE unsigned getAudioProfileCount();
     Q_INVOKABLE QString getAudioProfileName( unsigned index );
-	Q_INVOKABLE int getDefaultAudioProfileIndex();
+    Q_INVOKABLE int getDefaultAudioProfileIndex();
 
     void onNewRecordingDevice();
     void onNewPlaybackDevice();
@@ -185,6 +185,6 @@ signals:
     void audioProfileAdded();
     void audioProfileDefaultChanged( bool value );
 
-	void defaultProfileDisplay();
+    void defaultProfileDisplay();
 };
 } // namespace advsettings

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -69,7 +69,8 @@ private:
     bool m_micProximitySensorCanMute = false;
     bool m_micReversePtt = false;
     bool m_isDefaultAudioProfile = false;
-    std::string m_defaultProfileName;
+
+	int m_defaultProfileIndex = -1;
 
     unsigned settingsUpdateCounter = 0;
 
@@ -100,7 +101,7 @@ private:
     int getRecordingIndex( std::string str );
     int getMirrorIndex( std::string str );
 
-    void removeDefaultProfile( QString name );
+    void removeOtherDefaultProfiles( QString name );
 
     std::vector<AudioProfile> audioProfiles;
 
@@ -138,6 +139,7 @@ public:
 
     Q_INVOKABLE unsigned getAudioProfileCount();
     Q_INVOKABLE QString getAudioProfileName( unsigned index );
+	Q_INVOKABLE int getDefaultAudioProfileIndex();
 
     void onNewRecordingDevice();
     void onNewPlaybackDevice();
@@ -182,5 +184,7 @@ signals:
     void audioProfilesUpdated();
     void audioProfileAdded();
     void audioProfileDefaultChanged( bool value );
+
+	void defaultProfileDisplay();
 };
 } // namespace advsettings


### PR DESCRIPTION
- Fixed Issue #19 Audio profiles now properly display on start-up
- Fixed Issue #45 Re-named a function to allow better read-ability