### PR TITLE
Update to qt5.12

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-  - QT_LOC: '"C:\Qt\5.11.2\msvc2017_64\bin\"'
+  - QT_LOC: '"C:\Qt\5.12\msvc2017_64\bin\"'
     VS_LOC: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"'
     JOM_LOC: '"C:\Qt\Tools\QtCreator\bin\jom.exe"'
     NSIS_LOC: '"C:\Program Files (x86)\NSIS\"'
@@ -11,7 +11,7 @@ environment:
     PYTHON_LOC: '"C:\Python37\"'
     BUILD_PACKAGE: "1"
     
-  - QT_LOC: '"C:\Qt\5.11.2\msvc2017_64\bin\"'
+  - QT_LOC: '"C:\Qt\5.12\msvc2017_64\bin\"'
     VS_LOC: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"'
     JOM_LOC: '"C:\Qt\Tools\QtCreator\bin\jom.exe"'
     NSIS_LOC: '"C:\Program Files (x86)\NSIS\"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ install:
 
 script:
   - mkdir build && cd build
+  - qmake --version
   - qmake .. -spec $QMAKE_SPEC
   - make

--- a/docs/building_for_windows.md
+++ b/docs/building_for_windows.md
@@ -14,7 +14,7 @@
 For compiling:
 
 1. [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) (tested on 2017 Community)
-2. [Qt Framework](https://www.qt.io/download) version later than 5.6 (tested on 5.10 and 5.11)
+2. [Qt Framework](https://www.qt.io/download) version later than 5.6 (Requires at least 5.6. 5.12 is recommended)
 3. [Python 3](https://www.python.org/downloads/) (must be in `PATH` environment variable)
 
 For pushing changes to the repo:


### PR DESCRIPTION
The 5.11.2 version has been removed from AppVeyor leading to all builds failing due to lack of Qt install. The  5.12 folder is symlinked to the newest Qt 5.12 version, preventing the need for changes during small updates and preventing failures when versions have been removed.

This solves issue #53.

Additionally, it makes the Travis CI instance spit out the current Qt version with `qmake --version`.