### PR TITLE
Implement gravity options and ui

### DIFF
--- a/build_scripts/qt/resources.pri
+++ b/build_scripts/qt/resources.pri
@@ -22,8 +22,8 @@ DISTFILES += \
     src/res/qml/motion_page/gravity/* \
     src/res/qml/motion_page/height_toggle/* \
     src/res/qml/motion_page/snap_turn/* \
-    src/res/qml/motion_page/universe_drag/* \
-    src/res/qml/motion_page/universe_turn/* \
+    src/res/qml/motion_page/space_drag/* \
+    src/res/qml/motion_page/space_turn/* \
     src/res/qml/RevivePage.qml \
     src/res/qml/RootPage.qml \
     src/res/qml/SettingsPage.qml \

--- a/src/openvr/ivrinput.cpp
+++ b/src/openvr/ivrinput.cpp
@@ -122,6 +122,7 @@ SteamIVRInput::SteamIVRInput()
       m_swapSpaceDragToRightHandOverride(
           action_keys::k_actionSwapSpaceDragToRightHandOverride ),
       m_gravityToggle( action_keys::k_actionGravityToggle ),
+      m_gravityReverse( action_keys::k_actionGravityReverse ),
       m_heightToggle( action_keys::k_actionHeightToggle ),
       m_resetOffsets( action_keys::k_actionResetOffsets ),
       m_snapTurnLeft( action_keys::k_actionSnapTurnLeft ),
@@ -241,6 +242,11 @@ bool SteamIVRInput::swapSpaceDragToRightHandOverride()
 bool SteamIVRInput::gravityToggle()
 {
     return isDigitalActionActivatedOnce( m_gravityToggle );
+}
+
+bool SteamIVRInput::gravityReverse()
+{
+    return isDigitalActionActivatedConstant( m_gravityReverse );
 }
 
 bool SteamIVRInput::heightToggle()

--- a/src/openvr/ivrinput.h
+++ b/src/openvr/ivrinput.h
@@ -53,6 +53,7 @@ public:
     bool swapSpaceDragToLeftHandOverride();
     bool swapSpaceDragToRightHandOverride();
     bool gravityToggle();
+    bool gravityReverse();
     bool heightToggle();
     bool resetOffsets();
     bool snapTurnLeft();
@@ -111,6 +112,7 @@ private:
     DigitalAction m_swapSpaceDragToLeftHandOverride;
     DigitalAction m_swapSpaceDragToRightHandOverride;
     DigitalAction m_gravityToggle;
+    DigitalAction m_gravityReverse;
     DigitalAction m_heightToggle;
     DigitalAction m_resetOffsets;
     DigitalAction m_snapTurnLeft;
@@ -164,6 +166,7 @@ namespace action_keys
     constexpr auto k_actionSwapSpaceDragToRightHandOverride
         = "/actions/main/in/SwapSpaceDragToRightHandOverride";
     constexpr auto k_actionGravityToggle = "/actions/main/in/GravityToggle";
+    constexpr auto k_actionGravityReverse = "/actions/main/in/GravityReverse";
     constexpr auto k_actionHeightToggle = "/actions/main/in/HeightToggle";
     constexpr auto k_actionResetOffsets = "/actions/main/in/ResetOffsets";
     constexpr auto k_actionSnapTurnLeft = "/actions/main/in/SnapTurnLeft";

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -496,7 +496,7 @@ void OverlayController::processMediaKeyBindings()
     }
 }
 
-void OverlayController::processRoomBindings()
+void OverlayController::processMotionBindings()
 {
     // Execution order for moveCenterTabController actions is important. Don't
     // reorder these. Override actions must always come after normal because
@@ -511,6 +511,8 @@ void OverlayController::processRoomBindings()
     m_moveCenterTabController.rightHandSpaceTurn(
         m_actions.rightHandSpaceTurn() );
     m_moveCenterTabController.gravityToggleAction( m_actions.gravityToggle() );
+    m_moveCenterTabController.gravityReverseAction(
+        m_actions.gravityReverse() );
     m_moveCenterTabController.heightToggleAction( m_actions.heightToggle() );
     m_moveCenterTabController.resetOffsets( m_actions.resetOffsets() );
     m_moveCenterTabController.snapTurnLeft( m_actions.snapTurnLeft() );
@@ -563,7 +565,7 @@ void OverlayController::processInputBindings()
 {
     processMediaKeyBindings();
 
-    processRoomBindings();
+    processMotionBindings();
 
     processPushToTalkBindings();
 }

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -126,7 +126,7 @@ private:
     QPoint getMousePositionForEvent( vr::VREvent_Mouse_t mouse );
     void processInputBindings();
     void processMediaKeyBindings();
-    void processRoomBindings();
+    void processMotionBindings();
     void processPushToTalkBindings();
 
 public:

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -103,6 +103,11 @@
       "type": "boolean"
     },
     {
+      "name": "/actions/main/in/GravityReverse",
+      "requirement": "optional",
+      "type": "boolean"
+    },
+    {
       "name": "/actions/main/in/HeightToggle",
       "requirement": "optional",
       "type": "boolean"
@@ -172,6 +177,7 @@
         "/actions/main/in/SwapSpaceDragToLeftHandOverride" : "Swap Active Space Drag to Left Hand (Override)",
         "/actions/main/in/SwapSpaceDragToRightHandOverride" : "Swap Active Space Drag to Right Hand (Override)",
         "/actions/main/in/GravityToggle" : "Gravity Toggle",
+        "/actions/main/in/GravityReverse" : "Gravity Reverse",
         "/actions/main/in/HeightToggle" : "Height Toggle",
         "/actions/main/in/ResetOffsets" : "Reset Offsets",
         "/actions/main/in/SnapTurnLeft" : "Snap-Turn Left",

--- a/src/res/qml/motion_page/MotionPage.qml
+++ b/src/res/qml/motion_page/MotionPage.qml
@@ -3,9 +3,10 @@ import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import ovras.advsettings 1.0
 import "../common"
-import "universe_drag"
-import "universe_turn"
+import "space_drag"
+import "space_turn"
 import "height_toggle"
+import "gravity"
 
 MyStackViewPage {
     headerText: "Motion Settings"
@@ -13,11 +14,13 @@ MyStackViewPage {
     content: ColumnLayout {
         spacing: 18
 
-        UniverseDragGroupBox { id: universeDragGroupBox }
+        SpaceDragGroupBox { id: spaceDragGroupBox }
 
-        UniverseTurnGroupBox { id: universeTurnGroupBox }
+        SpaceTurnGroupBox { id: spaceTurnGroupBox }
 
         HeightToggleGroupBox { id: heightToggleGroupBox }
+
+        GravityGroupBox { id: gravityGroupBox }
 
         Item {
             Layout.fillHeight: true

--- a/src/res/qml/motion_page/gravity/GravityGroupBox.qml
+++ b/src/res/qml/motion_page/gravity/GravityGroupBox.qml
@@ -1,0 +1,172 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import ovras.advsettings 1.0
+import "../../common"
+
+GroupBox {
+    id: gravityGroupBox
+    Layout.fillWidth: true
+
+    label: MyText {
+        leftPadding: 10
+        text: "Gravity Settings"
+        bottomPadding: -10
+    }
+    background: Rectangle {
+        color: "transparent"
+        border.color: "#ffffff"
+        radius: 8
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        Rectangle {
+            color: "#ffffff"
+            height: 1
+            Layout.fillWidth: true
+            Layout.bottomMargin: 5
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            MyToggleButton {
+                id: gravityToggleButton
+                text: "On"
+                onCheckedChanged: {
+                    MoveCenterTabController.gravityActive = this.checked
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            MyText {
+                text: "Gravity Strength (+ is down):"
+                horizontalAlignment: Text.AlignRight
+                Layout.rightMargin: 10
+            }
+
+            MyTextField {
+                id: gravityStrengthText
+                text: "9.80"
+                keyBoardUID: 152
+                Layout.preferredWidth: 120
+                Layout.leftMargin: 10
+                Layout.rightMargin: 10
+                horizontalAlignment: Text.AlignHCenter
+                function onInputEvent(input) {
+                    var val = parseFloat(input)
+                    if (!isNaN(val)) {
+                        MoveCenterTabController.gravityStrength = val.toFixed(2)
+                        text = MoveCenterTabController.gravityStrength.toFixed(2)
+                    } else {
+                        text = MoveCenterTabController.gravityStrengtht.toFixed(2)
+                    }
+                }
+            }
+
+            MyPushButton {
+                id: gravityMoonButton
+                Layout.preferredWidth: 110
+                text:"Moon"
+                onClicked: {
+                    MoveCenterTabController.gravityStrength = 1.62
+                }
+           }
+            MyPushButton {
+                id: gravityMarsButton
+                Layout.preferredWidth: 110
+                text:"Mars"
+                onClicked: {
+                    MoveCenterTabController.gravityStrength = 3.71
+                }
+           }
+            MyPushButton {
+                id: gravityEarthButton
+                Layout.preferredWidth: 110
+                text:"Earth"
+                onClicked: {
+                    MoveCenterTabController.gravityStrength = 9.80
+                }
+           }
+            MyPushButton {
+                id: gravityJupiterButton
+                Layout.preferredWidth: 110
+                text:"Jupiter"
+                onClicked: {
+                    MoveCenterTabController.gravityStrength = 24.79
+                }
+           }
+        }
+        RowLayout {
+            Layout.fillWidth: true
+
+            MyToggleButton {
+                id: momentumToggleButton
+                text: "Save Momentum"
+                onCheckedChanged: {
+                    MoveCenterTabController.momentumSave = this.checked
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            MyText {
+                text: "Fling Strength"
+                horizontalAlignment: Text.AlignRight
+                Layout.rightMargin: 10
+            }
+
+            MyTextField {
+                id: flingStrengthText
+                text: "1.00"
+                keyBoardUID: 153
+                Layout.preferredWidth: 120
+                Layout.leftMargin: 10
+                Layout.rightMargin: 10
+                horizontalAlignment: Text.AlignHCenter
+                function onInputEvent(input) {
+                    var val = parseFloat(input)
+                    if (!isNaN(val)) {
+                        MoveCenterTabController.flingStrength = val.toFixed(2)
+                        text = MoveCenterTabController.flingStrength.toFixed(2)
+                    } else {
+                        text = MoveCenterTabController.flingStrength.toFixed(2)
+                    }
+                }
+            }
+
+
+        }
+    }
+
+    Component.onCompleted: {
+        gravityToggleButton.checked = MoveCenterTabController.gravityActive
+        gravityStrengthText.text = MoveCenterTabController.gravityStrength.toFixed(2)
+        momentumToggleButton.checked = MoveCenterTabController.momentumSave
+        flingStrengthText.text = MoveCenterTabController.flingStrength.toFixed(2)
+    }
+
+    Connections {
+        target: MoveCenterTabController
+
+        onGravityActiveChanged: {
+            gravityToggleButton.checked = MoveCenterTabController.gravityActive
+        }
+        onGravityStrengthChanged: {
+            gravityStrengthText.text = MoveCenterTabController.gravityStrength.toFixed(2)
+        }
+        onMomentumSaveChanged: {
+            momentumToggleButton.checked = MoveCenterTabController.momentumSave
+        }
+        onFlingStrengthChanged: {
+            flingStrengthText.text = MoveCenterTabController.flingStrength.toFixed(2)
+        }
+    }
+}

--- a/src/res/qml/motion_page/space_drag/SpaceDragGroupBox.qml
+++ b/src/res/qml/motion_page/space_drag/SpaceDragGroupBox.qml
@@ -5,12 +5,12 @@ import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {
-    id: universeDragGroupBox
+    id: spaceDragGroupBox
     Layout.fillWidth: true
 
     label: MyText {
         leftPadding: 10
-        text: "Universe Drag"
+        text: "Space Drag"
         bottomPadding: -10
     }
     background: Rectangle {

--- a/src/res/qml/motion_page/space_turn/SpaceTurnGroupBox.qml
+++ b/src/res/qml/motion_page/space_turn/SpaceTurnGroupBox.qml
@@ -5,12 +5,12 @@ import ovras.advsettings 1.0
 import "../../common"
 
 GroupBox {
-    id: universeTurnGroupBox
+    id: spaceTurnGroupBox
     Layout.fillWidth: true
 
     label: MyText {
         leftPadding: 10
-        text: "Universe Turn"
+        text: "Space Turn"
         bottomPadding: -10
     }
     background: Rectangle {

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -52,6 +52,14 @@ class MoveCenterTabController : public QObject
                     heightToggleChanged )
     Q_PROPERTY( float heightToggleOffset READ heightToggleOffset WRITE
                     setHeightToggleOffset NOTIFY heightToggleOffsetChanged )
+    Q_PROPERTY( float gravityStrength READ gravityStrength WRITE
+                    setGravityStrength NOTIFY gravityStrengthChanged )
+    Q_PROPERTY( float flingStrength READ flingStrength WRITE setFlingStrength
+                    NOTIFY flingStrengthChanged )
+    Q_PROPERTY( bool gravityActive READ gravityActive WRITE setGravityActive
+                    NOTIFY gravityActiveChanged )
+    Q_PROPERTY( bool momentumSave READ momentumSave WRITE setMomentumSave NOTIFY
+                    momentumSaveChanged )
     Q_PROPERTY( bool lockXToggle READ lockXToggle WRITE setLockX NOTIFY
                     requireLockXChanged )
     Q_PROPERTY( bool lockYToggle READ lockYToggle WRITE setLockY NOTIFY
@@ -90,6 +98,9 @@ private:
     bool m_heightToggle = false;
     float m_heightToggleOffset = -1.0f;
     float m_gravityFloor = 0.0f;
+    float m_gravityStrength = 9.8f;
+    float m_flingStrength = 1.0f;
+    bool m_momentumSave = false;
     bool m_lockXToggle = false;
     bool m_lockYToggle = false;
     bool m_lockZToggle = false;
@@ -123,8 +134,10 @@ private:
     bool m_swapDragToLeftHandActivated = false;
     bool m_swapDragToRightHandActivated = false;
     bool m_gravityActive = false;
+    bool m_gravityReversed = false;
     bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
+    bool m_dashWasOpenPreviousFrame = false;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
@@ -170,6 +183,10 @@ public:
     unsigned turnComfortFactor() const;
     bool heightToggle() const;
     float heightToggleOffset() const;
+    float gravityStrength() const;
+    float flingStrength() const;
+    bool gravityActive() const;
+    bool momentumSave() const;
     bool lockXToggle() const;
     bool lockYToggle() const;
     bool lockZToggle() const;
@@ -188,6 +205,7 @@ public:
     void swapSpaceDragToLeftHandOverride( bool swapDragToLeftHandActive );
     void swapSpaceDragToRightHandOverride( bool swapDragToRightHandActive );
     void gravityToggleAction( bool gravityToggleJustPressed );
+    void gravityReverseAction( bool gravityReverseHeld );
     void heightToggleAction( bool heightToggleJustPressed );
     void resetOffsets( bool resetOffsetsJustPressed );
     void snapTurnLeft( bool snapTurnLeftJustPressed );
@@ -220,6 +238,10 @@ public slots:
     void setTurnComfortFactor( unsigned value, bool notify = true );
     void setHeightToggle( bool value, bool notify = true );
     void setHeightToggleOffset( float value, bool notify = true );
+    void setGravityStrength( float value, bool notify = true );
+    void setFlingStrength( float value, bool notify = true );
+    void setGravityActive( bool value, bool notify = true );
+    void setMomentumSave( bool value, bool notify = true );
 
     void modOffsetX( float value, bool notify = true );
     void modOffsetY( float value, bool notify = true );
@@ -249,6 +271,10 @@ signals:
     void turnComfortFactorChanged( unsigned value );
     void heightToggleChanged( bool value );
     void heightToggleOffsetChanged( float value );
+    void gravityStrengthChanged( float value );
+    void flingStrengthChanged( float value );
+    void gravityActiveChanged( bool value );
+    void momentumSaveChanged( bool value );
     void requireLockXChanged( bool value );
     void requireLockYChanged( bool value );
     void requireLockZChanged( bool value );


### PR DESCRIPTION
**This update adds the following gravity options to the Motion tab:**

- "On" checkbox: enables disables gravity without the need for action bind.
- Gravity Strength: downward acceleration in m/s^2.
- Planet buttons: easy setting of gravity strengths.
- Save Momentum checkbox: when unchecked momentum is reset every time gravity is enabled.
- Fling Strength: Multiplier on velocity gained from space drag.

**The following action was added:**

- Gravity Reverse:

(non-toggle / holdable) When held, gravity strength is multiplied by -1. When gravity strength is negative it's possible to pass through the floor level, and the user is always considered in the "falling" state with negative gravity strength.

**Additional Notes:**

This update also prevents dynamic motion for occurring when the overlay is active. Motion will resume when the overlay is closed. This is to prevent someone from enabling negative gravity via the checkbox and flying upward endlessly flying past the dash without being able to disable gravity again.