### PR TITLE
Fix null pointer dereference in QtMessageHandler function

### DIFF
--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -15,19 +15,19 @@ void mainQtMessageHandler( QtMsgType type,
     switch ( type )
     {
     case QtDebugMsg:
-        LOG( DEBUG ) << localMsg.constData();
+        LOG( DEBUG ) << "QTMSGH: " << localMsg.constData();
         break;
     case QtInfoMsg:
-        LOG( INFO ) << localMsg.constData();
+        LOG( INFO ) << "QTMSGH: " << localMsg.constData();
         break;
     case QtWarningMsg:
-        LOG( WARNING ) << localMsg.constData();
+        LOG( WARNING ) << "QTMSGH: " << localMsg.constData();
         break;
     case QtCriticalMsg:
-        LOG( ERROR ) << localMsg.constData();
+        LOG( ERROR ) << "QTMSGH: " << localMsg.constData();
         break;
     case QtFatalMsg:
-        LOG( FATAL ) << localMsg.constData();
+        LOG( FATAL ) << "QTMSGH: " << localMsg.constData();
         break;
     }
 }

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -7,28 +7,27 @@ void mainQtMessageHandler( QtMsgType type,
                            const QMessageLogContext& context,
                            const QString& msg )
 {
+    // context contains null pointers on release builds. Cast to get rid of
+    // unreferenced formal parameter warnings.
+    static_cast<void>( context );
+
     QByteArray localMsg = msg.toLocal8Bit();
     switch ( type )
     {
     case QtDebugMsg:
-        LOG( DEBUG ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
+        LOG( DEBUG ) << localMsg.constData();
         break;
     case QtInfoMsg:
-        LOG( INFO ) << localMsg.constData() << " (" << context.file << ":"
-                    << context.line << ")";
+        LOG( INFO ) << localMsg.constData();
         break;
     case QtWarningMsg:
-        LOG( WARNING ) << localMsg.constData() << " (" << context.file << ":"
-                       << context.line << ")";
+        LOG( WARNING ) << localMsg.constData();
         break;
     case QtCriticalMsg:
-        LOG( ERROR ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
+        LOG( ERROR ) << localMsg.constData();
         break;
     case QtFatalMsg:
-        LOG( FATAL ) << localMsg.constData() << " (" << context.file << ":"
-                     << context.line << ")";
+        LOG( FATAL ) << localMsg.constData();
         break;
     }
 }


### PR DESCRIPTION
The `QMessageLogContext` is only filled out in debug builds. Release builds will have null pointers in `file` and `line`. This causes any error attempted to be logged to result in a null pointer dereference.

Since we never use debug builds anyway, simply removing the uses of `file` and `line` makes sense.

Github issue
https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/139

Fixes #139.