### PR TITLE
Add clang-tidy, update Linux build scripts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,353 @@
+---
+Checks:          '*,
+    -cert-err58-cpp,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -cppcoreguidelines-pro-type-member-init,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -cppcoreguidelines-pro-type-vararg,
+    -cppcoreguidelines-special-member-functions,
+    -fuchsia-default-arguments,
+    -fuchsia-statically-constructed-objects,
+    -google-default-arguments,
+    -google-explicit-constructor,
+    -google-readability-braces-around-statements,
+    -google-readability-todo,
+    -google-runtime-int,
+    -google-runtime-references,
+    -hicpp-braces-around-statements,
+    -hicpp-explicit-conversions,
+    -hicpp-member-init,
+    -hicpp-no-array-decay,
+    -hicpp-signed-bitwise,
+    -hicpp-special-member-functions,
+    -hicpp-use-auto,
+    -hicpp-use-equals-default,
+    -hicpp-use-override,
+    -hicpp-vararg,
+    -llvm-header-guard,
+    -llvm-include-order,
+    -misc-string-compare,
+    -misc-unused-using-decls,
+    -modernize-loop-convert,
+    -modernize-make-unique,
+    -modernize-use-auto,
+    -modernize-use-equals-default,
+    -modernize-use-override,
+    -modernize-use-using,
+    -performance-for-range-copy,
+    -performance-unnecessary-value-param,
+    -readability-avoid-const-params-in-decls,
+    -readability-braces-around-statements,
+    -readability-else-after-return,
+    -readability-implicit-bool-conversion,
+    -readability-inconsistent-declaration-parameter-name,
+    -readability-non-const-parameter,
+    -readability-string-compare,
+    -readability-redundant-declaration,
+    -readability-redundant-member-init,
+    -readability-static-accessed-through-instance'
+WarningsAsErrors:           '*,
+    -cert-err58-cpp,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+    -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+    -cppcoreguidelines-pro-type-member-init,
+    -cppcoreguidelines-pro-type-reinterpret-cast,
+    -cppcoreguidelines-pro-type-vararg,
+    -cppcoreguidelines-special-member-functions,
+    -fuchsia-default-arguments,
+    -google-default-arguments,
+    -google-explicit-constructor,
+    -google-readability-braces-around-statements,
+    -google-readability-todo,
+    -google-runtime-int,
+    -google-runtime-references,
+    -hicpp-braces-around-statements,
+    -hicpp-explicit-conversions,
+    -hicpp-member-init,
+    -hicpp-no-array-decay,
+    -hicpp-signed-bitwise,
+    -hicpp-special-member-functions,
+    -hicpp-use-auto,
+    -hicpp-use-equals-default,
+    -hicpp-use-override,
+    -hicpp-vararg,
+    -llvm-header-guard,
+    -llvm-include-order,
+    -misc-string-compare,
+    -misc-unused-using-decls,
+    -modernize-loop-convert,
+    -modernize-make-unique,
+    -modernize-use-auto,
+    -modernize-use-equals-default,
+    -modernize-use-override,
+    -modernize-use-using,
+    -performance-for-range-copy,
+    -performance-unnecessary-value-param,
+    -readability-avoid-const-params-in-decls,
+    -readability-braces-around-statements,
+    -readability-else-after-return,
+    -readability-implicit-bool-conversion,
+    -readability-inconsistent-declaration-parameter-name,
+    -readability-non-const-parameter,
+    -readability-redundant-declaration,
+    -readability-redundant-member-init,
+    -readability-static-accessed-through-instance'
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             cppcoreguidelines-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             cppcoreguidelines-no-malloc.Deallocations
+    value:           '::free'
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           ''
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-references.WhiteListTypes
+    value:           ''
+  - key:             hicpp-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             hicpp-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.StatementThreshold
+    value:           '800'
+  - key:             hicpp-member-init.IgnoreArrays
+    value:           '0'
+  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             hicpp-named-parameter.IgnoreFailedSplit
+    value:           '0'
+  - key:             hicpp-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             hicpp-no-malloc.Deallocations
+    value:           '::free'
+  - key:             hicpp-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             hicpp-use-auto.RemoveStars
+    value:           '0'
+  - key:             hicpp-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             hicpp-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             hicpp-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             hicpp-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             hicpp-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-noexcept.ReplacementString
+    value:           ''
+  - key:             hicpp-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             hicpp-use-nullptr.NullMacros
+    value:           ''
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '1'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '1'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           '1'
+  - key:             misc-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             misc-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             misc-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             misc-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             misc-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             misc-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             misc-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             misc-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             misc-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             misc-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             misc-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    value:           '1'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+  - key:             objc-forbidden-subclassing.ForbiddenSuperClassNames
+    value:           'ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView'
+  - key:             objc-property-declaration.Acronyms
+    value:           'ASCII;PDF;XML;HTML;URL;RTF;HTTP;TIFF;JPG;PNG;GIF;LZW;ROM;RGB;CMYK;MIDI;FTP'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+...
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -94,4 +94,4 @@
 
 #Linux Shell Scripts
 #Windows Subsystem for Linux will not run CLRF files.
-*.sh text eof=lf
+*.sh text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,17 @@ matrix:
         - g++-7
     env:
     - QMAKE_SPEC=linux-g++
+    compiler: gcc
 
   - os: linux
     env:
     - QMAKE_SPEC=linux-clang
+    compiler: clang
+
+  - os: linux
+    env:
+    - USE_TIDY=TRUE
+    compiler: clang
 
 before_install:
   - python ./build_scripts/run-clang-format.py ./src -r --color always  
@@ -24,9 +31,7 @@ install:
   - sudo add-apt-repository ppa:kubuntu-ppa/backports -y
   - sudo apt-get update -qq
   - sudo apt-get install build-essential qtbase5-dev qttools5-dev qtdeclarative5-dev qtmultimedia5-dev qt5-default qttools5-dev-tools
+  - sudo apt-get install bear clang-tidy
 
 script:
-  - mkdir build && cd build
-  - qmake --version
-  - qmake .. -spec $QMAKE_SPEC
-  - make
+  - ./build_scripts/linux/build_linux.sh

--- a/Readme.md
+++ b/Readme.md
@@ -291,10 +291,7 @@ Full build instructions can be found [here](docs/building_for_windows.md).
 <a name="building_on_linux"></a>
 ## Building on Linux
 
-If you want to run Advanced Settings on linux you can build it yourself using `qmake` and `make` or using Qt Creator, you'll have to copy the `res` folder from the `src` folder into folder that contains the binary
-and copy `third-party/openvr/lib/linux64/libopenvr_api.so` into your systems library path.
-
-If you want to contribute changes running `clang-format` is necessary. More details are in the [CONTRIBUTING.md](docs/CONTRIBUTING.md) file.
+Full build instructions can be found [here](docs/building_for_linux.md).
 
 <a name="notes"></a>
 # Notes:

--- a/build_scripts/linux/build_linux.sh
+++ b/build_scripts/linux/build_linux.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+if [[ -z $QMAKE_SPEC ]]; then
+    QMAKE_SPEC='linux-g++'
+fi
+
+if [[ -z $USE_TIDY ]]; then
+    MAKE_COMMAND='make --jobs'
+    CLANG_TIDY=
+else
+    # Bear replaces the compile database, it does not update it.
+    # If you run 'bear make' and there is nothing to compile, you
+    # will get an empty database.
+    # Clean up the artifacts and run everything together in that case.
+    MAKE_COMMAND='bear make --jobs'
+    QMAKE_SPEC='linux-clang'
+    CLANG_TIDY='../build_scripts/linux/run-clang-tidy.sh'
+fi
+
+echo $MAKE_COMMAND
+mkdir -p build
+cd build
+qmake --version
+qmake -spec $QMAKE_SPEC ..
+$MAKE_COMMAND
+$CLANG_TIDY

--- a/build_scripts/linux/format.sh
+++ b/build_scripts/linux/format.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 clang-format --version
 

--- a/build_scripts/linux/run-clang-tidy.sh
+++ b/build_scripts/linux/run-clang-tidy.sh
@@ -1,0 +1,15 @@
+set +e
+clang-tidy --version
+
+ERROR=0
+for file in $(find ../src -name "*.cpp"); do
+    echo $file
+    clang-tidy $file
+
+    EXIT=$?
+    if [[ $EXIT != 0 ]]; then
+        ERROR=1
+    fi
+done
+set -e
+exit $ERROR

--- a/build_scripts/linux/verify_formatting.sh
+++ b/build_scripts/linux/verify_formatting.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 clang-format --version;
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -1,0 +1,43 @@
+# Building for Linux
+
+- [Requirements](#requirements)
+- [Locations and Environment Variables](#locations-and-environment-variables)
+- [Building](#building)
+- [Contributing](#contributing)
+
+## Requirements
+
+The following packages are necessary for compiling: 
+
+`sudo apt install build-essential qtbase5-dev qttools5-dev qtdeclarative5-dev qtmultimedia5-dev qt5-default qttools5-dev-tools`
+
+If you install Qt 5.12 you should have the above packages.
+
+Along with either `clang` or `g++`. At least `g++-7` is required, due to C++17 support.
+
+For linting with `clang-tidy` the following are necessary:
+
+`sudo apt install bear clang-tidy`
+
+All applications are required to be in the `PATH`.
+
+## Locations and Environment Variables
+
+The following environmental variables are relevant for building the project.
+
+| Environment Variable  | Purpose |
+| --------------------  | ------------- |
+| `QMAKE_SPEC`              | The [mkspec](https://forum.qt.io/topic/70970/what-is-mkspecs-used-for-how-to-configure-for-my-hardware) to compile to. Either `linux-g++` or `linux-clang`. Defaults to `linux-g++`.   |
+| `USE_TIDY`              | If set a compilation database will be created and the project linted. Can only be used with `clang`.  |
+
+If an environment variable isn't set a default value will be provided. The default values are shown in the table below.
+
+## Building
+
+With the programs above installed and environment variables set, go into the root folder of the repository and run `./build_scripts/linux/build_linux.sh`.
+
+You'll have to copy the `res` directory into the resulting binary location, and add `third-party/openvr/lib/linux64/libopenvr_api.so` to your systems library path.
+
+## Contributing
+
+For full details, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -114,7 +114,7 @@ Section "Install" SecInstall
     ;Any action manifests
     File "${BASEDIR}\*.json"
     ;And their defaults
-    File "${BASEDIR}\default_action_manifests\*.json"
+    File /r "${BASEDIR}\default_action_manifests"
     
 	File "${THIRDDIR}\openvr\bin\win64\*.dll"
 	File "${BASEDIR}\*.dll"


### PR DESCRIPTION
## This PR:
* Adds clang-tidy checks for everything that does not currently produce warnings.
* Updates the Linux build scripts.
* Fixes Travis CI instances outputting the version of the wrong compiler.
* Fixes typo in `.gitattributes` that did not apply `LF` endings to `.sh` files.
* Fixes #80.

## Noteworthy Items:
* The `.clang-tidy` file specifies which checks are enabled. Right now all (`*`) checks are enabled, except those that are explicitly disabled with minus.
* All `.cpp` files are checked. The `easylogging++.cc` file is therefore not checked, but calls from other files to this file will still warn.
* A third Travis CI instance will handle `clang-tidy`. The program responsible for creating the compilation database (`bear`) is not available for Windows. Therefore Windows specific code will not be tested.
* `make` will now use multiple threads, which significantly speeds up compilation time.

## Technical Considerations:
* `clang-tidy` can also be invoked with an [official python script](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py). This worked on my local machine but did not work on the Travis CI. A simple bash script was therefore chosen instead.