### PR TITLE
Implement Seated Universe and Raw (Room Setup) Universe Support

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -748,6 +748,13 @@ void OverlayController::mainEventLoop()
         }
         break;
 
+        case vr::VREvent_SeatedZeroPoseReset:
+        {
+            m_moveCenterTabController.incomingSeatedReset();
+            LOG( INFO ) << "Game Triggered Seated Zero-Position Reset";
+        }
+        break;
+
         // Multiple ChaperoneUniverseHasChanged are often emitted at the
         // same time (some with a little bit of delay) There is no sure way
         // to recognize redundant events, we can only exclude redundant

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -710,7 +710,7 @@ void OverlayController::mainEventLoop()
             LOG( INFO ) << "Received quit request.";
             vr::VRSystem()->AcknowledgeQuit_Exiting(); // Let us buy some
                                                        // time just in case
-            m_moveCenterTabController.reset();
+            m_moveCenterTabController.shutdown();
             // Un-mute mic before Exiting VR, as it is set at system level Not
             // Vr level.
             m_audioTabController.setMicMuted( false, false );

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -61,7 +61,7 @@ namespace advsettings
 // Avoid setting values to the same numbers.
 constexpr int k_audioSettingsUpdateCounter = 89;
 constexpr int k_chaperoneSettingsUpdateCounter = 101;
-constexpr int k_moveCenterSettingsUpdateCounter = 149;
+constexpr int k_moveCenterSettingsUpdateCounter = 83;
 constexpr int k_reviveSettingsUpdateCounter = 139;
 constexpr int k_settingsTabSettingsUpdateCounter = 157;
 constexpr int k_steamVrSettingsUpdateCounter = 97;

--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -340,6 +340,30 @@ MyStackViewPage {
                     }
                 }
 
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                MyPushButton {
+                    id: spaceLogMatrices
+                    Layout.preferredWidth: 250
+                    visible: MoveCenterTabController.showLogMatricesButton
+                    text: "Log Matrices"
+                    onClicked: {
+                        MoveCenterTabController.outputLogPoses()
+                    }
+                }
+
+                MyPushButton {
+                    id: spaceSeatedRecenter
+                    Layout.preferredWidth: 250
+                    visible: false
+                    text: "Seated Recenter"
+                    onClicked: {
+                        MoveCenterTabController.updateSeatedResetData()
+                    }
+                }
+
             }
         }
 
@@ -356,19 +380,14 @@ MyStackViewPage {
 			lockXToggle.checked = MoveCenterTabController.lockXToggle
 			lockYToggle.checked = MoveCenterTabController.lockYToggle
 			lockZToggle.checked = MoveCenterTabController.lockZToggle
+            spaceLogMatrices.visible = MoveCenterTabController.showLogMatricesButton
 			
             if (MoveCenterTabController.trackingUniverse === 0) {
                 spaceModeText.text = "Sitting"
-                spaceRotationPlusButton.enabled = false
-                spaceRotationMinusButton.enabled = false
-                spaceRotationSlider.enabled = false
-                spaceRotationText.text = "-"
+                spaceSeatedRecenter.visible = true
             } else if (MoveCenterTabController.trackingUniverse === 1) {
                 spaceModeText.text = "Standing"
-                spaceRotationPlusButton.enabled = true
-                spaceRotationMinusButton.enabled = true
-                spaceRotationSlider.enabled = true
-                spaceRotationText.text = "0°"
+                spaceSeatedRecenter.visible = false
             } else {
                 spaceModeText.text = "Unknown(" + MoveCenterTabController.trackingUniverse + ")"
             }
@@ -407,16 +426,10 @@ MyStackViewPage {
             onTrackingUniverseChanged: {
                 if (MoveCenterTabController.trackingUniverse === 0) {
                     spaceModeText.text = "Sitting"
-                    spaceRotationPlusButton.enabled = false
-                    spaceRotationMinusButton.enabled = false
-                    spaceRotationSlider.enabled = false
-                    spaceRotationText.text = "-"
+                    spaceSeatedRecenter.visible = true
                 } else if (MoveCenterTabController.trackingUniverse === 1) {
                     spaceModeText.text = "Standing"
-                    spaceRotationPlusButton.enabled = true
-                    spaceRotationMinusButton.enabled = true
-                    spaceRotationSlider.enabled = true
-                    spaceRotationText.text = "0°"
+                    spaceSeatedRecenter.visible = false
                 } else {
                     spaceModeText.text = "Unknown(" + MoveCenterTabController.trackingUniverse + ")"
                 }

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -26,6 +26,14 @@ MyStackViewPage {
             }
         }
 
+        MyToggleButton {
+            id: allowExternalEditsToggle
+            text: "Allow External App Chaperone Edits (Danger)"
+            onCheckedChanged: {
+                MoveCenterTabController.setAllowExternalEdits(checked, true)
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
@@ -33,6 +41,7 @@ MyStackViewPage {
         Component.onCompleted: {
             settingsAutoStartToggle.checked = SettingsTabController.autoStartEnabled
             forceReviveToggle.checked = SettingsTabController.forceRevivePage
+            allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
         }
 
         Connections {
@@ -42,6 +51,13 @@ MyStackViewPage {
             }
             onForceRevivePageChanged: {
                 forceReviveToggle.checked = SettingsTabController.forceRevivePage
+            }
+        }
+
+        Connections {
+            target: MoveCenterTabController
+            onAllowExternalEditsChanged: {
+                allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
             }
         }
     }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -123,6 +123,11 @@ void MoveCenterTabController::initStage1()
     {
         m_showLogMatricesButton = value.toBool();
     }
+    value = settings->value( "allowExternalEdits", m_allowExternalEdits );
+    if ( value.isValid() && !value.isNull() )
+    {
+        m_allowExternalEdits = value.toBool();
+    }
     settings->endGroup();
     m_lastDragUpdateTimePoint = std::chrono::steady_clock::now();
     m_lastGravityUpdateTimePoint = std::chrono::steady_clock::now();
@@ -770,6 +775,25 @@ void MoveCenterTabController::setShowLogMatricesButton( bool value,
     if ( notify )
     {
         emit showLogMatricesButtonChanged( m_showLogMatricesButton );
+    }
+}
+
+bool MoveCenterTabController::allowExternalEdits() const
+{
+    return m_allowExternalEdits;
+}
+
+void MoveCenterTabController::setAllowExternalEdits( bool value, bool notify )
+{
+    m_allowExternalEdits = value;
+    auto settings = OverlayController::appSettings();
+    settings->beginGroup( "playspaceSettings" );
+    settings->setValue( "allowExternalEdits", m_allowExternalEdits );
+    settings->endGroup();
+    settings->sync();
+    if ( notify )
+    {
+        emit allowExternalEditsChanged( m_allowExternalEdits );
     }
 }
 
@@ -2093,6 +2117,15 @@ void MoveCenterTabController::updateSpace()
             saveUncommittedChaperone();
         }
         return;
+    }
+
+    if ( m_allowExternalEdits && m_oldOffsetX == 0.0f && m_oldOffsetY == 0.0f
+         && m_oldOffsetZ == 0.0f && m_oldRotation == 0 )
+    {
+        vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
+        vr::VRChaperoneSetup()->CommitWorkingCopy(
+            vr::EChaperoneConfigFile_Live );
+        updateChaperoneResetData();
     }
 
     vr::HmdMatrix34_t offsetUniverseCenter;

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -138,6 +138,7 @@ private:
     bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_dashWasOpenPreviousFrame = false;
+    bool m_isResetDataStandingUniverse = true;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
@@ -248,6 +249,7 @@ public slots:
     void setLockY( bool value, bool notify = true );
     void setLockZ( bool value, bool notify = true );
 
+    void shutdown();
     void reset();
     void zeroOffsets();
 

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -68,6 +68,9 @@ class MoveCenterTabController : public QObject
                     requireLockYChanged )
     Q_PROPERTY( bool lockZToggle READ lockZToggle WRITE setLockZ NOTIFY
                     requireLockZChanged )
+    Q_PROPERTY(
+        bool showLogMatricesButton READ showLogMatricesButton WRITE
+            setShowLogMatricesButton NOTIFY showLogMatricesButtonChanged )
 
 private:
     OverlayController* parent;
@@ -100,6 +103,7 @@ private:
     float m_gravityFloor = 0.0f;
     float m_gravityStrength = 9.8f;
     float m_flingStrength = 1.0f;
+    float m_seatedHeight = 1.0f;
     bool m_momentumSave = false;
     bool m_lockXToggle = false;
     bool m_lockYToggle = false;
@@ -138,8 +142,9 @@ private:
     bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_dashWasOpenPreviousFrame = false;
-    bool m_isResetDataStandingUniverse = true;
     bool m_roomSetupModeDetected = false;
+    bool m_seatedModeDetected = false;
+    bool m_showLogMatricesButton = false;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
@@ -150,6 +155,7 @@ private:
     vr::HmdQuad_t* m_collisionBoundsForReset;
     uint32_t m_collisionBoundsCountForReset = 0;
     vr::HmdMatrix34_t m_universeCenterForReset;
+    vr::HmdMatrix34_t m_seatedCenterForReset;
     vr::HmdQuad_t* m_collisionBoundsForOffset;
 
     void updateHmdRotationCounter( vr::TrackedDevicePose_t hmdPose,
@@ -162,6 +168,7 @@ private:
     void updateChaperoneResetData();
     void applyChaperoneResetData();
     void saveUncommittedChaperone();
+    void outputLogHmdMatrix( vr::HmdMatrix34_t hmdMatrix );
 
 public:
     void initStage1();
@@ -192,8 +199,10 @@ public:
     bool lockXToggle() const;
     bool lockYToggle() const;
     bool lockZToggle() const;
+    bool showLogMatricesButton() const;
     double getHmdYawTotal();
     void resetHmdYawTotal();
+    void incomingSeatedReset();
 
     // actions:
     void leftHandSpaceDrag( bool leftHandDragActive );
@@ -249,9 +258,12 @@ public slots:
     void setLockX( bool value, bool notify = true );
     void setLockY( bool value, bool notify = true );
     void setLockZ( bool value, bool notify = true );
+    void setShowLogMatricesButton( bool value, bool notify = true );
 
     void shutdown();
     void reset();
+    void updateSeatedResetData();
+    void outputLogPoses();
     void zeroOffsets();
 
 signals:
@@ -278,6 +290,7 @@ signals:
     void requireLockXChanged( bool value );
     void requireLockYChanged( bool value );
     void requireLockZChanged( bool value );
+    void showLogMatricesButtonChanged( bool value );
 };
 
 } // namespace advsettings

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -139,6 +139,7 @@ private:
     bool m_pendingZeroOffsets = true;
     bool m_dashWasOpenPreviousFrame = false;
     bool m_isResetDataStandingUniverse = true;
+    bool m_roomSetupModeDetected = false;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -71,6 +71,8 @@ class MoveCenterTabController : public QObject
     Q_PROPERTY(
         bool showLogMatricesButton READ showLogMatricesButton WRITE
             setShowLogMatricesButton NOTIFY showLogMatricesButtonChanged )
+    Q_PROPERTY( bool allowExternalEdits READ allowExternalEdits WRITE
+                    setAllowExternalEdits NOTIFY allowExternalEditsChanged )
 
 private:
     OverlayController* parent;
@@ -145,6 +147,7 @@ private:
     bool m_roomSetupModeDetected = false;
     bool m_seatedModeDetected = false;
     bool m_showLogMatricesButton = false;
+    bool m_allowExternalEdits = false;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
@@ -200,6 +203,7 @@ public:
     bool lockYToggle() const;
     bool lockZToggle() const;
     bool showLogMatricesButton() const;
+    bool allowExternalEdits() const;
     double getHmdYawTotal();
     void resetHmdYawTotal();
     void incomingSeatedReset();
@@ -259,6 +263,7 @@ public slots:
     void setLockY( bool value, bool notify = true );
     void setLockZ( bool value, bool notify = true );
     void setShowLogMatricesButton( bool value, bool notify = true );
+    void setAllowExternalEdits( bool value, bool notify = true );
 
     void shutdown();
     void reset();
@@ -291,6 +296,7 @@ signals:
     void requireLockYChanged( bool value );
     void requireLockZChanged( bool value );
     void showLogMatricesButtonChanged( bool value );
+    void allowExternalEditsChanged( bool value );
 };
 
 } // namespace advsettings

--- a/src/utils/ChaperoneUtils.cpp
+++ b/src/utils/ChaperoneUtils.cpp
@@ -74,10 +74,21 @@ float ChaperoneUtils::_getDistanceToChaperone(
     return distance;
 }
 
-void ChaperoneUtils::loadChaperoneData()
+void ChaperoneUtils::loadChaperoneData( bool fromLiveBounds )
 {
     std::lock_guard<std::recursive_mutex> lock( _mutex );
-    vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo( nullptr, &_quadsCount );
+
+    if ( fromLiveBounds )
+    {
+        vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo( nullptr,
+                                                            &_quadsCount );
+    }
+    else
+    {
+        vr::VRChaperoneSetup()->GetWorkingCollisionBoundsInfo( nullptr,
+                                                               &_quadsCount );
+    }
+
     if ( _quadsCount > 0 )
     {
         std::unique_ptr<vr::HmdQuad_t> quadsBuffer(
@@ -86,8 +97,17 @@ void ChaperoneUtils::loadChaperoneData()
         _corners.reset( reinterpret_cast<vr::HmdVector3_t*>(
             new vr::HmdQuad_t[_quadsCount] ) );
         vr::HmdVector3_t* _cornersPtr = _corners.get();
-        vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo( quadsBufferPtr,
-                                                            &_quadsCount );
+        if ( fromLiveBounds )
+        {
+            vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo( quadsBufferPtr,
+                                                                &_quadsCount );
+        }
+        else
+        {
+            vr::VRChaperoneSetup()->GetWorkingCollisionBoundsInfo(
+                quadsBufferPtr, &_quadsCount );
+        }
+
         for ( uint32_t i = 0; i < _quadsCount; i++ )
         {
             _cornersPtr[i] = quadsBufferPtr[i].vCorners[0];

--- a/src/utils/ChaperoneUtils.h
+++ b/src/utils/ChaperoneUtils.h
@@ -32,7 +32,7 @@ public:
         return _mutex;
     }
 
-    void loadChaperoneData();
+    void loadChaperoneData( bool fromLiveBounds = true );
 
     float getDistanceToChaperone( const vr::HmdVector3_t& point,
                                   vr::HmdVector3_t* projectedPoint = nullptr,


### PR DESCRIPTION
Addresses: #145 and #148  (proximity warning not addressed)

This pull requests implements the necessary considerations for universe types other than standing.

- Raw universe detection is added and actions taken such that room setup is properly applied.
- Seated universe is detected and the seated universe coordinate system has now been implemented into Advanced Settings.
- Added seated recenter button to offsets tab.

In order for seated recenter to mesh well with Advanced Settings the recenter function applies the hmd's position and angle as offsets to recenter the playspace. These offsets are visible and editable in the offsets tab.

- Added "Allow External App Chaperone Edits" checkbox to the settings tab. Off by default

This setting allows external modifications to the chaperone to be folded into Advanced Settings' baseline but only when we have reset offsets (0,0,0 rotation 0). We have no control over the external modifications so the option is disabled by default and labeled "(danger)". However it may prove important for compatibility with other apps.

