### PR TITLE
Clean up offsets ui and add snap turn settings

### DIFF
--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -177,7 +177,7 @@
         "/actions/main/in/SwapSpaceDragToLeftHandOverride" : "Swap Active Space Drag to Left Hand (Override)",
         "/actions/main/in/SwapSpaceDragToRightHandOverride" : "Swap Active Space Drag to Right Hand (Override)",
         "/actions/main/in/GravityToggle" : "Gravity Toggle",
-        "/actions/main/in/GravityReverse" : "Gravity Reverse",
+        "/actions/main/in/GravityReverse" : "Gravity Reverse (Held)",
         "/actions/main/in/HeightToggle" : "Height Toggle",
         "/actions/main/in/ResetOffsets" : "Reset Offsets",
         "/actions/main/in/SnapTurnLeft" : "Snap-Turn Left",

--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -318,20 +318,6 @@ MyStackViewPage {
             }
         }
 
-        GroupBox {
-            Layout.fillWidth: true
-
-            label: MyText {
-                leftPadding: 10
-                text: "Space Drag Binding"
-                bottomPadding: -10
-            }
-            background: Rectangle {
-                color: "transparent"
-                border.color: "#ffffff"
-                radius: 8
-            }
-        }
 
         ColumnLayout {
             RowLayout {

--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -6,7 +6,7 @@ import "common"
 
 
 MyStackViewPage {
-    headerText: "Space Settings"
+    headerText: "Space Offsets"
 
     content: ColumnLayout {
         spacing: 18
@@ -314,19 +314,6 @@ MyStackViewPage {
                             }
                        }
                     }
-
-                    MyToggleButton {
-                        id: spaceRotateHandToggle
-                        text: "Enable Space-Turn Binding"
-                        onCheckedChanged: {
-                            MoveCenterTabController.rotateHand = this.checked
-                        }
-                    }
-
-                    MyText {
-                        text: "Note: TurnSignal will ignore turning during Space-Turn rotation."
-                        font.pointSize: 15.0
-                    }
                 }
             }
         }
@@ -343,27 +330,6 @@ MyStackViewPage {
                 color: "transparent"
                 border.color: "#ffffff"
                 radius: 8
-            }
-            ColumnLayout {
-                RowLayout {
-                    Layout.fillWidth: true
-
-                    MyToggleButton {
-                        id: moveShortcutLeft
-                        text: "Enable Left Hand"
-                        onCheckedChanged: {
-                            MoveCenterTabController.moveShortcutLeft = this.checked
-                        }
-                    }
-
-                    MyToggleButton {
-                        id: moveShortcutRight
-                        text: "Enable Right Hand"
-                        onCheckedChanged: {
-                            MoveCenterTabController.moveShortcutRight = this.checked
-                        }
-                    }
-                }
             }
         }
 
@@ -397,13 +363,10 @@ MyStackViewPage {
 
         Component.onCompleted: {
             spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
-            spaceRotateHandToggle.checked = MoveCenterTabController.rotateHand
             spaceMoveXText.text = MoveCenterTabController.offsetX.toFixed(2)
             spaceMoveYText.text = MoveCenterTabController.offsetY.toFixed(2)
             spaceMoveZText.text = MoveCenterTabController.offsetZ.toFixed(2)
             spaceRotationSlider.value = MoveCenterTabController.rotation
-            moveShortcutRight.checked = MoveCenterTabController.moveShortcutRight
-            moveShortcutLeft.checked = MoveCenterTabController.moveShortcutLeft
 			lockXToggle.checked = MoveCenterTabController.lockXToggle
 			lockYToggle.checked = MoveCenterTabController.lockYToggle
 			lockZToggle.checked = MoveCenterTabController.lockZToggle
@@ -445,15 +408,6 @@ MyStackViewPage {
             }
             onAdjustChaperoneChanged: {
                 spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
-            }
-            onRotateHandChanged: {
-                spaceRotateHandToggle.checked = MoveCenterTabController.rotateHand
-            }
-            onMoveShortcutRightChanged: {
-                moveShortcutRight.checked = MoveCenterTabController.moveShortcutRight
-            }
-            onMoveShortcutLeftChanged: {
-                moveShortcutLeft.checked = MoveCenterTabController.moveShortcutLeft
             }
 			onLockXToggleChanged: {
 				lockXToggle.checked = MoveCenterTabController.lockXToggle

--- a/src/res/qml/motion_page/MotionPage.qml
+++ b/src/res/qml/motion_page/MotionPage.qml
@@ -7,6 +7,7 @@ import "space_drag"
 import "space_turn"
 import "height_toggle"
 import "gravity"
+import "snap_turn"
 
 MyStackViewPage {
     headerText: "Motion Settings"
@@ -21,6 +22,8 @@ MyStackViewPage {
         HeightToggleGroupBox { id: heightToggleGroupBox }
 
         GravityGroupBox { id: gravityGroupBox }
+
+        SnapTurnGroupBox { id: snapTurnGroupBox }
 
         Item {
             Layout.fillHeight: true

--- a/src/res/qml/motion_page/gravity/GravityGroupBox.qml
+++ b/src/res/qml/motion_page/gravity/GravityGroupBox.qml
@@ -47,7 +47,7 @@ GroupBox {
             MyText {
                 text: "Gravity Strength (+ is down):"
                 horizontalAlignment: Text.AlignRight
-                Layout.rightMargin: 10
+                Layout.rightMargin: 2
             }
 
             MyTextField {
@@ -118,14 +118,14 @@ GroupBox {
             }
 
             MyText {
-                text: "Fling Strength"
+                text: "Fling Strength:"
                 horizontalAlignment: Text.AlignRight
-                Layout.rightMargin: 10
+                Layout.rightMargin: 2
             }
 
             MyTextField {
                 id: flingStrengthText
-                text: "1.00"
+                text: "1.0"
                 keyBoardUID: 153
                 Layout.preferredWidth: 120
                 Layout.leftMargin: 10
@@ -134,11 +134,43 @@ GroupBox {
                 function onInputEvent(input) {
                     var val = parseFloat(input)
                     if (!isNaN(val)) {
-                        MoveCenterTabController.flingStrength = val.toFixed(2)
-                        text = MoveCenterTabController.flingStrength.toFixed(2)
+                        MoveCenterTabController.flingStrength = val.toFixed(1)
+                        text = MoveCenterTabController.flingStrength.toFixed(1)
                     } else {
-                        text = MoveCenterTabController.flingStrength.toFixed(2)
+                        text = MoveCenterTabController.flingStrength.toFixed(1)
                     }
+                }
+            }
+
+            MyPushButton2 {
+                Layout.preferredWidth: 50
+                text: "1x"
+                onClicked: {
+                    MoveCenterTabController.flingStrength = 1.0
+                }
+            }
+
+            MyPushButton2 {
+                Layout.preferredWidth: 50
+                text: "2x"
+                onClicked: {
+                    MoveCenterTabController.flingStrength = 2.0
+                }
+            }
+
+            MyPushButton2 {
+                Layout.preferredWidth: 50
+                text: "3x"
+                onClicked: {
+                    MoveCenterTabController.flingStrength = 3.0
+                }
+            }
+
+            MyPushButton2 {
+                Layout.preferredWidth: 50
+                text: "4x"
+                onClicked: {
+                    MoveCenterTabController.flingStrength = 4.0
                 }
             }
 

--- a/src/res/qml/motion_page/height_toggle/HeightToggleGroupBox.qml
+++ b/src/res/qml/motion_page/height_toggle/HeightToggleGroupBox.qml
@@ -47,7 +47,7 @@ GroupBox {
             MyText {
                 text: "Height Offset (+ is down):"
                 horizontalAlignment: Text.AlignRight
-                Layout.rightMargin: 10
+                Layout.rightMargin: 2
             }
 
             MyTextField {
@@ -64,7 +64,7 @@ GroupBox {
                         MoveCenterTabController.heightToggleOffset = val.toFixed(2)
                         text = MoveCenterTabController.heightToggleOffset.toFixed(2)
                     } else {
-                        text = MoveCenterTabController.heighToggleOffset.toFixed(2)
+                        text = MoveCenterTabController.heightToggleOffset.toFixed(2)
                     }
                 }
             }

--- a/src/res/qml/motion_page/snap_turn/SnapTurnGroupBox.qml
+++ b/src/res/qml/motion_page/snap_turn/SnapTurnGroupBox.qml
@@ -1,0 +1,112 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import ovras.advsettings 1.0
+import "../../common"
+
+GroupBox {
+    id: snapTurnGroupBox
+    Layout.fillWidth: true
+
+    label: MyText {
+        leftPadding: 10
+        text: "Snap Turn Angle"
+        bottomPadding: -10
+    }
+    background: Rectangle {
+        color: "transparent"
+        border.color: "#ffffff"
+        radius: 8
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        Rectangle {
+            color: "#ffffff"
+            height: 1
+            Layout.fillWidth: true
+            Layout.bottomMargin: 5
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            MyTextField {
+                id: snapTurnAngleText
+                text: "45°"
+                keyBoardUID: 154
+                Layout.preferredWidth: 150
+                Layout.leftMargin: 10
+                horizontalAlignment: Text.AlignHCenter
+                function onInputEvent(input) {
+                    var val = parseFloat(input)
+                    if (!isNaN(val)) {
+                        val = val % 180
+                        MoveCenterTabController.snapTurnAngle = val.toFixed(2) * 100
+                        text = ( Math.round( MoveCenterTabController.snapTurnAngle / 100 ) ) + "°"
+                    } else {
+                        text = ( Math.round( MoveCenterTabController.snapTurnAngle / 100 ) ) + "°"
+                    }
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            MyPushButton {
+                id: snapTurnButton15
+                Layout.preferredWidth: 90
+                text:"15°"
+                onClicked: {
+                    MoveCenterTabController.snapTurnAngle = 1500
+                }
+           }
+            MyPushButton {
+                id: snapTurnButton30
+                Layout.preferredWidth: 90
+                text:"30°"
+                onClicked: {
+                    MoveCenterTabController.snapTurnAngle = 3000
+                }
+           }
+            MyPushButton {
+                id: snapTurnButton45
+                Layout.preferredWidth: 90
+                text:"45°"
+                onClicked: {
+                    MoveCenterTabController.snapTurnAngle = 4500
+                }
+           }
+            MyPushButton {
+                id: snapTurnButton90
+                Layout.preferredWidth: 90
+                text:"90°"
+                onClicked: {
+                    MoveCenterTabController.snapTurnAngle = 9000
+                }
+           }
+            MyPushButton {
+                id: snapTurnButton180
+                Layout.preferredWidth: 90
+                text:"180°"
+                onClicked: {
+                    MoveCenterTabController.snapTurnAngle = 18000
+                }
+           }
+        }
+    }
+
+    Component.onCompleted: {
+        snapTurnAngleText.text = ( Math.round( MoveCenterTabController.snapTurnAngle / 100 ) ) + "°"
+    }
+
+    Connections {
+        target: MoveCenterTabController
+
+        onSnapTurnAngleChanged: {
+            snapTurnAngleText.text = ( Math.round( MoveCenterTabController.snapTurnAngle / 100 ) ) + "°"
+        }
+    }
+}

--- a/src/res/qml/motion_page/snap_turn/SnapTurnGroupBox.qml
+++ b/src/res/qml/motion_page/snap_turn/SnapTurnGroupBox.qml
@@ -8,29 +8,17 @@ GroupBox {
     id: snapTurnGroupBox
     Layout.fillWidth: true
 
-    label: MyText {
-        leftPadding: 10
-        text: "Snap Turn Angle"
-        bottomPadding: -10
-    }
-    background: Rectangle {
-        color: "transparent"
-        border.color: "#ffffff"
-        radius: 8
-    }
-
     ColumnLayout {
         anchors.fill: parent
 
-        Rectangle {
-            color: "#ffffff"
-            height: 1
-            Layout.fillWidth: true
-            Layout.bottomMargin: 5
-        }
-
         RowLayout {
             Layout.fillWidth: true
+
+            MyText {
+                text: "Snap Turn Angle:"
+                horizontalAlignment: Text.AlignRight
+                Layout.rightMargin: 2
+            }
 
             MyTextField {
                 id: snapTurnAngleText

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -494,6 +494,7 @@ void MoveCenterTabController::setGravityStrength( float value, bool notify )
     {
         emit gravityStrengthChanged( m_gravityStrength );
     }
+    m_lastGravityUpdateTimePoint = std::chrono::steady_clock::now();
 }
 
 float MoveCenterTabController::flingStrength() const

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -46,11 +46,6 @@ void MoveCenterTabController::initStage1()
     {
         m_adjustChaperone = value.toBool();
     }
-    value = settings->value( "rotateHand", m_settingsHandTurningEnabled );
-    if ( value.isValid() && !value.isNull() )
-    {
-        m_settingsHandTurningEnabled = value.toBool();
-    }
     value = settings->value( "moveShortcutRight",
                              m_settingsRightHandDragEnabled );
     if ( value.isValid() && !value.isNull() )
@@ -280,25 +275,6 @@ void MoveCenterTabController::setAdjustChaperone( bool value, bool notify )
         {
             emit adjustChaperoneChanged( m_adjustChaperone );
         }
-    }
-}
-
-bool MoveCenterTabController::rotateHand() const
-{
-    return m_settingsHandTurningEnabled;
-}
-
-void MoveCenterTabController::setRotateHand( bool value, bool notify )
-{
-    m_settingsHandTurningEnabled = value;
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "playspaceSettings" );
-    settings->setValue( "rotateHand", m_settingsHandTurningEnabled );
-    settings->endGroup();
-    settings->sync();
-    if ( notify )
-    {
-        emit rotateHandChanged( m_settingsHandTurningEnabled );
     }
 }
 

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -78,6 +78,11 @@ void MoveCenterTabController::initStage1()
     {
         m_turnComfortFactor = value.toUInt();
     }
+    value = settings->value( "snapTurnAngle", m_snapTurnAngle );
+    if ( value.isValid() && !value.isNull() )
+    {
+        m_snapTurnAngle = value.toInt();
+    }
     value = settings->value( "heightToggleOffset", m_heightToggleOffset );
     if ( value.isValid() && !value.isNull() )
     {
@@ -253,6 +258,28 @@ void MoveCenterTabController::setTempRotation( int value, bool notify )
     if ( notify )
     {
         emit tempRotationChanged( m_tempRotation );
+    }
+}
+
+int MoveCenterTabController::snapTurnAngle() const
+{
+    return m_snapTurnAngle;
+}
+
+void MoveCenterTabController::setSnapTurnAngle( int value, bool notify )
+{
+    if ( m_snapTurnAngle != value )
+    {
+        m_snapTurnAngle = value;
+        auto settings = OverlayController::appSettings();
+        settings->beginGroup( "playspaceSettings" );
+        settings->setValue( "snapTurnAngle", m_snapTurnAngle );
+        settings->endGroup();
+        settings->sync();
+        if ( notify )
+        {
+            emit snapTurnAngleChanged( m_snapTurnAngle );
+        }
     }
 }
 
@@ -1363,7 +1390,7 @@ void MoveCenterTabController::snapTurnLeft( bool snapTurnLeftJustPressed )
 
     // TODO add interface to configure snap angle.
     // temporarily hard coded to 45 degrees
-    int newRotationAngleDeg = m_rotation - 4500;
+    int newRotationAngleDeg = m_rotation - m_snapTurnAngle;
     // Keep angle within -18000 ~ 18000 centidegrees
     if ( newRotationAngleDeg > 18000 )
     {
@@ -1386,7 +1413,7 @@ void MoveCenterTabController::snapTurnRight( bool snapTurnRightJustPressed )
 
     // TODO add interface to configure snap angle.
     // temporarily hard coded to 45 degrees
-    int newRotationAngleDeg = m_rotation + 4500;
+    int newRotationAngleDeg = m_rotation + m_snapTurnAngle;
     // Keep angle within -18000 ~ 18000 centidegrees
     if ( newRotationAngleDeg > 18000 )
     {

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -34,6 +34,8 @@ class MoveCenterTabController : public QObject
         int rotation READ rotation WRITE setRotation NOTIFY rotationChanged )
     Q_PROPERTY( int tempRotation READ tempRotation WRITE setTempRotation NOTIFY
                     tempRotationChanged )
+    Q_PROPERTY( int snapTurnAngle READ snapTurnAngle WRITE setSnapTurnAngle
+                    NOTIFY snapTurnAngleChanged )
     Q_PROPERTY( bool adjustChaperone READ adjustChaperone WRITE
                     setAdjustChaperone NOTIFY adjustChaperoneChanged )
     Q_PROPERTY( bool moveShortcutRight READ moveShortcutRight WRITE
@@ -81,6 +83,7 @@ private:
     int m_rotation = 0;
     int m_oldRotation = 0;
     int m_tempRotation = 0;
+    int m_snapTurnAngle = 4500;
     bool m_adjustChaperone = true;
     bool m_moveShortcutRightPressed = false;
     bool m_moveShortcutLeftPressed = false;
@@ -170,6 +173,7 @@ public:
     float offsetZ() const;
     int rotation() const;
     int tempRotation() const;
+    int snapTurnAngle() const;
     bool adjustChaperone() const;
     bool moveShortcutRight() const;
     bool moveShortcutLeft() const;
@@ -219,11 +223,10 @@ public slots:
     void setOffsetZ( float value, bool notify = true );
 
     void setRotation( int value, bool notify = true );
-
     void setTempRotation( int value, bool notify = true );
+    void setSnapTurnAngle( int value, bool notify = true );
 
     void setAdjustChaperone( bool value, bool notify = true );
-
     void setMoveShortcutRight( bool value, bool notify = true );
     void setMoveShortcutLeft( bool value, bool notify = true );
     void setTurnBindRight( bool value, bool notify = true );
@@ -255,6 +258,7 @@ signals:
     void offsetZChanged( float value );
     void rotationChanged( int value );
     void tempRotationChanged( int value );
+    void snapTurnAngleChanged( int value );
     void adjustChaperoneChanged( bool value );
     void moveShortcutRightChanged( bool value );
     void moveShortcutLeftChanged( bool value );

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -66,8 +66,6 @@ class MoveCenterTabController : public QObject
                     requireLockYChanged )
     Q_PROPERTY( bool lockZToggle READ lockZToggle WRITE setLockZ NOTIFY
                     requireLockZChanged )
-    Q_PROPERTY( bool rotateHand READ rotateHand WRITE setRotateHand NOTIFY
-                    rotateHandChanged )
 
 private:
     OverlayController* parent;
@@ -84,7 +82,6 @@ private:
     int m_oldRotation = 0;
     int m_tempRotation = 0;
     bool m_adjustChaperone = true;
-    bool m_settingsHandTurningEnabled = false;
     bool m_moveShortcutRightPressed = false;
     bool m_moveShortcutLeftPressed = false;
     vr::TrackedDeviceIndex_t m_activeMoveController;
@@ -174,7 +171,6 @@ public:
     int rotation() const;
     int tempRotation() const;
     bool adjustChaperone() const;
-    bool rotateHand() const;
     bool moveShortcutRight() const;
     bool moveShortcutLeft() const;
     bool turnBindRight() const;
@@ -228,8 +224,6 @@ public slots:
 
     void setAdjustChaperone( bool value, bool notify = true );
 
-    void setRotateHand( bool value, bool notify = true );
-
     void setMoveShortcutRight( bool value, bool notify = true );
     void setMoveShortcutLeft( bool value, bool notify = true );
     void setTurnBindRight( bool value, bool notify = true );
@@ -262,7 +256,6 @@ signals:
     void rotationChanged( int value );
     void tempRotationChanged( int value );
     void adjustChaperoneChanged( bool value );
-    void rotateHandChanged( bool value );
     void moveShortcutRightChanged( bool value );
     void moveShortcutLeftChanged( bool value );
     void turnBindRightChanged( bool value );


### PR DESCRIPTION
**Added:**

- Snap-turn angle buttons to the motion tab
- Fling strength 1x, 2x, 3x, 4x buttons

**Removed:**

-  non-functional left over elements from the offsets tab