### PR TITLE
Add partial KeyboardManager for Linux, update build scripts and docs

### DIFF
--- a/build_scripts/linux/build_linux.sh
+++ b/build_scripts/linux/build_linux.sh
@@ -17,4 +17,3 @@ cp $PROJECT_DIR/src/package_files/action_manifest.json $BUILD_DIR/bin/linux/Adva
 cp $PROJECT_DIR/src/package_files/manifest.vrmanifest $BUILD_DIR/bin/linux/AdvancedSettings/
 cp -r $PROJECT_DIR/src/package_files/default_action_manifests $BUILD_DIR/bin/linux/AdvancedSettings/
 cp $PROJECT_DIR/third-party/openvr/lib/linux64/libopenvr_api.so $BUILD_DIR/bin/linux/AdvancedSettings/
-cp $PROJECT_DIR/build_scripts/linux/run-with-library.sh $BUILD_DIR/bin/linux/AdvancedSettings/

--- a/build_scripts/linux/build_linux.sh
+++ b/build_scripts/linux/build_linux.sh
@@ -9,7 +9,7 @@ echo $MAKE_COMMAND
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 qmake --version
-qmake -spec $QMAKE_SPEC $PROJECT_DIR
+qmake -spec $QMAKE_SPEC $PROJECT_DIR $QMAKE_EXTRAS
 $MAKE_COMMAND
 $CLANG_TIDY
 cp -r $PROJECT_DIR/src/res $BUILD_DIR/bin/linux/AdvancedSettings/

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -18,3 +18,6 @@ else
     CLANG_TIDY="$SCRIPT_DIR/run-clang-tidy.sh"
 fi
 
+if [[ -n $NO_X11 ]]; then
+    QMAKE_EXTRAS='CONFIG+=noX11'
+fi

--- a/build_scripts/linux/run-with-library.sh
+++ b/build_scripts/linux/run-with-library.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-BASEDIR=$(dirname "$0")
-
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BASEDIR" "$BASEDIR/AdvancedSettings" "$@"

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -1,8 +1,8 @@
-
 # Makes sure the "g++" command used to invoke the compilation is abvove version 7.
 # If it's at or above version 7 then we can use the default g++, otherwise we'll
 # specifically need g++-7.
-system( g++ --version | grep -e " [0-9]\?[0-9]\?[6-9].[0-9]" ) {
+GCC_VERSION = $$system("g++ -dumpversion")
+!greaterThan(GCC_VERSION, 6) {
     message('g++' version is not above 7. Manually using 'g++-7'.)
     !system(g++-7 --version) {
         error(At least g++-7 required.)

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -1,5 +1,15 @@
-#g++-7 is needed for C++17 features. travis does not supply this by default.
-QMAKE_CXX = g++-7
+
+# Makes sure the "g++" command used to invoke the compilation is abvove version 7.
+# If it's at or above version 7 then we can use the default g++, otherwise we'll
+# specifically need g++-7.
+system( g++ --version | grep -e " [0-9]\?[0-9]\?[6-9].[0-9]" ) {
+    message('g++' version is not above 7. Manually using 'g++-7'.)
+    !system(g++-7 --version) {
+        error(At least g++-7 required.)
+    }
+    #g++-7 is needed for C++17 features. travis does not supply this by default.
+    QMAKE_CXX = g++-7
+}
 
 include(clang-gcc-common-switches.pri)
 

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -53,7 +53,13 @@ win32 {
     HEADERS += src/tabcontrollers/audiomanager/AudioManagerWindows.h
 }
 
-!win32 {
+unix {
+    SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+    CONFIG += x11
+    LIBS += -lXtst
+}
+
+!win32&:!unix {
     SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
 }
 

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -78,6 +78,9 @@ win32-clang-msvc {
 # Anything g++ or clang
 # In order to suppress warnings in third party headers
 *clang|*clang-g++|*clang-libc++|*g++* {
+    #Force Linux to look into the current dir for the OpenVR lib
+    QMAKE_LFLAGS    += '-Wl,-rpath,\'\$$ORIGIN\''
+
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtCore
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtGui

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -53,13 +53,13 @@ win32 {
     HEADERS += src/tabcontrollers/audiomanager/AudioManagerWindows.h
 }
 
-unix {
+unix:!macx {
     SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
     CONFIG += x11
     LIBS += -lXtst
 }
 
-!win32&:!unix {
+macx {
     SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
 }
 

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -84,8 +84,9 @@ win32-clang-msvc {
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtCore
     QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]/QtGui
-    QMAKE_CXXFLAGS += -isystem ../third-party/openvr/headers
-    QMAKE_CXXFLAGS += -isystem ../third-party/easylogging++
+
+    QMAKE_CXXFLAGS += -isystem $$PWD/../../third-party/openvr/headers
+    QMAKE_CXXFLAGS += -isystem $$PWD/../../third-party/easylogging++
 }
 
 # easylogging++ used to be a header only lib. Now requires easylogging++.cc

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -54,9 +54,14 @@ win32 {
 }
 
 unix:!macx {
-    SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
-    CONFIG += x11
-    LIBS += -lXtst
+    !noX11 {
+        SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+        CONFIG += x11
+        LIBS += -lXtst
+    }
+    else {
+        SOURCES += src/tabcontrollers/keyboardinput/KeyboardInputDummy.cpp
+    }
 }
 
 macx {

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -2,6 +2,7 @@
   * [Compiler and Build Essentials](#compiler-and-build-essentials)
   * [Qt](#qt)
   * [Official Qt Installer](#official-qt-installer)
+    + [`qtchooser`](#-qtchooser-)
   * [Unofficial Ubuntu Packages](#unofficial-ubuntu-packages)
   * [`qtchooser` and versions](#-qtchooser--and-versions)
   * [X11](#x11)
@@ -32,6 +33,9 @@ At least version `5.12` is required.
 ## Official Qt Installer
 
 The easiest way to get it is from the [official Qt installer](https://www.qt.io/download-qt-installer).
+
+### `qtchooser`
+After installing using the official installer you will likely need to `qtchooser -install <name> <qmake-location>` in order for Qt to use the correct version. See the `qtchooser` section below.
 
 ## Unofficial Ubuntu Packages
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -143,6 +143,7 @@ The following environmental variables are relevant for building the project.
 | --------------------  | ------------- |
 | `QMAKE_SPEC`              | The [mkspec](https://forum.qt.io/topic/70970/what-is-mkspecs-used-for-how-to-configure-for-my-hardware) to compile to. Either `linux-g++` or `linux-clang`. Defaults to `linux-g++`.   |
 | `USE_TIDY`              | If set a compilation database will be created and the project linted. Can only be used with `clang`.  |
+| `NO_X11`              | If set the application will be compiled without X11 specific libraries. This disables certain things like sending keystrokes from VR.  |
 
 If an environment variable isn't set a default value will be provided. The default values are shown in the table below.
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -139,6 +139,18 @@ qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 export QT_SELECT=opt-qt512
 ```
 
+## Ubuntu 19.04 Disco
+
+```bash
+sudo apt install build-essential libgl1-mesa-dev
+sudo apt install g++7
+sudo apt install qt5-default qtmultimedia5-dev libqt5multimediawidgets5 libqt5multimedia5-plugins libqt5multimedia5 qml-module-qtquick-extras qml-module-qtquick-controls2 qml-module-qtquick-dialogs qtdeclarative5-dev
+sudo apt-get install libx11-dev libxt-dev libxtst-dev
+sudo apt install bear clang-tidy
+```
+You should not need to use `qtchooser` to set the Qt version on 19.04.
+
+
 # Locations and Environment Variables
 
 The following environmental variables are relevant for building the project.

--- a/src/tabcontrollers/keyboardinput/KeyboardInput.h
+++ b/src/tabcontrollers/keyboardinput/KeyboardInput.h
@@ -5,6 +5,17 @@
 
 namespace keyboardinput
 {
+/*!
+Represents the state of a keyboard button press. Can be either Up or Down.
+
+Implemented because neither Qt nor Windows.h included a sensible key state enum.
+*/
+enum class KeyStatus
+{
+    Up,
+    Down,
+};
+
 void sendKeyboardInput( QString input );
 void sendKeyboardEnter();
 void sendKeyboardBackspace( const int count );

--- a/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputWindows.cpp
@@ -5,17 +5,6 @@
 namespace keyboardinput
 {
 /*!
-Represents the state of a keyboard button press. Can be either Up or Down.
-
-Implemented because neither Qt nor Windows.h included a sensible key state enum.
-*/
-enum class KeyStatus
-{
-    Up,
-    Down,
-};
-
-/*!
 Fills out an INPUT struct ip with scanCode and keyup status.
 */
 void fillKiStruct( INPUT& ip, WORD scanCode, bool keyup )

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -1,0 +1,94 @@
+#include "KeyboardInput.h"
+#include <X11/Xlib.h>
+#include <X11/Intrinsic.h>
+#include <X11/extensions/XTest.h>
+#include <unistd.h>
+
+// Used to get the compiler to shut up about C4100: unreferenced formal
+// parameter. The cast is to get GCC to shut up about it.
+#define UNREFERENCED_PARAMETER( P ) static_cast<void>( ( P ) )
+
+namespace keyboardinput
+{
+static void sendKeyPressAndRelease (const KeySym keySymbol, const KeySym modifierSymbol){
+    Display *disp = XOpenDisplay (NULL);
+
+    KeyCode keycode = 0;
+    keycode = XKeysymToKeycode (disp, keySymbol);
+
+    KeyCode modcode = 0;
+
+    if (keycode == 0) {
+        return;
+    }
+
+    XTestGrabControl (disp, True);
+
+    /* Generate modkey press */
+    if (modifierSymbol != 0) {
+        modcode = XKeysymToKeycode(disp, modsym);
+        XTestFakeKeyEvent (disp, modcode, True, 0);
+    }
+    /* Generate regular key press and release */
+    XTestFakeKeyEvent (disp, keycode, True, 0);
+    XTestFakeKeyEvent (disp, keycode, False, 0);
+
+    /* Generate modkey release */
+    if (modifierSymbol != 0) {
+        XTestFakeKeyEvent (disp, modcode, False, 0);
+    }
+
+    XSync (disp, False);
+    XTestGrabControl (disp, False);
+
+    XCloseDisplay(disp);
+}
+
+void sendKeyboardInput( QString input )
+{
+    // noop
+    UNREFERENCED_PARAMETER( input );
+}
+
+void sendKeyboardEnter()
+{
+    // noop
+}
+
+void sendKeyboardBackspace( const int count )
+{
+    // noop
+    UNREFERENCED_PARAMETER( count );
+}
+
+void sendKeyboardAltTab()
+{
+    // noop
+}
+
+void sendKeyboardAltEnter()
+{
+    // noop
+}
+
+void sendMediaNextSong()
+{
+    // noop
+}
+
+void sendMediaPreviousSong()
+{
+    // noop
+}
+
+void sendMediaPausePlay()
+{
+    // noop
+}
+
+void sendMediaStopSong()
+{
+    // noop
+}
+
+} // namespace keyboardinput

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -10,8 +10,8 @@
 
 namespace keyboardinput
 {
-static void sendKeyPressAndRelease( const KeySym keySymbol,
-                                    const KeySym modifierSymbol )
+constexpr auto noModifier = 0;
+void sendKeyPress( const KeySym keySymbol, const KeySym modifierSymbol )
 {
     Display* const display = XOpenDisplay( nullptr );
 
@@ -50,23 +50,25 @@ void sendKeyboardInput( QString input )
 
 void sendKeyboardEnter()
 {
-    // noop
+    sendKeyPress( XK_ISO_Enter, noModifier );
 }
 
 void sendKeyboardBackspace( const int count )
 {
-    // noop
-    UNREFERENCED_PARAMETER( count );
+    for ( int i = 0; i < count; ++i )
+    {
+        sendKeyPress( XK_BackSpace, noModifier );
+    }
 }
 
 void sendKeyboardAltTab()
 {
-    sendKeyPressAndRelease( XK_Tab, XK_Alt_L );
+    sendKeyPress( XK_Tab, XK_Alt_L );
 }
 
 void sendKeyboardAltEnter()
 {
-    // noop
+    sendKeyPress( XK_ISO_Enter, XK_Alt_L );
 }
 
 void sendMediaNextSong()

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -10,38 +10,36 @@
 
 namespace keyboardinput
 {
-static void sendKeyPressAndRelease (const KeySym keySymbol, const KeySym modifierSymbol){
-    Display *disp = XOpenDisplay (NULL);
+static void sendKeyPressAndRelease( const KeySym keySymbol,
+                                    const KeySym modifierSymbol )
+{
+    Display* const display = XOpenDisplay( nullptr );
 
-    KeyCode keycode = 0;
-    keycode = XKeysymToKeycode (disp, keySymbol);
-
-    KeyCode modcode = 0;
-
-    if (keycode == 0) {
+    const KeyCode keycode = XKeysymToKeycode( display, keySymbol );
+    if ( keycode == 0 )
+    {
         return;
     }
 
-    XTestGrabControl (disp, True);
+    XTestGrabControl( display, True );
 
-    /* Generate modkey press */
-    if (modifierSymbol != 0) {
-        modcode = XKeysymToKeycode(disp, modsym);
-        XTestFakeKeyEvent (disp, modcode, True, 0);
-    }
-    /* Generate regular key press and release */
-    XTestFakeKeyEvent (disp, keycode, True, 0);
-    XTestFakeKeyEvent (disp, keycode, False, 0);
-
-    /* Generate modkey release */
-    if (modifierSymbol != 0) {
-        XTestFakeKeyEvent (disp, modcode, False, 0);
+    KeyCode modcode = 0;
+    if ( modifierSymbol != 0 )
+    {
+        modcode = XKeysymToKeycode( display, modifierSymbol );
+        XTestFakeKeyEvent( display, modcode, True, 0 );
     }
 
-    XSync (disp, False);
-    XTestGrabControl (disp, False);
+    XTestFakeKeyEvent( display, keycode, True, 0 );
+    XTestFakeKeyEvent( display, keycode, False, 0 );
 
-    XCloseDisplay(disp);
+    if ( modifierSymbol != 0 )
+    {
+        XTestFakeKeyEvent( display, modcode, False, 0 );
+    }
+
+    XSync( display, False );
+    XTestGrabControl( display, False );
 }
 
 void sendKeyboardInput( QString input )
@@ -63,7 +61,7 @@ void sendKeyboardBackspace( const int count )
 
 void sendKeyboardAltTab()
 {
-    // noop
+    sendKeyPressAndRelease( XK_Tab, XK_Alt_L );
 }
 
 void sendKeyboardAltEnter()

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -71,6 +71,16 @@ void sendKeyboardAltEnter()
     sendKeyPress( XK_Return, XK_Alt_L );
 }
 
+void sendKeyboardCtrlC()
+{
+    sendKeyPress( XK_c, XK_Control_L );
+}
+
+void sendKeyboardCtrlV()
+{
+    sendKeyPress( XK_v, XK_Control_L );
+}
+
 void sendMediaNextSong()
 {
     // noop

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -50,7 +50,7 @@ void sendKeyboardInput( QString input )
 
 void sendKeyboardEnter()
 {
-    sendKeyPress( XK_ISO_Enter, noModifier );
+    sendKeyPress( XK_Return, noModifier );
 }
 
 void sendKeyboardBackspace( const int count )
@@ -68,7 +68,7 @@ void sendKeyboardAltTab()
 
 void sendKeyboardAltEnter()
 {
-    sendKeyPress( XK_ISO_Enter, XK_Alt_L );
+    sendKeyPress( XK_Return, XK_Alt_L );
 }
 
 void sendMediaNextSong()

--- a/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
+++ b/src/tabcontrollers/keyboardinput/KeyboardInputX11.cpp
@@ -3,10 +3,7 @@
 #include <X11/Intrinsic.h>
 #include <X11/extensions/XTest.h>
 #include <unistd.h>
-
-// Used to get the compiler to shut up about C4100: unreferenced formal
-// parameter. The cast is to get GCC to shut up about it.
-#define UNREFERENCED_PARAMETER( P ) static_cast<void>( ( P ) )
+#include <array>
 
 namespace keyboardinput
 {
@@ -44,8 +41,16 @@ void sendKeyPress( const KeySym keySymbol, const KeySym modifierSymbol )
 
 void sendKeyboardInput( QString input )
 {
-    // noop
-    UNREFERENCED_PARAMETER( input );
+    std::vector<char> characters = { 0 };
+    for ( const auto& character : input )
+    {
+        characters.push_back( character.toLatin1() );
+    }
+
+    for ( const auto character : characters )
+    {
+        sendKeyPress( XStringToKeysym( &character ), noModifier );
+    }
 }
 
 void sendKeyboardEnter()


### PR DESCRIPTION
## This PR:
* Adds all KeyboardManager functions for Linux except for the media keys which are probably going to be implemented with [DBUS](https://doc.qt.io/qt-5/qtdbus-index.html) instead of as literal keyboard keys. Progresses #43 with `Send regular keystrokes`.
* Updates hardcoded `g++` version to any at or above version 7. Previously it would only use `g++-7`. Newer versions of Ubuntu ship with `>7`.
* Makes the Linux executable look in the current directory for libraries. This means it is unnecessary to use `LD_LIBRARY_PATH`.
* Updates build script to make Qt Creator `#include`s work correctly on Linux.
* Updates documentation for building on Ubuntu 19.04.

## Noteworthy Items:
* The implementation for sending user defined strings as keyboard keys is very shoddily implemented. Currently it only supports the [Latin1 (ASCII)](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) character set like the Windows version. I have considered writing a platform independent string parser that would handle more locales as part of the work on #138.