### PR TITLE
Fix Linux Keyboard Input not working

### DIFF
--- a/src/keyboard_input/input_parser.cpp
+++ b/src/keyboard_input/input_parser.cpp
@@ -372,6 +372,27 @@ bool isLiteralKey( const Token token ) noexcept
     case Token::KEY_z:
         return true;
 
+    case Token::KEY_0:
+        return true;
+    case Token::KEY_1:
+        return true;
+    case Token::KEY_2:
+        return true;
+    case Token::KEY_3:
+        return true;
+    case Token::KEY_4:
+        return true;
+    case Token::KEY_5:
+        return true;
+    case Token::KEY_6:
+        return true;
+    case Token::KEY_7:
+        return true;
+    case Token::KEY_8:
+        return true;
+    case Token::KEY_9:
+        return true;
+
     default:
         return false;
     }

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -170,11 +170,6 @@ void sendKeyPress( const Token token,
         keyDown = true;
     }
 
-    LOG( INFO ) << "Pressing key:";
-    LOG( INFO ) << static_cast<int>( token );
-    LOG( INFO ) << "Status:";
-    LOG( INFO ) << static_cast<int>( status );
-
     XTestFakeKeyEvent( display,
                        XKeysymToKeycode( display, tokenToKeySym( token ) ),
                        keyDown,

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -3,7 +3,7 @@
 #include <X11/Intrinsic.h>
 #include <X11/extensions/XTest.h>
 
-unsigned int tokenToKeyCode( const Token token )
+unsigned int tokenToKeySym( const Token token )
 {
     switch ( token )
     {
@@ -175,7 +175,10 @@ void sendKeyPress( const Token token,
     LOG( INFO ) << "Status:";
     LOG( INFO ) << static_cast<int>( status );
 
-    XTestFakeKeyEvent( display, tokenToKeyCode( token ), keyDown, 0 );
+    XTestFakeKeyEvent( display,
+                       XKeysymToKeycode( display, tokenToKeySym( token ) ),
+                       keyDown,
+                       0 );
 }
 
 void sendTokensAsInput( const std::vector<Token> tokens )

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -5,13 +5,82 @@
 
 unsigned int tokenToKeyCode( const Token token, Display* const display )
 {
-    if ( isLiteralKey( token ) )
-    {
-        return XKeysymToKeycode( display, static_cast<KeySym>( token ) );
-    }
-
     switch ( token )
     {
+    case Token::KEY_a:
+        return XK_a;
+    case Token::KEY_b:
+        return XK_b;
+    case Token::KEY_c:
+        return XK_c;
+    case Token::KEY_d:
+        return XK_d;
+    case Token::KEY_e:
+        return XK_e;
+    case Token::KEY_f:
+        return XK_f;
+    case Token::KEY_g:
+        return XK_g;
+    case Token::KEY_h:
+        return XK_h;
+    case Token::KEY_i:
+        return XK_i;
+    case Token::KEY_j:
+        return XK_j;
+    case Token::KEY_k:
+        return XK_k;
+    case Token::KEY_l:
+        return XK_l;
+    case Token::KEY_m:
+        return XK_m;
+    case Token::KEY_n:
+        return XK_n;
+    case Token::KEY_o:
+        return XK_o;
+    case Token::KEY_p:
+        return XK_p;
+    case Token::KEY_q:
+        return XK_q;
+    case Token::KEY_r:
+        return XK_r;
+    case Token::KEY_s:
+        return XK_s;
+    case Token::KEY_t:
+        return XK_t;
+    case Token::KEY_u:
+        return XK_u;
+    case Token::KEY_v:
+        return XK_v;
+    case Token::KEY_w:
+        return XK_w;
+    case Token::KEY_x:
+        return XK_x;
+    case Token::KEY_y:
+        return XK_y;
+    case Token::KEY_z:
+        return XK_z;
+
+    case Token::KEY_0:
+        return XK_0;
+    case Token::KEY_1:
+        return XK_1;
+    case Token::KEY_2:
+        return XK_2;
+    case Token::KEY_3:
+        return XK_3;
+    case Token::KEY_4:
+        return XK_4;
+    case Token::KEY_5:
+        return XK_5;
+    case Token::KEY_6:
+        return XK_6;
+    case Token::KEY_7:
+        return XK_7;
+    case Token::KEY_8:
+        return XK_8;
+    case Token::KEY_9:
+        return XK_9;
+
     case Token::KEY_F1:
         return XK_F1;
     case Token::KEY_F2:

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -101,6 +101,11 @@ void sendKeyPress( const Token token,
         keyDown = true;
     }
 
+    LOG( INFO ) << "Pressing key:";
+    LOG( INFO ) << token;
+    LOG( INFO ) << "Status:";
+    LOG( INFO ) << status;
+
     XTestFakeKeyEvent( display, tokenToKeyCode( token, display ), keyDown, 0 );
 }
 

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -120,6 +120,7 @@ void sendTokensAsInput( const std::vector<Token> tokens )
         if ( isModifier( token ) )
         {
             sendKeyPress( token, KeyStatus::Down, display );
+            heldInputs.push_back( token );
             continue;
         }
 

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -102,9 +102,9 @@ void sendKeyPress( const Token token,
     }
 
     LOG( INFO ) << "Pressing key:";
-    LOG( INFO ) << token;
+    LOG( INFO ) << static_cast<int>( token );
     LOG( INFO ) << "Status:";
-    LOG( INFO ) << status;
+    LOG( INFO ) << static_cast<int>( status );
 
     XTestFakeKeyEvent( display, tokenToKeyCode( token, display ), keyDown, 0 );
 }

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -3,7 +3,7 @@
 #include <X11/Intrinsic.h>
 #include <X11/extensions/XTest.h>
 
-unsigned int tokenToKeyCode( const Token token, Display* const display )
+unsigned int tokenToKeyCode( const Token token )
 {
     switch ( token )
     {
@@ -175,7 +175,7 @@ void sendKeyPress( const Token token,
     LOG( INFO ) << "Status:";
     LOG( INFO ) << static_cast<int>( status );
 
-    XTestFakeKeyEvent( display, tokenToKeyCode( token, display ), keyDown, 0 );
+    XTestFakeKeyEvent( display, tokenToKeyCode( token ), keyDown, 0 );
 }
 
 void sendTokensAsInput( const std::vector<Token> tokens )


### PR DESCRIPTION
Keys were erroneously being sent as `KeySym`s instead of `KeyCode`s.

Additionally, held modifiers also weren't released correctly and numbers were not treated correctly on all platforms.