### PR TITLE
Add Linux support for Media Keys with DBUS

### DIFF
--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -21,3 +21,6 @@ fi
 if [[ -n $NO_X11 ]]; then
     QMAKE_EXTRAS='CONFIG+=noX11'
 fi
+if [[ -n $NO_DBUS ]]; then
+    QMAKE_EXTRAS='CONFIG+=noDBUS'
+fi

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -68,8 +68,15 @@ unix:!macx {
         SOURCES += src/keyboard_input/input_sender_dummy.cpp
     }
 
-    SOURCES += src/tabcontrollers/audiomanager/AudioManagerDummy.cpp \
-                src/media_keys/media_keys_dummy.cpp
+    !noDBUS {
+        SOURCES += src/media_keys/media_keys_dbus.cpp
+        QT += dbus
+    }
+    else {
+        SOURCES += src/media_keys/media_keys_dummy.cpp
+    }
+
+    SOURCES += src/tabcontrollers/audiomanager/AudioManagerDummy.cpp
     HEADERS += src/tabcontrollers/audiomanager/AudioManagerDummy.h
 }
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -6,6 +6,7 @@
   * [Unofficial Ubuntu Packages](#unofficial-ubuntu-packages)
   * [`qtchooser` and versions](#-qtchooser--and-versions)
   * [X11](#x11)
+  * [DBUS](#dbus)
   * [`clang-tidy` and `bear`](#-clang-tidy--and--bear-)
 - [TL;DR: for Ubuntu](#tl-dr--for-ubuntu)
   * [Ubuntu 16.04 Xenial](#ubuntu-1604-xenial)
@@ -100,7 +101,11 @@ Afterwards you should set the `QT_SELECT` environment variable to the name you c
 
 ## X11
 
-X11 packages are currently needed for sending keystrokes to the desktop from VR. Install the packages with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`. This feature will be gated behind a compile flag soon.
+X11 packages are currently needed for sending keystrokes to the desktop from VR. Install the packages with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`. 
+
+## DBUS
+
+DBUS is  needed for controlling media players from VR. 
 
 ## `clang-tidy` and `bear`
 
@@ -160,6 +165,7 @@ The following environmental variables are relevant for building the project.
 | `QMAKE_SPEC`              | The [mkspec](https://forum.qt.io/topic/70970/what-is-mkspecs-used-for-how-to-configure-for-my-hardware) to compile to. Either `linux-g++` or `linux-clang`. Defaults to `linux-g++`.   |
 | `USE_TIDY`              | If set a compilation database will be created and the project linted. Can only be used with `clang`.  |
 | `NO_X11`              | If set the application will be compiled without X11 specific libraries. This disables certain things like sending keystrokes from VR.  |
+| `NO_DBUS`              | If set the application will be compiled without DBUS specific functionality. This disables certain things like media keys.  |
 
 If an environment variable isn't set a default value will be provided. The default values are shown in the table below.
 

--- a/src/media_keys/media_keys.h
+++ b/src/media_keys/media_keys.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <easylogging++.h>
 #include <vector>
 #include <QString>
 

--- a/src/media_keys/media_keys_dbus.cpp
+++ b/src/media_keys/media_keys_dbus.cpp
@@ -1,0 +1,59 @@
+#include "media_keys.h"
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
+#include <QtCore/QStringList>
+#include <QtDBus/QtDBus>
+
+namespace keyboardinput
+{
+void callMethodForAllMediaPlayerAvailableServices( const QString& method )
+{
+    if ( !QDBusConnection::sessionBus().isConnected() )
+    {
+        LOG( ERROR ) << "Media Keys: Unable to connect to DBUS session bus.";
+        return;
+    }
+
+    QDBusReply<QStringList> names
+        = QDBusConnection::sessionBus().interface()->registeredServiceNames();
+    if ( !names.isValid() )
+    {
+        LOG( ERROR )
+            << "Media Keys: Error getting DBUS registered service names:";
+        LOG( ERROR ) << names.error().message();
+    }
+
+    foreach ( QString name, names.value() )
+    {
+        if ( name.contains( "org.mpris.MediaPlayer2" ) )
+        {
+            QDBusInterface iface( name,
+                                  "/org/mpris/MediaPlayer2",
+                                  "org.mpris.MediaPlayer2.Player",
+                                  QDBusConnection::sessionBus() );
+            iface.call( method );
+        }
+    }
+}
+
+void sendMediaNextSong()
+{
+    callMethodForAllMediaPlayerAvailableServices( "Next" );
+}
+
+void sendMediaPreviousSong()
+{
+    callMethodForAllMediaPlayerAvailableServices( "Previous" );
+}
+
+void sendMediaPausePlay()
+{
+    callMethodForAllMediaPlayerAvailableServices( "PlayPause" );
+}
+
+void sendMediaStopSong()
+{
+    callMethodForAllMediaPlayerAvailableServices( "Stop" );
+}
+
+} // namespace keyboardinput


### PR DESCRIPTION
## This PR:

* Enables all media keys for use on applications that support DBUS with the MediaPlayer2 interface.
* Partially solves #43.

## Considerations:

* The Windows media keys implicitly make every media player perform the required function, there is no way to only target one specific application. The Linux version replicates this, even though finer controls are possible.
* It is also possible to have two way communication between media players and Advanced Settings on Linux. This could be used for displaying currently playing song or other metadata. This does not seem available on Windows in a standardized way.

## Other:

* Tested on Ubuntu 19.04 (header and cpp file in separate application, not tested from VR with Advanced Settings).