### PR TITLE
Update Travis CI LLVM to version 8.0.0, fix whitespace issues in upgrading to 8.0.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,6 @@ init:
   - set TAG_NAME=%APPVEYOR_REPO_TAG_NAME%
 
 build_script:
-  - "C:\Program Files\LLVM\bin\clang-format.exe" --version
   - python ./build_scripts/run-clang-format.py ./src -r --clang-format-executable "C:\Program Files\LLVM\bin\clang-format.exe" --color always
   - call "build_windows.cmd"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,7 @@ init:
   - set TAG_NAME=%APPVEYOR_REPO_TAG_NAME%
 
 build_script:
+  - "C:\Program Files\LLVM\bin\clang-format.exe" --version
   - python ./build_scripts/run-clang-format.py ./src -r --clang-format-executable "C:\Program Files\LLVM\bin\clang-format.exe" --color always
   - call "build_windows.cmd"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,12 @@ before_install:
   - chmod +x ./build_scripts/linux/format.sh
   - chmod +x ./build_scripts/linux/run-clang-tidy.sh
   - chmod +x ./build_scripts/linux/verify_formatting.sh
-  - python ./build_scripts/run-clang-format.py ./src -r --color always
+  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+  - sudo apt update -qq
+  - sudo apt install clang-format-8
+  - clang-format-8 --version
+  - python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
 
 install:
   - sudo add-apt-repository ppa:kubuntu-ppa/backports -y

--- a/src/openvr/openvr_init.cpp
+++ b/src/openvr/openvr_init.cpp
@@ -32,8 +32,8 @@ void initializeProperly( const OpenVrInitializationType initType )
         }
         LOG( ERROR ) << "Failed to initialize OpenVR: "
                             + std::string(
-                                  vr::VR_GetVRInitErrorAsEnglishDescription(
-                                      initError ) );
+                                vr::VR_GetVRInitErrorAsEnglishDescription(
+                                    initError ) );
         exit( EXIT_FAILURE );
     }
     else

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -338,7 +338,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
             throw std::runtime_error( std::string(
                 "Failed to create Overlay: "
                 + std::string( vr::VROverlay()->GetOverlayErrorNameFromEnum(
-                      overlayError ) ) ) );
+                    overlayError ) ) ) );
         }
         vr::VROverlay()->SetOverlayWidthInMeters( m_ulOverlayHandle, 2.5f );
         vr::VROverlay()->SetOverlayInputMethod(
@@ -446,7 +446,7 @@ void OverlayController::renderOverlay()
         if ( !vr::VROverlay()
              || ( !vr::VROverlay()->IsOverlayVisible( m_ulOverlayHandle )
                   && !vr::VROverlay()->IsOverlayVisible(
-                         m_ulOverlayThumbnailHandle ) ) )
+                      m_ulOverlayThumbnailHandle ) ) )
             return;
         m_pRenderControl->polishItems();
         m_pRenderControl->sync();

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -337,8 +337,8 @@ void UtilitiesTabController::eventLoopTick()
                                 parent->setAlarmEnabled( true );
                             }
                             else if (
-                                res
-                                >= vr::VRMessageOverlayResponse_CouldntFindSystemOverlay )
+                                res >= vr::
+                                    VRMessageOverlayResponse_CouldntFindSystemOverlay )
                             {
                                 static const char* errorMessages[]
                                     = { "CouldntFindSystemOverlay",
@@ -346,7 +346,8 @@ void UtilitiesTabController::eventLoopTick()
                                         "ApplicationQuit" };
                                 int errorCode
                                     = res
-                                      - vr::VRMessageOverlayResponse_CouldntFindSystemOverlay;
+                                      - vr::
+                                          VRMessageOverlayResponse_CouldntFindSystemOverlay;
                                 if ( res < 3 )
                                 {
                                     LOG( ERROR )

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -107,8 +107,8 @@ void enableApplicationAutostart()
         throw std::runtime_error(
             std::string( "Could not set auto start: " )
             + std::string(
-                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                      app_error ) ) );
+                vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                    app_error ) ) );
     }
 }
 
@@ -124,8 +124,8 @@ void installApplicationManifest( const std::string manifestPath )
         throw std::runtime_error(
             std::string( "Could not add application manifest: " )
             + std::string(
-                  vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                      app_error ) ) );
+                vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                    app_error ) ) );
     }
 }
 
@@ -163,8 +163,8 @@ void reinstallApplicationManifest( const std::string manifestPath )
                 "Could not find working directory of already "
                 "installed application: "
                 + std::string(
-                      vr::VRApplications()->GetApplicationsErrorNameFromEnum(
-                          app_error ) ) );
+                    vr::VRApplications()->GetApplicationsErrorNameFromEnum(
+                        app_error ) ) );
         }
 
         const auto oldManifestPath


### PR DESCRIPTION
Within the last 24 hours AppVeyor updated to LLVM 8.0.0. For some reason this results in clang-format wanting a different layout.

Since it doesn't seem to be possible to downgrade the AppVeyor version, we'll need to update everything else. In our case our personal machines and the Travis instance.