### PR TITLE
Create DigitalAction and AnalogAction types to replace the Action

### DIFF
--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -39,7 +39,7 @@ HEADERS += src/overlaycontroller.h \
     src/openvr/ivrinput_action.h \
     src/openvr/ivrinput_manifest.h \
     src/openvr/ivrinput_action_set.h \
-	src/openvr/ivrinput_input_source.h \
+    src/openvr/ivrinput_input_source.h \
     src/openvr/ivrinput.h \
     src/utils/setup.h
 

--- a/src/openvr/ivrinput.cpp
+++ b/src/openvr/ivrinput.cpp
@@ -1,4 +1,5 @@
 #include "ivrinput.h"
+#include "ivrinput_action.h"
 #include <openvr.h>
 #include <iostream>
 #include <QStandardPaths>
@@ -17,20 +18,8 @@ it isn't the struct will still need to be created somewhere, and with move
 semantics it almost doesn't matter if the struct is created in the calling
 function and passed as reference, or created in this function.
 */
-vr::InputDigitalActionData_t getDigitalActionData( Action& action )
+vr::InputDigitalActionData_t getDigitalActionData( DigitalAction& action )
 {
-    if ( action.type() != ActionType::Digital )
-    {
-        LOG( ERROR )
-            << "Action was passed to IVRInput getDigitalActionData without "
-               "being a digital type. Action: "
-            << action.name();
-
-        throw std::runtime_error(
-            "Action was passed to IVRInput getDigitalActionData without being "
-            "a digital type. See log for details." );
-    }
-
     vr::InputDigitalActionData_t handleData = {};
 
     const auto error = vr::VRInput()->GetDigitalActionData(
@@ -59,20 +48,8 @@ it isn't the struct will still need to be created somewhere, and with move
 semantics it almost doesn't matter if the struct is created in the calling
 function and passed as reference, or created in this function.
 */
-vr::InputAnalogActionData_t getAnalogActionData( Action& action )
+vr::InputAnalogActionData_t getAnalogActionData( AnalogAction& action )
 {
-    if ( action.type() != ActionType::Analog )
-    {
-        LOG( ERROR )
-            << "Action was passed to IVRInput getAnalogActionData without "
-               "being an analog type. Action: "
-            << action.name();
-
-        throw std::runtime_error(
-            "Action was passed to IVRInput getAnalogActionData without being "
-            "an analog type. See log for details." );
-    }
-
     vr::InputAnalogActionData_t handleData = {};
 
     const auto error
@@ -96,7 +73,7 @@ This will only return true the first time the button is released. It is
 necessary to release the button and the push it again in order for this function
 to return true again.
 */
-bool isDigitalActionActivatedOnce( Action& action )
+bool isDigitalActionActivatedOnce( DigitalAction& action )
 {
     const auto handleData = getDigitalActionData( action );
 
@@ -107,7 +84,7 @@ bool isDigitalActionActivatedOnce( Action& action )
 Gets the action state of an Action.
 This will continually return true while the button is held down.
 */
-bool isDigitalActionActivatedConstant( Action& action )
+bool isDigitalActionActivatedConstant( DigitalAction& action )
 {
     const auto handleData = getDigitalActionData( action );
 
@@ -124,54 +101,37 @@ mystically not working.
 */
 SteamIVRInput::SteamIVRInput()
     : m_manifest(), m_mainSet( action_sets::k_setMain ),
-      m_nextTrack( action_keys::k_actionNextTrack, ActionType::Digital ),
-      m_previousTrack( action_keys::k_actionPreviousTrack,
-                       ActionType::Digital ),
-      m_pausePlayTrack( action_keys::k_actionPausePlayTrack,
-                        ActionType::Digital ),
-      m_stopTrack( action_keys::k_actionStopTrack, ActionType::Digital ),
-      m_leftHandSpaceTurn( action_keys::k_actionLeftHandSpaceTurn,
-                           ActionType::Digital ),
-      m_rightHandSpaceTurn( action_keys::k_actionRightHandSpaceTurn,
-                            ActionType::Digital ),
-      m_leftHandSpaceDrag( action_keys::k_actionLeftHandSpaceDrag,
-                           ActionType::Digital ),
-      m_rightHandSpaceDrag( action_keys::k_actionRightHandSpaceDrag,
-                            ActionType::Digital ),
+      m_nextTrack( action_keys::k_actionNextTrack ),
+      m_previousTrack( action_keys::k_actionPreviousTrack ),
+      m_pausePlayTrack( action_keys::k_actionPausePlayTrack ),
+      m_stopTrack( action_keys::k_actionStopTrack ),
+      m_leftHandSpaceTurn( action_keys::k_actionLeftHandSpaceTurn ),
+      m_rightHandSpaceTurn( action_keys::k_actionRightHandSpaceTurn ),
+      m_leftHandSpaceDrag( action_keys::k_actionLeftHandSpaceDrag ),
+      m_rightHandSpaceDrag( action_keys::k_actionRightHandSpaceDrag ),
       m_optionalOverrideLeftHandSpaceTurn(
-          action_keys::k_actionOptionalOverrideLeftHandSpaceTurn,
-          ActionType::Digital ),
+          action_keys::k_actionOptionalOverrideLeftHandSpaceTurn ),
       m_optionalOverrideRightHandSpaceTurn(
-          action_keys::k_actionOptionalOverrideRightHandSpaceTurn,
-          ActionType::Digital ),
+          action_keys::k_actionOptionalOverrideRightHandSpaceTurn ),
       m_optionalOverrideLeftHandSpaceDrag(
-          action_keys::k_actionOptionalOverrideLeftHandSpaceDrag,
-          ActionType::Digital ),
+          action_keys::k_actionOptionalOverrideLeftHandSpaceDrag ),
       m_optionalOverrideRightHandSpaceDrag(
-          action_keys::k_actionOptionalOverrideRightHandSpaceDrag,
-          ActionType::Digital ),
+          action_keys::k_actionOptionalOverrideRightHandSpaceDrag ),
       m_swapSpaceDragToLeftHandOverride(
-          action_keys::k_actionSwapSpaceDragToLeftHandOverride,
-          ActionType::Digital ),
+          action_keys::k_actionSwapSpaceDragToLeftHandOverride ),
       m_swapSpaceDragToRightHandOverride(
-          action_keys::k_actionSwapSpaceDragToRightHandOverride,
-          ActionType::Digital ),
-      m_gravityToggle( action_keys::k_actionGravityToggle,
-                       ActionType::Digital ),
-      m_heightToggle( action_keys::k_actionHeightToggle, ActionType::Digital ),
-      m_resetOffsets( action_keys::k_actionResetOffsets, ActionType::Digital ),
-      m_snapTurnLeft( action_keys::k_actionSnapTurnLeft, ActionType::Digital ),
-      m_snapTurnRight( action_keys::k_actionSnapTurnRight,
-                       ActionType::Digital ),
-      m_xAxisLockToggle( action_keys::k_actionXAxisLockToggle,
-                         ActionType::Digital ),
-      m_yAxisLockToggle( action_keys::k_actionYAxisLockToggle,
-                         ActionType::Digital ),
-      m_zAxisLockToggle( action_keys::k_actionZAxisLockToggle,
-                         ActionType::Digital ),
-      m_pushToTalk( action_keys::k_actionPushToTalk, ActionType::Digital ),
-      m_leftHaptic( action_keys::k_actionHapticsLeft, ActionType::Haptic ),
-      m_rightHaptic( action_keys::k_actionHapticsRight, ActionType::Haptic ),
+          action_keys::k_actionSwapSpaceDragToRightHandOverride ),
+      m_gravityToggle( action_keys::k_actionGravityToggle ),
+      m_heightToggle( action_keys::k_actionHeightToggle ),
+      m_resetOffsets( action_keys::k_actionResetOffsets ),
+      m_snapTurnLeft( action_keys::k_actionSnapTurnLeft ),
+      m_snapTurnRight( action_keys::k_actionSnapTurnRight ),
+      m_xAxisLockToggle( action_keys::k_actionXAxisLockToggle ),
+      m_yAxisLockToggle( action_keys::k_actionYAxisLockToggle ),
+      m_zAxisLockToggle( action_keys::k_actionZAxisLockToggle ),
+      m_pushToTalk( action_keys::k_actionPushToTalk ),
+      m_leftHaptic( action_keys::k_actionHapticsLeft ),
+      m_rightHaptic( action_keys::k_actionHapticsRight ),
       m_leftHand( input_keys::k_inputSourceLeft ),
       m_rightHand( input_keys::k_inputSourceRight )
 {

--- a/src/openvr/ivrinput.h
+++ b/src/openvr/ivrinput.h
@@ -94,37 +94,37 @@ private:
     vr::VRActiveActionSet_t m_activeActionSet = {};
 
     // Music player bindings
-    Action m_nextTrack;
-    Action m_previousTrack;
-    Action m_pausePlayTrack;
-    Action m_stopTrack;
+    DigitalAction m_nextTrack;
+    DigitalAction m_previousTrack;
+    DigitalAction m_pausePlayTrack;
+    DigitalAction m_stopTrack;
 
     // Space bindings
-    Action m_leftHandSpaceTurn;
-    Action m_rightHandSpaceTurn;
-    Action m_leftHandSpaceDrag;
-    Action m_rightHandSpaceDrag;
-    Action m_optionalOverrideLeftHandSpaceTurn;
-    Action m_optionalOverrideRightHandSpaceTurn;
-    Action m_optionalOverrideLeftHandSpaceDrag;
-    Action m_optionalOverrideRightHandSpaceDrag;
-    Action m_swapSpaceDragToLeftHandOverride;
-    Action m_swapSpaceDragToRightHandOverride;
-    Action m_gravityToggle;
-    Action m_heightToggle;
-    Action m_resetOffsets;
-    Action m_snapTurnLeft;
-    Action m_snapTurnRight;
-    Action m_xAxisLockToggle;
-    Action m_yAxisLockToggle;
-    Action m_zAxisLockToggle;
+    DigitalAction m_leftHandSpaceTurn;
+    DigitalAction m_rightHandSpaceTurn;
+    DigitalAction m_leftHandSpaceDrag;
+    DigitalAction m_rightHandSpaceDrag;
+    DigitalAction m_optionalOverrideLeftHandSpaceTurn;
+    DigitalAction m_optionalOverrideRightHandSpaceTurn;
+    DigitalAction m_optionalOverrideLeftHandSpaceDrag;
+    DigitalAction m_optionalOverrideRightHandSpaceDrag;
+    DigitalAction m_swapSpaceDragToLeftHandOverride;
+    DigitalAction m_swapSpaceDragToRightHandOverride;
+    DigitalAction m_gravityToggle;
+    DigitalAction m_heightToggle;
+    DigitalAction m_resetOffsets;
+    DigitalAction m_snapTurnLeft;
+    DigitalAction m_snapTurnRight;
+    DigitalAction m_xAxisLockToggle;
+    DigitalAction m_yAxisLockToggle;
+    DigitalAction m_zAxisLockToggle;
 
     // Push To Talk
-    Action m_pushToTalk;
+    DigitalAction m_pushToTalk;
 
     // haptic bindings
-    Action m_leftHaptic;
-    Action m_rightHaptic;
+    DigitalAction m_leftHaptic;
+    DigitalAction m_rightHaptic;
 
     // input sources
     InputSource m_leftHand;

--- a/src/openvr/ivrinput_action.h
+++ b/src/openvr/ivrinput_action.h
@@ -24,8 +24,7 @@ with a name similar to that of the one in the actions manifest.
 class Action
 {
 public:
-    Action( const char* const actionName, const ActionType type )
-        : m_name( actionName ), m_type( type )
+    Action( const char* const actionName ) : m_name( actionName )
     {
         auto error = vr::VRInput()->GetActionHandle( actionName, &m_handle );
 
@@ -49,19 +48,22 @@ public:
     {
         return m_name;
     }
-    /*!
-    The type of the action. Used for runtime checking that the wrong functions
-    aren't called.
-    */
-    ActionType type() const noexcept
-    {
-        return m_type;
-    }
 
 private:
     vr::VRActionHandle_t m_handle = 0;
     const std::string m_name;
-    const ActionType m_type = ActionType::Undefined;
+};
+
+class DigitalAction : public Action
+{
+public:
+    DigitalAction( const char* const actionName ) : Action( actionName ) {}
+};
+
+class AnalogAction : public Action
+{
+public:
+    AnalogAction( const char* const actionName ) : Action( actionName ) {}
 };
 
 } // namespace input


### PR DESCRIPTION
This errors at compile time if the wrong action is being used instead of at runtime.

This is a part of #111.