### PR TITLE
Update required Qt version to 5.12

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,7 +97,7 @@ WarningsAsErrors:           '*,
     -readability-redundant-declaration,
     -readability-redundant-member-init,
     -readability-static-accessed-through-instance'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '^((?!qt).)*h$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - g++-7
     env:
     - QMAKE_SPEC=linux-g++
+    - QT_SELECT="opt-qt512"
     compiler: gcc
 
   - os: linux
@@ -23,6 +24,7 @@ matrix:
         - g++-7
     env:
     - QMAKE_SPEC=linux-clang
+    - QT_SELECT="opt-qt512"
     compiler: clang
 
   - os: linux
@@ -34,6 +36,7 @@ matrix:
         - g++-7
     env:
     - USE_TIDY=TRUE
+    - QT_SELECT="opt-qt512"
     compiler: clang
 
 before_install:
@@ -41,13 +44,17 @@ before_install:
   - chmod +x ./build_scripts/linux/format.sh
   - chmod +x ./build_scripts/linux/run-clang-tidy.sh
   - chmod +x ./build_scripts/linux/verify_formatting.sh
-  - python ./build_scripts/run-clang-format.py ./src -r --color always  
+  - python ./build_scripts/run-clang-format.py ./src -r --color always
 
 install:
   - sudo add-apt-repository ppa:kubuntu-ppa/backports -y
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
   - sudo apt-get update -qq
-  - sudo apt-get install build-essential qtbase5-dev qttools5-dev qtdeclarative5-dev qtmultimedia5-dev qt5-default qttools5-dev-tools
+  - sudo apt-get install build-essential libgl1-mesa-dev
+  - sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base
+  - sudo apt-get install libx11-dev libxt-dev libxtst-dev
   - sudo apt-get install bear clang-tidy
+  - qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 
 script:
   - ./build_scripts/linux/build_linux.sh

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -3,8 +3,8 @@ CONFIG   += c++1z
 
 DEFINES += ELPP_THREAD_SAFE ELPP_QT_LOGGING ELPP_NO_DEFAULT_LOG_FILE
 
-lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5.6 or higher")
-lessThan(QT_MINOR_VERSION, 6): error("requires Qt 5.6 or higher")
+lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5.12 or higher")
+lessThan(QT_MINOR_VERSION, 12): error("requires Qt 5.12 or higher")
 
 TARGET = AdvancedSettings
 TEMPLATE = app

--- a/build_scripts/linux/build_linux.sh
+++ b/build_scripts/linux/build_linux.sh
@@ -1,21 +1,7 @@
 #!/usr/bin/env bash
 set -e
-if [[ -z $QMAKE_SPEC ]]; then
-    QMAKE_SPEC='linux-g++'
-fi
-
-if [[ -z $USE_TIDY ]]; then
-    MAKE_COMMAND='make --jobs'
-    CLANG_TIDY=
-else
-    # Bear replaces the compile database, it does not update it.
-    # If you run 'bear make' and there is nothing to compile, you
-    # will get an empty database.
-    # Clean up the artifacts and run everything together in that case.
-    MAKE_COMMAND='bear make --jobs'
-    QMAKE_SPEC='linux-clang'
-    CLANG_TIDY='../build_scripts/linux/run-clang-tidy.sh'
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+. $DIR/configure.sh
 
 echo $MAKE_COMMAND
 mkdir -p build

--- a/build_scripts/linux/build_linux.sh
+++ b/build_scripts/linux/build_linux.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 set -e
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-. $DIR/configure.sh
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PROJECT_DIR=$SCRIPT_DIR/../../
+BUILD_DIR=$PROJECT_DIR/build/
+. $SCRIPT_DIR/configure.sh
 
 echo $MAKE_COMMAND
-mkdir -p build
-cd build
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
 qmake --version
-qmake -spec $QMAKE_SPEC ..
+qmake -spec $QMAKE_SPEC $PROJECT_DIR
 $MAKE_COMMAND
 $CLANG_TIDY
-cp -r ../src/res ./bin/linux/AdvancedSettings/
-cp ../src/package_files/action_manifest.json ./bin/linux/AdvancedSettings/
-cp ../src/package_files/manifest.vrmanifest ./bin/linux/AdvancedSettings/
-cp -r ../src/package_files/default_action_manifests ./bin/linux/AdvancedSettings/
-cp ../third-party/openvr/lib/linux64/libopenvr_api.so ./bin/linux/AdvancedSettings/
-cp ../build_scripts/linux/run-with-library.sh ./bin/linux/AdvancedSettings/
+cp -r $PROJECT_DIR/src/res $BUILD_DIR/bin/linux/AdvancedSettings/
+cp $PROJECT_DIR/src/package_files/action_manifest.json $BUILD_DIR/bin/linux/AdvancedSettings/
+cp $PROJECT_DIR/src/package_files/manifest.vrmanifest $BUILD_DIR/bin/linux/AdvancedSettings/
+cp -r $PROJECT_DIR/src/package_files/default_action_manifests $BUILD_DIR/bin/linux/AdvancedSettings/
+cp $PROJECT_DIR/third-party/openvr/lib/linux64/libopenvr_api.so $BUILD_DIR/bin/linux/AdvancedSettings/
+cp $PROJECT_DIR/build_scripts/linux/run-with-library.sh $BUILD_DIR/bin/linux/AdvancedSettings/

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+
 if [[ -z $QMAKE_SPEC ]]; then
     QMAKE_SPEC='linux-g++'
 fi
@@ -14,6 +15,6 @@ else
     # Clean up the artifacts and run everything together in that case.
     MAKE_COMMAND='bear make --jobs'
     QMAKE_SPEC='linux-clang'
-    CLANG_TIDY='$SCRIPT_DIR/run-clang-tidy.sh'
+    CLANG_TIDY="$SCRIPT_DIR/run-clang-tidy.sh"
 fi
 

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -14,6 +14,6 @@ else
     # Clean up the artifacts and run everything together in that case.
     MAKE_COMMAND='bear make --jobs'
     QMAKE_SPEC='linux-clang'
-    CLANG_TIDY='../build_scripts/linux/run-clang-tidy.sh'
+    CLANG_TIDY='$SCRIPT_DIR/run-clang-tidy.sh'
 fi
 

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+if [[ -z $QMAKE_SPEC ]]; then
+    QMAKE_SPEC='linux-g++'
+fi
+
+if [[ -z $USE_TIDY ]]; then
+    MAKE_COMMAND='make --jobs'
+    CLANG_TIDY=
+else
+    # Bear replaces the compile database, it does not update it.
+    # If you run 'bear make' and there is nothing to compile, you
+    # will get an empty database.
+    # Clean up the artifacts and run everything together in that case.
+    MAKE_COMMAND='bear make --jobs'
+    QMAKE_SPEC='linux-clang'
+    CLANG_TIDY='../build_scripts/linux/run-clang-tidy.sh'
+fi
+

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -7,6 +7,7 @@ QMAKE_CXXFLAGS += -Wpedantic
 QMAKE_CXXFLAGS += -Werror
 #All includes from the third-party directory will not warn.
 QMAKE_CXXFLAGS += --system-header-prefix=third-party
+QMAKE_CXXFLAGS += --system-header-prefix=qt
 
 # Sign conversion warns on auto generated Qt MOC files.
 QMAKE_CXXFLAGS += -Weffc++ -Wconversion -Wno-sign-conversion

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -72,6 +72,9 @@ win32-clang-msvc {
 # Anything g++ or clang
 # In order to suppress warnings in third party headers
 *clang|*clang-g++|*clang-libc++|*g++* {
+    QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
+    QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtCore
+    QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtGui
     QMAKE_CXXFLAGS += -isystem ../third-party/openvr/headers
     QMAKE_CXXFLAGS += -isystem ../third-party/easylogging++
 }

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -10,7 +10,7 @@ SOURCES += src/main.cpp\
     src/tabcontrollers/ReviveTabController.cpp \
     src/tabcontrollers/UtilitiesTabController.cpp \
     src/tabcontrollers/PttController.cpp \
-	src/tabcontrollers/VideoTabController.cpp \
+    src/tabcontrollers/VideoTabController.cpp \
     src/utils/ChaperoneUtils.cpp \
     src/tabcontrollers/audiomanager/AudioManagerDummy.cpp \
     src/openvr/openvr_init.cpp \
@@ -29,7 +29,7 @@ HEADERS += src/overlaycontroller.h \
     src/tabcontrollers/SteamVRTabController.h \
     src/tabcontrollers/ReviveTabController.h \
     src/tabcontrollers/UtilitiesTabController.h \
-	src/tabcontrollers/VideoTabController.h \
+    src/tabcontrollers/VideoTabController.h \
     src/tabcontrollers/AudioManager.h \
     src/tabcontrollers/PttController.h \
     src/tabcontrollers/keyboardinput/KeyboardInput.h \

--- a/build_scripts/win/common.py
+++ b/build_scripts/win/common.py
@@ -24,7 +24,7 @@ ZIP_LOC_VAR_NAME = "ZIP_LOC"
 NSIS_LOC_VAR_NAME = "NSIS_LOC"
 LLVM_LOC_VAR_NAME = "LLVM_LOC"
 
-QT_LOC_DEFAULT = r"C:\Qt\5.11.1\msvc2017_64\bin\""
+QT_LOC_DEFAULT = r"C:\Qt\5.12.2\msvc2017_64\bin\""
 VS_LOC_DEFAULT = r"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"
 JOM_LOC_DEFAULT = r"C:\Qt\Tools\QtCreator\bin\jom.exe"
 ZIP_LOC_DEFAULT = r"C:\Program Files\7-Zip\7z.exe"

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -1,25 +1,123 @@
-# Building for Linux
-
-- [Requirements](#requirements)
-- [Locations and Environment Variables](#locations-and-environment-variables)
-- [Building](#building)
-- [Contributing](#contributing)
-
+# Building on Linux
 ## Requirements
+### Compiler and Build Essentials
 
-The following packages are necessary for compiling: 
+You will need either `clang` og `g++`. At least `g++-7` or `clang` version `5.0` is required due to C++17 support.
+You will additionally need the `build-essential` and `libgl1-mesa-dev` packages.
 
-`sudo apt install build-essential qtbase5-dev qttools5-dev qtdeclarative5-dev qtmultimedia5-dev qt5-default qttools5-dev-tools`
+If they are available from your package manager they can be installed with `sudo apt install build-essential libgl1-mesa-dev`. If the versions in your package manager are not up to date, you can get the packages on Ubuntu with 
+```bash
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt update
+sudo apt install g++-7
+```
+### Qt
 
-If you install Qt 5.12 you should have the above packages.
+At least version `5.12` is required.
 
-Along with either `clang` or `g++`. At least `g++-7` is required, due to C++17 support.
+#### Official Qt Installer
 
-For linting with `clang-tidy` the following are necessary:
+The easiest way to get it is from the [official Qt installer](https://www.qt.io/download-qt-installer).
 
-`sudo apt install bear clang-tidy`
+#### Unofficial Ubuntu Packages
 
-All applications are required to be in the `PATH`.
+If you don't want to use the offical installer, you can use [this](https://launchpad.net/~beineri) PPA.
+
+You will need at least `qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base`, although if you have the drive space it's probably easier just to get `qt512-meta-full`.
+
+For Ubuntu 16.04
+```bash
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial
+sudo apt-get update
+sudo apt install qt512-meta-full
+```
+For Ubuntu 18.04
+```bash
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-bionic
+sudo apt-get update
+sudo apt install qt512-meta-full
+```
+If you choose the wrong Ubuntu version you will get an error from `apt` about there not being a `Release` file. Try the other one instead.
+
+#### `qtchooser` and versions
+
+If you have multiple Qt installations you might need to select the correct one using `qtchooser`.
+
+Type `qmake --version` into the terminal to see which version you're currently using:
+```bash
+$ qmake --version
+QMake version 3.1
+Using Qt version 5.12.2 in /opt/qt512/lib
+```
+If you get a version equal to or above `5.12` you don't need to use `qtchooser`.
+
+If you get `qmake: could not find a Qt installation of ''` or a version lower than `5.12` then you'll need to follow the steps below.
+
+You can list currently installed versions with `qtchooser -l`:
+```bash
+$ qtchooser -l
+4
+5
+opt-qt512
+qt4-x86_64-linux-gnu
+qt4
+qt5-x86_64-linux-gnu
+qt5
+```
+
+If you installed from the PPA above, you'll need to use `opt-qt512`. Activate this by setting the `QT_SELECT` environment variable:
+
+```bash
+export QT_SELECT=opt-qt512
+```
+
+Run `qmake --version` again to make sure the correct version is set.
+
+If you don't see the required version in the list of currently installed versions you will need to install it. You do this with `qtchooser -install <name> <path-to-qmake>`. If you used the PPA above then you'll need to write 
+```bash
+qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+```
+
+Afterwards you should set the `QT_SELECT` environment variable to the name you chose (we used `opt-qt512`).
+
+### X11
+
+X11 packages are currently needed for sending keystrokes to the desktop from VR. Install the packages with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`. This feature will be gated behind a compile flag soon.
+
+### `clang-tidy` and `bear`
+
+In order to use `clang-tidy` you will need `bear clang-tidy` in addition to the above (and `clang`). You will only need this if you're going to make contributions to the codebase.
+
+```bash
+sudo apt install bear clang-tidy
+```
+
+## TL;DR: for Ubuntu
+### Ubuntu 16.04 Xenial
+```bash
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial
+sudo apt update
+sudo apt install g++-7
+sudo apt-get install build-essential libgl1-mesa-dev
+sudo apt-get install qt512-meta-full
+sudo apt-get install libx11-dev libxt-dev libxtst-dev
+sudo apt-get install bear clang-tidy
+qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+```
+
+### Ubuntu 18.04 Bionic
+```bash
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-bionic
+sudo apt update
+sudo apt install g++-7
+sudo apt-get install build-essential libgl1-mesa-dev
+sudo apt-get install qt512-meta-full
+sudo apt-get install libx11-dev libxt-dev libxtst-dev
+sudo apt-get install bear clang-tidy
+qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+```
 
 ## Locations and Environment Variables
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -118,6 +118,7 @@ sudo apt-get install qt512-meta-full
 sudo apt-get install libx11-dev libxt-dev libxtst-dev
 sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+export QT_SELECT=opt-qt512
 ```
 
 ## Ubuntu 18.04 Bionic
@@ -131,6 +132,7 @@ sudo apt-get install qt512-meta-full
 sudo apt-get install libx11-dev libxt-dev libxtst-dev
 sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+export QT_SELECT=opt-qt512
 ```
 
 # Locations and Environment Variables

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -1,6 +1,20 @@
-# Building on Linux
-## Requirements
-### Compiler and Build Essentials
+- [Requirements](#requirements)
+  * [Compiler and Build Essentials](#compiler-and-build-essentials)
+  * [Qt](#qt)
+  * [Official Qt Installer](#official-qt-installer)
+  * [Unofficial Ubuntu Packages](#unofficial-ubuntu-packages)
+  * [`qtchooser` and versions](#-qtchooser--and-versions)
+  * [X11](#x11)
+  * [`clang-tidy` and `bear`](#-clang-tidy--and--bear-)
+- [TL;DR: for Ubuntu](#tl-dr--for-ubuntu)
+  * [Ubuntu 16.04 Xenial](#ubuntu-1604-xenial)
+  * [Ubuntu 18.04 Bionic](#ubuntu-1804-bionic)
+- [Locations and Environment Variables](#locations-and-environment-variables)
+- [Building](#building)
+- [Contributing](#contributing)
+
+# Requirements
+## Compiler and Build Essentials
 
 You will need either `clang` og `g++`. At least `g++-7` or `clang` version `5.0` is required due to C++17 support.
 You will additionally need the `build-essential` and `libgl1-mesa-dev` packages.
@@ -11,15 +25,15 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt update
 sudo apt install g++-7
 ```
-### Qt
+## Qt
 
 At least version `5.12` is required.
 
-#### Official Qt Installer
+## Official Qt Installer
 
 The easiest way to get it is from the [official Qt installer](https://www.qt.io/download-qt-installer).
 
-#### Unofficial Ubuntu Packages
+## Unofficial Ubuntu Packages
 
 If you don't want to use the offical installer, you can use [this](https://launchpad.net/~beineri) PPA.
 
@@ -39,7 +53,7 @@ sudo apt install qt512-meta-full
 ```
 If you choose the wrong Ubuntu version you will get an error from `apt` about there not being a `Release` file. Try the other one instead.
 
-#### `qtchooser` and versions
+## `qtchooser` and versions
 
 If you have multiple Qt installations you might need to select the correct one using `qtchooser`.
 
@@ -80,11 +94,11 @@ qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 
 Afterwards you should set the `QT_SELECT` environment variable to the name you chose (we used `opt-qt512`).
 
-### X11
+## X11
 
 X11 packages are currently needed for sending keystrokes to the desktop from VR. Install the packages with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`. This feature will be gated behind a compile flag soon.
 
-### `clang-tidy` and `bear`
+## `clang-tidy` and `bear`
 
 In order to use `clang-tidy` you will need `bear clang-tidy` in addition to the above (and `clang`). You will only need this if you're going to make contributions to the codebase.
 
@@ -92,8 +106,8 @@ In order to use `clang-tidy` you will need `bear clang-tidy` in addition to the 
 sudo apt install bear clang-tidy
 ```
 
-## TL;DR: for Ubuntu
-### Ubuntu 16.04 Xenial
+# TL;DR: for Ubuntu
+## Ubuntu 16.04 Xenial
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial
@@ -106,7 +120,7 @@ sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 ```
 
-### Ubuntu 18.04 Bionic
+## Ubuntu 18.04 Bionic
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-bionic
@@ -119,7 +133,7 @@ sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 ```
 
-## Locations and Environment Variables
+# Locations and Environment Variables
 
 The following environmental variables are relevant for building the project.
 
@@ -130,12 +144,12 @@ The following environmental variables are relevant for building the project.
 
 If an environment variable isn't set a default value will be provided. The default values are shown in the table below.
 
-## Building
+# Building
 
 With the programs above installed and environment variables set, go into the root folder of the repository and run `./build_scripts/linux/build_linux.sh`.
 
 If you copy the `third-party/openvr/lib/linux64/libopenvr_api.so` file into `/lib` you can run the `AdvancedSettings` file without anything else. Otherwise you'll need to run the `run-with-library.sh` file.
 
-## Contributing
+# Contributing
 
 For full details, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/building_for_windows.md
+++ b/docs/building_for_windows.md
@@ -14,7 +14,7 @@
 For compiling:
 
 1. [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) (tested on 2017 Community)
-2. [Qt Framework](https://www.qt.io/download) version later than 5.6 (Requires at least 5.6. 5.12 is recommended)
+2. [Qt Framework](https://www.qt.io/download) version equal to or greater than 5.12.
 3. [Python 3](https://www.python.org/downloads/) (must be in `PATH` environment variable)
 
 For pushing changes to the repo:
@@ -48,7 +48,7 @@ If an environment variable isn't set a default value will be provided. The defau
 
 | Environment Variable  | Default Value |
 | --------------------  | ------------- |
-| `QT_LOC`              | `"C:\Qt\5.11.1\msvc2017_64\bin\"`    |
+| `QT_LOC`              | `"C:\Qt\5.12.2\msvc2017_64\bin\"`    |
 | `VS_LOC`              | `"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat"`  |
 | `JOM_LOC`             | `"C:\Qt\Tools\QtCreator\bin\jom.exe"`|
 | `ZIP_LOC`             | `"C:\Program Files\7-Zip\7z.exe"`    |


### PR DESCRIPTION
This is mostly changes for Linux, since the CI for Windows is already on 5.12.

On Windows there was already a soft requirement for 5.12, since QMAKE did not recognize the C++17 flag for MSVC, leading to compile errors.

On Linux there was a soft requirement for 5.7 at runtime.

The majority of this is just documentation for building on Linux and getting the Linux CI working with 5.12, since the packages are needed from a third party repository.

The Linux part has been tested as working on Windows Subsystem for Linux Ubuntu 18.04 and the Ubuntu 16.04 Travis CI.

Getting docs for non-Ubuntu systems would be great.

Fixes #137.