### PR TITLE
Move audio profile popup to center of screen

### DIFF
--- a/src/res/qml/audio_page/dialog_boxes/AudioNewProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/AudioNewProfileDialog.qml
@@ -9,6 +9,8 @@ MyDialogOkCancelPopup {
     dialogTitle: "Create New Audio Profile"
     dialogWidth: 600
     dialogHeight: 300
+    y: -300
+    x: 100
     dialogContentItem: ColumnLayout {
         RowLayout {
             Layout.topMargin: 16


### PR DESCRIPTION
## This PR:
* Fixes #105.

## Technical Considerations
* The offset is applied with specific X/Y coordinates instead of changing the parent component since this keeps the associated elements contained. 