### PR TITLE
Fix NULL dereference in OnDefaultDeviceChanged

### DIFF
--- a/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
@@ -457,7 +457,7 @@ IMMDevice*
                                     LPCWSTR id )
 {
     IMMDevice* pDevice;
-    if ( deviceEnumerator->GetDevice( id, &pDevice ) < 0 )
+    if ( !id || deviceEnumerator->GetDevice( id, &pDevice ) < 0 )
     {
         return nullptr;
     }
@@ -606,6 +606,10 @@ AudioManagerWindows::OnDefaultDeviceChanged( EDataFlow flow,
                     micAudioEndpointVolume
                         = getAudioEndpointVolume( micAudioDevice );
                 }
+                else if ( !pwstrDefaultDeviceId )
+                {
+                    LOG( WARNING ) << "No recording device available.";
+                }
                 else
                 {
                     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>
@@ -632,7 +636,11 @@ AudioManagerWindows::OnDefaultDeviceChanged( EDataFlow flow,
                     playbackAudioDevice->Release();
                 }
                 playbackAudioDevice = device;
-                if ( !playbackAudioDevice )
+                if ( !pwstrDefaultDeviceId )
+                {
+                    LOG( WARNING ) << "No playback device available.";
+                }
+                else if ( !playbackAudioDevice )
                 {
                     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>
                         converter;


### PR DESCRIPTION
When the vive pro wireless adapter loses connection, its audio devices are
removed, causing an OnDefaultDeviceChanged event to be issued for each
such device that was previously set as the default. However, if no other
device is available for the role that was disconnected (e.g. if the Vive
Pro was providing the only system microphone), then pwstrDefaultDeviceId
is NULL.

In this case, we would invoke getDevice on the NULL device ID, then
attempt to print the default device name in the debug logging path; this
NULL dereference would cause AdvancedSettings to crash.

This change simply fixes the logging code to not attempt to print the
new default device name when it is NULL.