### PR TITLE
Change log and settings file locations

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ For bug reports include what you expect to happen, what happened, version number
 
 For improvement requests include what you're expecting to do, why you want the feature this way, the problem that you're solving and any other information that you find relevant.
 
-Include logs if possible. Logs can be found in `%APPDATA%\matzman666\OpenVRAdvancedSettings\AdvancedSettings.log` on Windows.
+Include logs if possible. Logs can be found in `%APPDATA%\AdvancedSettings-Team\AdvancedSettings.log` on Windows.
 
 <a name="patch"></a>
 ## You want to submit changes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,12 @@ int main( int argc, char* argv[] )
 
     MyQApplication mainEventLoop( argc, argv );
     mainEventLoop.setOrganizationName(
-        advsettings::OverlayController::applicationOrganizationName );
-    mainEventLoop.setApplicationName(
-        advsettings::OverlayController::applicationName );
+        application_strings::applicationOrganizationName );
+    mainEventLoop.setApplicationName( application_strings::applicationName );
     mainEventLoop.setApplicationDisplayName(
-        advsettings::OverlayController::applicationDisplayName );
+        application_strings::applicationDisplayName );
     mainEventLoop.setApplicationVersion(
-        advsettings::OverlayController::applicationVersionString );
+        application_strings::applicationVersionString );
 
     qInstallMessageHandler( mainQtMessageHandler );
 
@@ -61,10 +60,9 @@ int main( int argc, char* argv[] )
                          << std::endl;
         }
         auto quickObj = component.create();
-        controller.SetWidget(
-            qobject_cast<QQuickItem*>( quickObj ),
-            advsettings::OverlayController::applicationDisplayName,
-            advsettings::OverlayController::applicationKey );
+        controller.SetWidget( qobject_cast<QQuickItem*>( quickObj ),
+                              application_strings::applicationDisplayName,
+                              application_strings::applicationKey );
 
         // Attempts to install the application manifest on all "regular" starts.
         if ( !commandLineArgs.desktopMode && !commandLineArgs.forceNoManifest )

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -138,8 +138,9 @@ OverlayController::OverlayController( bool desktopMode,
     // rewriting all QML to not be singletons, which should probably be done
     // whenever possible.
     static OverlayController* const objectAddress = this;
+    constexpr auto qmlSingletonImportName = "matzman666.advsettings";
     qmlRegisterSingletonType<OverlayController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "OverlayController",
@@ -153,7 +154,7 @@ OverlayController::OverlayController( bool desktopMode,
     // remaining function calls, or if it's just a copy paste accident that
     // happens to work.
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "SteamVRTabController",
@@ -163,7 +164,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "ChaperoneTabController",
@@ -173,7 +174,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "MoveCenterTabController",
@@ -183,7 +184,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "FixFloorTabController",
@@ -193,7 +194,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "AudioTabController",
@@ -203,7 +204,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "StatisticsTabController",
@@ -213,7 +214,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "SettingsTabController",
@@ -223,7 +224,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "ReviveTabController",
@@ -233,7 +234,7 @@ OverlayController::OverlayController( bool desktopMode,
             return obj;
         } );
     qmlRegisterSingletonType<SteamVRTabController>(
-        "matzman666.advsettings",
+        qmlSingletonImportName,
         1,
         0,
         "UtilitiesTabController",

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -138,7 +138,7 @@ OverlayController::OverlayController( bool desktopMode,
     // rewriting all QML to not be singletons, which should probably be done
     // whenever possible.
     static OverlayController* const objectAddress = this;
-    constexpr auto qmlSingletonImportName = "matzman666.advsettings";
+    constexpr auto qmlSingletonImportName = "ovras.advsettings";
     qmlRegisterSingletonType<OverlayController>(
         qmlSingletonImportName,
         1,

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -24,8 +24,6 @@
 // application namespace
 namespace advsettings
 {
-constexpr const char* OverlayController::applicationVersionString;
-
 QSettings* OverlayController::_appSettings = nullptr;
 
 OverlayController::OverlayController( bool desktopMode,
@@ -1035,7 +1033,7 @@ void OverlayController::RotateCollisionBounds( float angle, bool commit )
 
 QString OverlayController::getVersionString()
 {
-    return QString( applicationVersionString );
+    return QString( application_strings::applicationVersionString );
 }
 
 QUrl OverlayController::getVRRuntimePathUrl()

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -44,7 +44,7 @@ namespace application_strings
 {
 constexpr auto applicationOrganizationName = "AdvancedSettings-Team";
 constexpr auto applicationName = "OpenVRAdvancedSettings";
-constexpr const char* applicationKey = "matzman666.AdvancedSettings";
+constexpr const char* applicationKey = "OVRAS-Team.AdvancedSettings";
 constexpr const char* applicationDisplayName = "Advanced Settings";
 constexpr const char* applicationVersionString = "v2.8.0-dev";
 } // namespace application_strings

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -40,6 +40,15 @@
 
 #include "openvr/ivrinput.h"
 
+namespace application_strings
+{
+constexpr auto applicationOrganizationName = "matzman666";
+constexpr auto applicationName = "OpenVRAdvancedSettings";
+constexpr const char* applicationKey = "matzman666.AdvancedSettings";
+constexpr const char* applicationDisplayName = "Advanced Settings";
+constexpr const char* applicationVersionString = "v2.8.0-dev";
+} // namespace application_strings
+
 // application namespace
 namespace advsettings
 {
@@ -65,13 +74,6 @@ class OverlayController : public QObject
 {
     Q_OBJECT
     Q_PROPERTY( bool m_desktopMode READ isDesktopMode )
-
-public:
-    static constexpr auto applicationOrganizationName = "matzman666";
-    static constexpr auto applicationName = "OpenVRAdvancedSettings";
-    static constexpr const char* applicationKey = "matzman666.AdvancedSettings";
-    static constexpr const char* applicationDisplayName = "Advanced Settings";
-    static constexpr const char* applicationVersionString = "v2.8.0-dev";
 
 private:
     vr::VROverlayHandle_t m_ulOverlayHandle = vr::k_ulOverlayHandleInvalid;

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -42,7 +42,7 @@
 
 namespace application_strings
 {
-constexpr auto applicationOrganizationName = "matzman666";
+constexpr auto applicationOrganizationName = "AdvancedSettings-Team";
 constexpr auto applicationName = "OpenVRAdvancedSettings";
 constexpr const char* applicationKey = "matzman666.AdvancedSettings";
 constexpr const char* applicationDisplayName = "Advanced Settings";

--- a/src/package_files/default_action_manifests/vive_defaults.json
+++ b/src/package_files/default_action_manifests/vive_defaults.json
@@ -1,6 +1,6 @@
 {
    "alias_info" : {},
-   "app_key" : "matzman666.advancedsettings",
+   "app_key" : "OVRAS-Team.advancedsettings",
    "bindings" : {
       "/actions/main" : {
          "sources" : []

--- a/src/package_files/manifest.vrmanifest
+++ b/src/package_files/manifest.vrmanifest
@@ -1,7 +1,7 @@
 {
 	"source" : "builtin",
 	"applications": [{
-		"app_key": "matzman666.AdvancedSettings",
+		"app_key": "OVRAS-Team.AdvancedSettings",
 		"launch_type": "binary",
 		"binary_path_windows": "AdvancedSettings.exe",
 		"is_dashboard_overlay": true,

--- a/src/res/qml/ChaperonePage.qml
+++ b/src/res/qml/ChaperonePage.qml
@@ -2,7 +2,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "." // QTBUG-34418, singletons require explicit import to load qmldir file
 import "common"
 

--- a/src/res/qml/ChaperoneWarningsPage.qml
+++ b/src/res/qml/ChaperoneWarningsPage.qml
@@ -2,7 +2,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "." // QTBUG-34418, singletons require explicit import to load qmldir file
 import "common"
 

--- a/src/res/qml/FixFloorPage.qml
+++ b/src/res/qml/FixFloorPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 

--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 

--- a/src/res/qml/RevivePage.qml
+++ b/src/res/qml/RevivePage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 MyStackViewPage {

--- a/src/res/qml/RootPage.qml
+++ b/src/res/qml/RootPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "." // QTBUG-34418, singletons require explicit import to load qmldir file
 import "common"
 import "utilities_page"

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 MyStackViewPage {

--- a/src/res/qml/StatisticsPage.qml
+++ b/src/res/qml/StatisticsPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 

--- a/src/res/qml/SteamVRPage.qml
+++ b/src/res/qml/SteamVRPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "common"
 
 MyStackViewPage {

--- a/src/res/qml/audio_page/AudioPage.qml
+++ b/src/res/qml/audio_page/AudioPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../common"
 import "device_selector"
 import "proximity"

--- a/src/res/qml/audio_page/device_selector/AudioDeviceSelector.qml
+++ b/src/res/qml/audio_page/device_selector/AudioDeviceSelector.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 RowLayout {

--- a/src/res/qml/audio_page/device_selector/MicDeviceSelector.qml
+++ b/src/res/qml/audio_page/device_selector/MicDeviceSelector.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 RowLayout {

--- a/src/res/qml/audio_page/device_selector/MicVolumeSlider.qml
+++ b/src/res/qml/audio_page/device_selector/MicVolumeSlider.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 ColumnLayout {

--- a/src/res/qml/audio_page/device_selector/MirrorDeviceSelector.qml
+++ b/src/res/qml/audio_page/device_selector/MirrorDeviceSelector.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 RowLayout {

--- a/src/res/qml/audio_page/device_selector/MirrorVolumeSlider.qml
+++ b/src/res/qml/audio_page/device_selector/MirrorVolumeSlider.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 import "."
 

--- a/src/res/qml/audio_page/dialog_boxes/AudioDeleteProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/AudioDeleteProfileDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyDialogOkCancelPopup {

--- a/src/res/qml/audio_page/dialog_boxes/AudioMessageDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/AudioMessageDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyDialogOkPopup {

--- a/src/res/qml/audio_page/dialog_boxes/AudioNewProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/AudioNewProfileDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyDialogOkCancelPopup {

--- a/src/res/qml/audio_page/dialog_boxes/PttDeleteProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/PttDeleteProfileDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyDialogOkCancelPopup {

--- a/src/res/qml/audio_page/dialog_boxes/PttNewProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/PttNewProfileDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyDialogOkCancelPopup {

--- a/src/res/qml/audio_page/profiles/ProfileButtons.qml
+++ b/src/res/qml/audio_page/profiles/ProfileButtons.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 import "../dialog_boxes"
 

--- a/src/res/qml/audio_page/proximity/ProximityToggle.qml
+++ b/src/res/qml/audio_page/proximity/ProximityToggle.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyToggleButton {

--- a/src/res/qml/audio_page/push_to_talk/PttButtons.qml
+++ b/src/res/qml/audio_page/push_to_talk/PttButtons.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 ColumnLayout {

--- a/src/res/qml/common/LineSeparator.qml
+++ b/src/res/qml/common/LineSeparator.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 // Necessary for the project specific Components.
 import ".."
 

--- a/src/res/qml/common/MyResources.qml
+++ b/src/res/qml/common/MyResources.qml
@@ -1,7 +1,7 @@
 pragma Singleton
 import QtQuick 2.7
 import QtMultimedia 5.6
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 
 QtObject {
 	function playActivationSound() {

--- a/src/res/qml/common/MyTextField.qml
+++ b/src/res/qml/common/MyTextField.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 
 TextField {
 	property int keyBoardUID: 0

--- a/src/res/qml/motion_page/MotionPage.qml
+++ b/src/res/qml/motion_page/MotionPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../common"
 import "universe_drag"
 import "universe_turn"

--- a/src/res/qml/motion_page/universe_drag/UniverseDragGroupBox.qml
+++ b/src/res/qml/motion_page/universe_drag/UniverseDragGroupBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/res/qml/motion_page/universe_turn/UniverseTurnGroupBox.qml
+++ b/src/res/qml/motion_page/universe_turn/UniverseTurnGroupBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/res/qml/utilities_page/UtilitiesPage.qml
+++ b/src/res/qml/utilities_page/UtilitiesPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "media_keys"
 import "alarm_clock"
 import "desktop_size"

--- a/src/res/qml/utilities_page/alarm_clock/AlarmGroupBox.qml
+++ b/src/res/qml/utilities_page/alarm_clock/AlarmGroupBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/res/qml/utilities_page/desktop_size/SteamDesktopGroupBox.qml
+++ b/src/res/qml/utilities_page/desktop_size/SteamDesktopGroupBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/res/qml/utilities_page/keyboard_utils/KeyboardGroupBox.qml
+++ b/src/res/qml/utilities_page/keyboard_utils/KeyboardGroupBox.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/res/qml/utilities_page/media_keys/MediaButton.qml
+++ b/src/res/qml/utilities_page/media_keys/MediaButton.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 MyPushButton2 {

--- a/src/res/qml/utilities_page/media_keys/MediaControllerKeys.qml
+++ b/src/res/qml/utilities_page/media_keys/MediaControllerKeys.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
-import matzman666.advsettings 1.0
+import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -64,7 +64,7 @@ void AudioTabController::initStage2( OverlayController* var_parent,
     this->widget = var_widget;
 
     std::string notifKey
-        = std::string( OverlayController::applicationKey ) + ".pptnotification";
+        = std::string( application_strings::applicationKey ) + ".pptnotification";
 
     vr::VROverlayError overlayError = vr::VROverlay()->CreateOverlay(
         notifKey.c_str(), notifKey.c_str(), &m_ulNotificationOverlayHandle );

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -63,8 +63,8 @@ void AudioTabController::initStage2( OverlayController* var_parent,
     this->parent = var_parent;
     this->widget = var_widget;
 
-    std::string notifKey
-        = std::string( application_strings::applicationKey ) + ".pptnotification";
+    std::string notifKey = std::string( application_strings::applicationKey )
+                           + ".pptnotification";
 
     vr::VROverlayError overlayError = vr::VROverlay()->CreateOverlay(
         notifKey.c_str(), notifKey.c_str(), &m_ulNotificationOverlayHandle );

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -540,8 +540,7 @@ void ChaperoneTabController::handleChaperoneWarnings( float distance )
         {
             if ( !vr::VROverlay()->IsDashboardVisible() )
             {
-                vr::VROverlay()->ShowDashboard(
-                    OverlayController::applicationKey );
+                vr::VROverlay()->ShowDashboard( application_strings::applicationKey );
             }
             m_chaperoneShowDashboardActive = true;
         }

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -540,7 +540,8 @@ void ChaperoneTabController::handleChaperoneWarnings( float distance )
         {
             if ( !vr::VROverlay()->IsDashboardVisible() )
             {
-                vr::VROverlay()->ShowDashboard( application_strings::applicationKey );
+                vr::VROverlay()->ShowDashboard(
+                    application_strings::applicationKey );
             }
             m_chaperoneShowDashboardActive = true;
         }

--- a/src/tabcontrollers/SettingsTabController.cpp
+++ b/src/tabcontrollers/SettingsTabController.cpp
@@ -8,7 +8,7 @@ namespace advsettings
 void SettingsTabController::initStage1()
 {
     m_autoStartEnabled = vr::VRApplications()->GetApplicationAutoLaunch(
-        OverlayController::applicationKey );
+        application_strings::applicationKey );
     auto settings = OverlayController::appSettings();
     settings->beginGroup( "applicationSettings" );
     auto value = settings->value( "forceRevivePage", m_forceRevivePage );
@@ -33,7 +33,7 @@ void SettingsTabController::eventLoopTick()
         if ( parent->isDashboardVisible() )
         {
             setAutoStartEnabled( vr::VRApplications()->GetApplicationAutoLaunch(
-                OverlayController::applicationKey ) );
+                application_strings::applicationKey ) );
         }
         settingsUpdateCounter = 0;
     }
@@ -54,7 +54,7 @@ void SettingsTabController::setAutoStartEnabled( bool value, bool notify )
     {
         m_autoStartEnabled = value;
         auto apperror = vr::VRApplications()->SetApplicationAutoLaunch(
-            OverlayController::applicationKey, m_autoStartEnabled );
+            application_strings::applicationKey, m_autoStartEnabled );
         if ( apperror != vr::VRApplicationError_None )
         {
             LOG( ERROR ) << "Could not set auto start: "

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -259,8 +259,8 @@ QString getBatteryIconPath( int batteryState )
 vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index )
 {
     vr::VROverlayHandle_t handle = vr::k_ulOverlayHandleInvalid;
-    std::string batteryKey = std::string( application_strings::applicationKey ) + ".battery."
-                             + std::to_string( index );
+    std::string batteryKey = std::string( application_strings::applicationKey )
+                             + ".battery." + std::to_string( index );
     vr::VROverlayError overlayError = vr::VROverlay()->CreateOverlay(
         batteryKey.c_str(), batteryKey.c_str(), &handle );
     if ( overlayError == vr::VROverlayError_None )

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -259,8 +259,8 @@ QString getBatteryIconPath( int batteryState )
 vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index )
 {
     vr::VROverlayHandle_t handle = vr::k_ulOverlayHandleInvalid;
-    std::string batteryKey = std::string( OverlayController::applicationKey )
-                             + ".battery." + std::to_string( index );
+    std::string batteryKey = std::string( application_strings::applicationKey ) + ".battery."
+                             + std::to_string( index );
     vr::VROverlayError overlayError = vr::VROverlay()->CreateOverlay(
         batteryKey.c_str(), batteryKey.c_str(), &handle );
     if ( overlayError == vr::VROverlayError_None )

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -274,7 +274,7 @@ void setUpLogging()
 
     const auto appDataLocation
         = std::string( "/" ) + application_strings::applicationOrganizationName
-          + "/" + application_strings::applicationName;
+          + "/";
     const auto logFilePath = QDir( QStandardPaths::writableLocation(
                                        QStandardPaths::AppDataLocation )
                                    + appDataLocation.c_str() )

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -102,7 +102,7 @@ namespace manifest
 void enableApplicationAutostart()
 {
     const auto app_error = vr::VRApplications()->SetApplicationAutoLaunch(
-        advsettings::OverlayController::applicationKey, true );
+        application_strings::applicationKey, true );
     if ( app_error != vr::VRApplicationError_None )
     {
         throw std::runtime_error(
@@ -119,7 +119,7 @@ void enableApplicationAutostart()
 void installApplicationManifest( const QString manifestPath )
 {
     if ( vr::VRApplications()->IsApplicationInstalled(
-             advsettings::OverlayController::applicationKey ) )
+             application_strings::applicationKey ) )
     {
         // We don't want to disrupt applications that are already installed.
         return;
@@ -148,7 +148,7 @@ void removeApplicationManifest( const QString manifestPath )
     }
 
     if ( vr::VRApplications()->IsApplicationInstalled(
-             advsettings::OverlayController::applicationKey ) )
+             application_strings::applicationKey ) )
     {
         vr::VRApplications()->RemoveApplicationManifest(
             QDir::toNativeSeparators( manifestPath ).toStdString().c_str() );
@@ -166,14 +166,14 @@ void reinstallApplicationManifest( const QString manifestPath )
     }
 
     if ( vr::VRApplications()->IsApplicationInstalled(
-             advsettings::OverlayController::applicationKey ) )
+             application_strings::applicationKey ) )
     {
         // String size was arbitrarily chosen by original author.
         constexpr auto kStringSize = 1024;
         char oldApplicationWorkingDir[kStringSize] = { 0 };
         auto app_error = vr::VRApplicationError_None;
         vr::VRApplications()->GetApplicationPropertyString(
-            advsettings::OverlayController::applicationKey,
+            application_strings::applicationKey,
             vr::VRApplicationProperty_WorkingDirectory_String,
             oldApplicationWorkingDir,
             kStringSize,
@@ -293,7 +293,6 @@ void setUpLogging()
     el::Loggers::reconfigureAllLoggers( conf );
 
     LOG( INFO ) << "Application started (Version "
-                << advsettings::OverlayController::applicationVersionString
-                << ")";
+                << application_strings::applicationVersionString << ")";
     LOG( INFO ) << "Log File: " << logFilePath;
 }

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -256,8 +256,8 @@ void setUpLogging()
     conf.set( Level::Global,
               ConfigurationType::Format,
               "[%level] %datetime{%Y-%M-%d %H:%m:%s}: %msg" );
-    conf.set(
-        Level::Global, ConfigurationType::Filename, "AdvancedSettings.log" );
+    constexpr auto logFileName = "AdvancedSettings.log";
+    conf.set( Level::Global, ConfigurationType::Filename, logFileName );
 
     constexpr auto confEnabled = "true";
     conf.set( Level::Global, ConfigurationType::Enabled, confEnabled );
@@ -278,7 +278,7 @@ void setUpLogging()
     const auto logFilePath = QDir( QStandardPaths::writableLocation(
                                        QStandardPaths::AppDataLocation )
                                    + appDataLocation.c_str() )
-                                 .absoluteFilePath( "AdvancedSettings.log" );
+                                 .absoluteFilePath( logFileName );
     conf.set( el::Level::Global,
               el::ConfigurationType::Filename,
               QDir::toNativeSeparators( logFilePath ).toStdString() );

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -272,18 +272,13 @@ void setUpLogging()
     conf.set( Level::Trace, ConfigurationType::Enabled, confDisabled );
     conf.set( Level::Debug, ConfigurationType::Enabled, confDisabled );
 
-    // This places the log file in
-    // Roaming/AppData/matzman666/OpenVRAdvancedSettings/AdvancedSettings.log.
-    // The log file placement has been broken since at least git tag "v2.7".
-    // It was being placed in the working dir of the executable.
-    // The change hasn't been documented anywhere, so it is likely that it was
-    // unintentional. This fixes the probable regression until a new path is
-    // decided on.
-    constexpr auto appDataFolders = "/matzman666/OpenVRAdvancedSettings";
-    const QString logFilePath = QDir( QStandardPaths::writableLocation(
-                                          QStandardPaths::AppDataLocation )
-                                      + appDataFolders )
-                                    .absoluteFilePath( "AdvancedSettings.log" );
+    const auto appDataLocation
+        = std::string( "/" ) + application_strings::applicationOrganizationName
+          + "/" + application_strings::applicationName;
+    const auto logFilePath = QDir( QStandardPaths::writableLocation(
+                                       QStandardPaths::AppDataLocation )
+                                   + appDataLocation.c_str() )
+                                 .absoluteFilePath( "AdvancedSettings.log" );
     conf.set( el::Level::Global,
               el::ConfigurationType::Filename,
               QDir::toNativeSeparators( logFilePath ).toStdString() );


### PR DESCRIPTION
## This PR:
* Fixes #66.
* Renames the singleton imports.
* Renames the SteamVR application key.

## Noteworthy Items:
* The SteamVR application key has been changed. This will make sure that `3.0.0` is not mistakenly using `2.8.0` settings and configurations in SteamVR. Since SteamVR caches and saves arbitrary values, this might prevent weird bugs from occuring for end users.
* The new location for both settings and logging is `%APPDATA%\AdvancedSettings-Team\`. This also means that all settings are wiped unless they're copied over.