### PR TITLE
Add proper exit to shutdown code

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -671,9 +671,11 @@ void OverlayController::mainEventLoop()
             m_chaperoneTabController.shutdown();
             Shutdown();
             QApplication::exit();
-            return;
+
+            LOG( INFO ) << "All systems exited.";
+            exit( EXIT_SUCCESS );
+            // Does not fallthrough
         }
-        break;
 
         case vr::VREvent_DashboardActivated:
         {


### PR DESCRIPTION
The old shutdown code did not correctly exit but instead just continuously called the QApplication notify function until it SEGFAULTed. This led to crashes whenever SteamVR was shut down. Users with Windows Error Reporting turned on would get a 100+ MB crashdump file along with increased shutdown time for SteamVR. 

For clarity the shutdown functions should probably be collected in a
single function in the future.

This fixes #89.