### PR TITLE
ChaperoneTab flipOrentation should reset offsets

### DIFF
--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -1242,6 +1242,7 @@ void ChaperoneTabController::setChaperoneVelocityModifier( float value,
 
 void ChaperoneTabController::flipOrientation()
 {
+    parent->m_moveCenterTabController.reset();
     parent->RotateUniverseCenter( vr::TrackingUniverseStanding,
                                   ( float ) M_PI );
 }


### PR DESCRIPTION
ChaperoneTab's flipOrentation() calls RotateUniverseCenter() and should reset the universe offsets first. Not doing so might have unexpected behaviors.