### PR TITLE
Release 3.1.0

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,7 +97,7 @@ WarningsAsErrors:           '*,
     -readability-redundant-declaration,
     -readability-redundant-member-init,
     -readability-static-accessed-through-instance'
-HeaderFilterRegex: '^((?!qt).)*h$'
+HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -97,7 +97,7 @@ WarningsAsErrors:           '*,
     -readability-redundant-declaration,
     -readability-redundant-member-init,
     -readability-static-accessed-through-instance'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '^((?!qt).)*h$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 CheckOptions:

--- a/build_scripts/win/common.py
+++ b/build_scripts/win/common.py
@@ -11,7 +11,7 @@ import distutils.dir_util
 #Const globals
 #Version string must be bumped every release.
 #TODO: See developer documentation.
-VERSION_STRING = "3-1-0-RC1"
+VERSION_STRING = "3-1-0"
 
 EXIT_CODE_SUCCESS = 0
 EXIT_CODE_FAILURE_BUILD_APP = 1

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -11,7 +11,7 @@
 		!define THIRDDIR "..\third-party"
         !define PACKAGEDIR "..\src\package_files"
         !define PROJECTDIR "..\"
-        !define VERSION_STRING "3-1-0-RC1"
+        !define VERSION_STRING "3-1-0"
 
         
     ;Installer icon

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -48,7 +48,7 @@ constexpr auto applicationOrganizationName = "AdvancedSettings-Team";
 constexpr auto applicationName = "OpenVRAdvancedSettings";
 constexpr const char* applicationKey = "OVRAS-Team.AdvancedSettings";
 constexpr const char* applicationDisplayName = "Advanced Settings";
-constexpr const char* applicationVersionString = "v3.1.0 RC1";
+constexpr const char* applicationVersionString = "v3.1.0";
 } // namespace application_strings
 
 // application namespace


### PR DESCRIPTION
Release 3.1.0 PR

###New Features:

- Brightness Adjustment: Finely control your brightness now! (Found in new "Video" tab) - [Ykeara](https://github.com/ykeara)
- Desktop Adjustment: Shift Desktop View Left/Right/Up/Down/Closer/Further, and save that state (easier to use desktop overlay). - [username223](https://github.com/username223)
- New "Seated Recenter" button now visible in Offsets tab when in seated mode applications. - [Kung](https://github.com/Kung-vr)
- Add Ctrl-C and Ctrl-V keyboard shortcuts to the Utilities tab. - [Kung](https://github.com/Kung-vr)
- “Allow External App Chaperone Edits” checkbox (in settings tab) applies adjustments to the chaperone from external sources (only when offsets are zeroed). - [Kung](https://github.com/Kung-vr)

###Bug Fixes:

- Fixed an issue that prevented new room setup from applying. - [Kung](https://github.com/Kung-vr)
- Add motion support for seated universe mode. - [Kung](https://github.com/Kung-vr)
- Fixed an issue where chaperone warnings (haptics etc..) didn’t respect offsets. - [Kung](https://github.com/Kung-vr)
- Fixed case where error reporting would cause crashing on startup. - [username223](https://github.com/username223)
- Fixed an Issue causing WMR/Rift to snap back to reset position when using motion. (3.0.1) - [Kung](https://github.com/Kung-vr)
- Disabled Space Fix tab's "Undo" Feature (pending integration into new motion system) (3.0.1) - [Kung](https://github.com/Kung-vr)
- Disabled Chaperone Height Slider (pending integration into new motion system) (3.0.1) - [Kung](https://github.com/Kung-vr)
- Fix offset for knuckles/wands not being applied on floor fix. (3.0.1) - [Ykeara](https://github.com/ykeara)

###Miscellaneous:
 - Updated OpenVR libraries to version 1.3.22.