### PR TITLE
Add CircleCI support for Linux, update Linux build process and docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,14 @@
-version: 2
+workflows:
+    version: 2
+    gcc_1:
+        jobs:
+          - gcc
+    clang_1:
+        jobs:
+          - clang
+
 jobs:
-    build:
+    gcc:
         docker:
             - image: "ubuntu:xenial"
         steps:
@@ -47,4 +55,53 @@ jobs:
             - run:
                 name: Run build script
                 command: './build_scripts/linux/build_linux.sh'
-
+    clang:
+        docker:
+            - image: circleci/buildpack-deps:xenial
+        steps:
+            - checkout
+            - run:
+                name: Set up env vars
+                command: echo 'export QMAKE_SPEC=linux-clang' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
+            - run:
+                name: Update and upgrade
+                command: 'sudo apt-get update && sudo apt-get upgrade -y'
+            - run:
+                name: Get wget
+                command: 'sudo  apt-get install wget -y; sudo  apt-get install software-properties-common -y'
+            - run:
+                name: Prereqs for clang-format-8
+                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo  apt-key add -; sudo  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+            - run:
+                name: Installing clang-format-8
+                command: ' sudo apt update -qq;  sudo apt install clang-format-8 -y; sudo clang-format-8 --version;'
+            - run:
+                name: Installing clang-8
+                command: 'sudo apt install clang-8 -y; sudo apt install clang -y; clang++ --version;'
+            - run:
+                name: Run clang-format
+                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
+            - run:
+                name: Install g++-7
+                command: sudo apt-get install -y software-properties-common; sudo add-apt-repository ppa:ubuntu-toolchain-r/test; sudo apt update; sudo apt install g++-7 -y;
+            - run:
+                name: Install required packages
+                command: 'sudo  add-apt-repository ppa:kubuntu-ppa/backports -y;  sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  sudo apt-get update -qq;  sudo apt-get install build-essential libgl1-mesa-dev -y'
+            - run:
+                name: Install QT packages
+                command: 'sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
+            - run:
+                name: Install X11 packages
+                command: ' sudo apt-get install libx11-dev libxt-dev libxtst-dev -y'
+            - run:
+                name: Install bear/clang-tidy
+                command: ' sudo apt-get install bear clang-tidy -y'
+            - run:
+                name: Set up QT
+                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
+            - run:
+                name: Give build scripts +x
+                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
+            - run:
+                name: Run build script
+                command: './build_scripts/linux/build_linux.sh'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
             QMAKE_SPEC: linux-clang
             QT_SELECT: opt-qt512
             USE_TIDY: TRUE
+            CLANG_TIDY_EXECUTABLE: clang-tidy-7
             MAKE_JOBS: 2
         docker:
             - image: "ubuntu:xenial"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ workflows:
     clang_1:
         jobs:
           - clang
+    clang_tidy:
+        jobs:
+          - clang-tidy
 
 jobs:
     gcc:
@@ -63,6 +66,56 @@ jobs:
             - run:
                 name: Set up env vars
                 command: echo 'export QMAKE_SPEC=linux-clang' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
+            - run:
+                name: Update and upgrade
+                command: 'sudo apt-get update && sudo apt-get upgrade -y'
+            - run:
+                name: Get wget
+                command: 'sudo  apt-get install wget -y; sudo  apt-get install software-properties-common -y'
+            - run:
+                name: Prereqs for clang-format-8
+                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo  apt-key add -; sudo  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+            - run:
+                name: Installing clang-format-8
+                command: ' sudo apt update -qq;  sudo apt install clang-format-8 -y; sudo clang-format-8 --version;'
+            - run:
+                name: Installing clang-8
+                command: 'sudo apt install clang-8 -y; sudo apt install clang -y; clang++ --version;'
+            - run:
+                name: Run clang-format
+                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
+            - run:
+                name: Install g++-7
+                command: sudo apt-get install -y software-properties-common; sudo add-apt-repository ppa:ubuntu-toolchain-r/test; sudo apt update; sudo apt install g++-7 -y;
+            - run:
+                name: Install required packages
+                command: 'sudo  add-apt-repository ppa:kubuntu-ppa/backports -y;  sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  sudo apt-get update -qq;  sudo apt-get install build-essential libgl1-mesa-dev -y'
+            - run:
+                name: Install QT packages
+                command: 'sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
+            - run:
+                name: Install X11 packages
+                command: ' sudo apt-get install libx11-dev libxt-dev libxtst-dev -y'
+            - run:
+                name: Install bear/clang-tidy
+                command: ' sudo apt-get install bear clang-tidy -y'
+            - run:
+                name: Set up QT
+                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
+            - run:
+                name: Give build scripts +x
+                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
+            - run:
+                name: Run build script
+                command: './build_scripts/linux/build_linux.sh'
+    clang-tidy:
+        docker:
+            - image: circleci/buildpack-deps:xenial
+        steps:
+            - checkout
+            - run:
+                name: Set up env vars
+                command: echo 'export USE_TIDY=TRUE' >> $BASH_ENV; echo 'export QMAKE_SPEC=linux-clang' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
             - run:
                 name: Update and upgrade
                 command: 'sudo apt-get update && sudo apt-get upgrade -y'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,151 +10,94 @@ workflows:
         jobs:
           - clang-tidy
 
+update_and_install_prereqs: &update_and_install_prereqs
+    - checkout
+    - run: apt-get update &&  apt-get upgrade -y
+    - run:
+        name: Get wget and apt-key
+        command: |
+            apt-get install wget -y
+            apt-get install software-properties-common -y
+    - run:
+        name: Set up LLVM-8 repo
+        command: |
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -
+            add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+            add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
+            apt update -qq
+    - run:
+        name: Install LLVM-8 binaries
+        command: |
+            apt install clang-format-8 -y
+            apt install clang-tidy-7 -y
+            apt install clang-8 -y
+            apt install clang -y
+    - run:
+        name: Run clang-format
+        command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
+    - run:
+        name: Install g++-7
+        command: |
+            add-apt-repository ppa:ubuntu-toolchain-r/test
+            apt update
+            apt install g++-7 -y
+    - run:
+        name: Add required QT repos
+        command: |
+            add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
+            apt-get update -qq
+    - run: apt-get install build-essential libgl1-mesa-dev -y
+    - run:
+        name: Install QT packages
+        command: |
+            apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y
+    - run:
+        name: Install X11 packages
+        command: apt-get install libx11-dev libxt-dev libxtst-dev -y
+    - run:
+        name: Install bear/clang-tidy
+        command: apt-get install bear clang-tidy -y
+    - run:
+        name: Set up qtchooser
+        command: qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+    - run:
+        name: Give build scripts +x
+        command: |
+            chmod +x ./build_scripts/linux/build_linux.sh
+            chmod +x ./build_scripts/linux/format.sh
+            chmod +x ./build_scripts/linux/run-clang-tidy.sh
+            chmod +x ./build_scripts/linux/verify_formatting.sh
+    - run: clang --version
+    - run:
+        name: Run build script
+        command: ./build_scripts/linux/build_linux.sh
+
 jobs:
+       
     gcc:
+        environment:
+            QMAKE_SPEC: linux-g++
+            QT_SELECT: opt-qt512
+            MAKE_JOBS: 2
         docker:
             - image: "ubuntu:xenial"
-        steps:
-            - checkout
-            - run:
-                name: Set up env vars
-                command: echo 'export QMAKE_SPEC=linux-g++' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
-            - run:
-                name: Update and upgrade
-                command: ' apt-get update &&  apt-get upgrade -y'
-            - run:
-                name: Get wget
-                command: ' apt-get install wget -y;  apt-get install software-properties-common -y'
-            - run:
-                name: Prereqs for clang-format-8
-                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -;  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            - run:
-                name: Installing clang-format-8
-                command: ' apt update -qq;  apt install clang-format-8 -y; clang-format-8 --version;'
-            - run:
-                name: Run clang-format
-                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
-            - run:
-                name: Install g++-7
-                command: apt-get install -y software-properties-common; add-apt-repository ppa:ubuntu-toolchain-r/test; apt update; apt install g++-7 -y;
-            - run:
-                name: Install required packages
-                command: ' add-apt-repository ppa:kubuntu-ppa/backports -y;  add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  apt-get update -qq;  apt-get install build-essential libgl1-mesa-dev -y'
-            - run:
-                name: Install QT packages
-                command: ' apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
-            - run:
-                name: Install X11 packages
-                command: ' apt-get install libx11-dev libxt-dev libxtst-dev -y'
-            - run:
-                name: Install bear/clang-tidy
-                command: ' apt-get install bear clang-tidy -y'
-            - run:
-                name: Set up QT
-                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
-            - run:
-                name: Give build scripts +x
-                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
-            - run:
-                name: Run build script
-                command: './build_scripts/linux/build_linux.sh'
+        steps: *update_and_install_prereqs
+
     clang:
+        environment:
+            QMAKE_SPEC: linux-clang
+            QT_SELECT: opt-qt512
+            MAKE_JOBS: 2
         docker:
-            - image: circleci/buildpack-deps:xenial
-        steps:
-            - checkout
-            - run:
-                name: Set up env vars
-                command: echo 'export QMAKE_SPEC=linux-clang' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
-            - run:
-                name: Update and upgrade
-                command: 'sudo apt-get update && sudo apt-get upgrade -y'
-            - run:
-                name: Get wget
-                command: 'sudo  apt-get install wget -y; sudo  apt-get install software-properties-common -y'
-            - run:
-                name: Prereqs for clang-format-8
-                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo  apt-key add -; sudo  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            - run:
-                name: Installing clang-format-8
-                command: ' sudo apt update -qq;  sudo apt install clang-format-8 -y; sudo clang-format-8 --version;'
-            - run:
-                name: Installing clang-8
-                command: 'sudo apt install clang-8 -y; sudo apt install clang -y; clang++ --version;'
-            - run:
-                name: Run clang-format
-                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
-            - run:
-                name: Install g++-7
-                command: sudo apt-get install -y software-properties-common; sudo add-apt-repository ppa:ubuntu-toolchain-r/test; sudo apt update; sudo apt install g++-7 -y;
-            - run:
-                name: Install required packages
-                command: 'sudo  add-apt-repository ppa:kubuntu-ppa/backports -y;  sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  sudo apt-get update -qq;  sudo apt-get install build-essential libgl1-mesa-dev -y'
-            - run:
-                name: Install QT packages
-                command: 'sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
-            - run:
-                name: Install X11 packages
-                command: ' sudo apt-get install libx11-dev libxt-dev libxtst-dev -y'
-            - run:
-                name: Install bear/clang-tidy
-                command: ' sudo apt-get install bear clang-tidy -y'
-            - run:
-                name: Set up QT
-                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
-            - run:
-                name: Give build scripts +x
-                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
-            - run:
-                name: Run build script
-                command: './build_scripts/linux/build_linux.sh'
+            - image: "ubuntu:xenial"
+        steps: *update_and_install_prereqs
+            
     clang-tidy:
+        environment:
+            QMAKE_SPEC: linux-clang
+            QT_SELECT: opt-qt512
+            USE_TIDY: TRUE
+            MAKE_JOBS: 2
         docker:
-            - image: circleci/buildpack-deps:xenial
-        steps:
-            - checkout
-            - run:
-                name: Set up env vars
-                command: echo 'export USE_TIDY=TRUE' >> $BASH_ENV; echo 'export QMAKE_SPEC=linux-clang' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
-            - run:
-                name: Update and upgrade
-                command: 'sudo apt-get update && sudo apt-get upgrade -y'
-            - run:
-                name: Get wget
-                command: 'sudo  apt-get install wget -y; sudo  apt-get install software-properties-common -y'
-            - run:
-                name: Prereqs for clang-format-8
-                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo  apt-key add -; sudo  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            - run:
-                name: Installing clang-format-8
-                command: ' sudo apt update -qq;  sudo apt install clang-format-8 -y; sudo clang-format-8 --version;'
-            - run:
-                name: Installing clang-8
-                command: 'sudo apt install clang-8 -y; sudo apt install clang -y; clang++ --version;'
-            - run:
-                name: Run clang-format
-                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
-            - run:
-                name: Install g++-7
-                command: sudo apt-get install -y software-properties-common; sudo add-apt-repository ppa:ubuntu-toolchain-r/test; sudo apt update; sudo apt install g++-7 -y;
-            - run:
-                name: Install required packages
-                command: 'sudo  add-apt-repository ppa:kubuntu-ppa/backports -y;  sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  sudo apt-get update -qq;  sudo apt-get install build-essential libgl1-mesa-dev -y'
-            - run:
-                name: Install QT packages
-                command: 'sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
-            - run:
-                name: Install X11 packages
-                command: ' sudo apt-get install libx11-dev libxt-dev libxtst-dev -y'
-            - run:
-                name: Install bear/clang-tidy
-                command: ' sudo apt-get install bear clang-tidy -y'
-            - run:
-                name: Set up QT
-                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
-            - run:
-                name: Give build scripts +x
-                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
-            - run:
-                name: Run build script
-                command: './build_scripts/linux/build_linux.sh'
+            - image: "ubuntu:xenial"
+        steps: *update_and_install_prereqs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: "ubuntu:xenial"
+        steps:
+            - checkout
+            - run:
+                name: Set up env vars
+                command: echo 'export QMAKE_SPEC=linux-g++' >> $BASH_ENV; echo 'export QT_SELECT=opt-qt512' >> $BASH_ENV
+            - run:
+                name: Update and upgrade
+                command: ' apt-get update &&  apt-get upgrade -y'
+            - run:
+                name: Get wget
+                command: ' apt-get install wget -y;  apt-get install software-properties-common -y'
+            - run:
+                name: Prereqs for clang-format-8
+                command: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -;  add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+            - run:
+                name: Installing clang-format-8
+                command: ' apt update -qq;  apt install clang-format-8 -y; clang-format-8 --version;'
+            - run:
+                name: Run clang-format
+                command: 'python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8'
+            - run:
+                name: Install g++-7
+                command: apt-get install -y software-properties-common; add-apt-repository ppa:ubuntu-toolchain-r/test; apt update; apt install g++-7 -y;
+            - run:
+                name: Install required packages
+                command: ' add-apt-repository ppa:kubuntu-ppa/backports -y;  add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y;  apt-get update -qq;  apt-get install build-essential libgl1-mesa-dev -y'
+            - run:
+                name: Install QT packages
+                command: ' apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y'
+            - run:
+                name: Install X11 packages
+                command: ' apt-get install libx11-dev libxt-dev libxtst-dev -y'
+            - run:
+                name: Install bear/clang-tidy
+                command: ' apt-get install bear clang-tidy -y'
+            - run:
+                name: Set up QT
+                command: 'qtchooser -install opt-qt512 /opt/qt512/bin/qmake'
+            - run:
+                name: Give build scripts +x
+                command: 'chmod +x ./build_scripts/linux/build_linux.sh; chmod +x ./build_scripts/linux/format.sh; chmod +x ./build_scripts/linux/run-clang-tidy.sh ;chmod +x ./build_scripts/linux/verify_formatting.sh'
+            - run:
+                name: Run build script
+                command: './build_scripts/linux/build_linux.sh'
+

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -6,7 +6,7 @@ if [[ -z $QMAKE_SPEC ]]; then
 fi
 
 if [[ -z $USE_TIDY ]]; then
-    MAKE_COMMAND='make'
+    MAKE_COMMAND="make --jobs ${MAKE_JOBS}"
     CLANG_TIDY=
 else
     # Bear replaces the compile database, it does not update it.

--- a/build_scripts/linux/configure.sh
+++ b/build_scripts/linux/configure.sh
@@ -6,7 +6,7 @@ if [[ -z $QMAKE_SPEC ]]; then
 fi
 
 if [[ -z $USE_TIDY ]]; then
-    MAKE_COMMAND='make --jobs'
+    MAKE_COMMAND='make'
     CLANG_TIDY=
 else
     # Bear replaces the compile database, it does not update it.

--- a/build_scripts/linux/run-clang-tidy.sh
+++ b/build_scripts/linux/run-clang-tidy.sh
@@ -1,10 +1,10 @@
 set +e
-clang-tidy --version
+clang-tidy-7 --version
 
 ERROR=0
 for file in $(find ../src -name "*.cpp"); do
     echo $file
-    clang-tidy $file
+    clang-tidy-7 $file
 
     EXIT=$?
     if [[ $EXIT != 0 ]]; then

--- a/build_scripts/linux/run-clang-tidy.sh
+++ b/build_scripts/linux/run-clang-tidy.sh
@@ -1,10 +1,15 @@
 set +e
-clang-tidy-7 --version
+
+if [[ -z $CLANG_TIDY_EXECUTABLE ]]; then
+    CLANG_TIDY_EXECUTABLE='clang-tidy'
+fi
+
+$CLANG_TIDY_EXECUTABLE --version
 
 ERROR=0
 for file in $(find ../src -name "*.cpp"); do
     echo $file
-    clang-tidy-7 $file
+    $CLANG_TIDY_EXECUTABLE $file
 
     EXIT=$?
     if [[ $EXIT != 0 ]]; then

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -1,14 +1,36 @@
-# Makes sure the "clang++" command used to invoke the compilation is abvove version 8.
-# If it's at or above version 7 then we can use the default clang++ otherwise we'll
-# specifically need clang++-8.
-CLANG_VERSION = $$system("clang++ -dumpversion")
-!greaterThan(CLANG_VERSION, 7) {
-    message('clang++' version is not above 8. Manually using 'clang++-8'.)
-    !system(clang++-8 --version) {
-        error(At least clang++-8 required.)
+# comments are the value of CLANG_VERSION
+CLANG_VERSION = $$system("clang --version | grep 'clang version'")
+# clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
+CLANG_VERSION = $$split(CLANG_VERSION, ' ')
+# CLANG_VERSION is now a list, this is shown as spaces in QMAKE
+# clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
+CLANG_VERSION = $$member(CLANG_VERSION, 2)
+# 6.0.0-1ubuntu2
+CLANG_VERSION = $$split(CLANG_VERSION, '.')
+# 6 0 0-1ubuntu2
+CLANG_VERSION = $$member(CLANG_VERSION, 0)
+# 6
+
+greaterThan(CLANG_VERSION, 4) {
+    message('clang' version is above 4. Using regular clang.)
+}
+else {
+    system("clang-5 --version") {
+        QMAKE_CXX = clang-5
+        message('clang-5' found.)
     }
-    #clang++-8 is needed for C++17 features. travis does not supply this by default.
-    QMAKE_CXX = clang++-8
+    system("clang-6 --version") {
+        QMAKE_CXX = clang-6
+        message('clang-6' found.)
+    }
+    system("clang-7 --version") {
+        QMAKE_CXX = clang-7
+        message('clang-7' found.)
+    }
+    system("clang-8 --version") {
+        QMAKE_CXX = clang-8
+        message('clang-8' found.)
+    }
 }
 
 include(clang-gcc-common-switches.pri)

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -15,6 +15,7 @@ greaterThan(CLANG_VERSION, 4) {
     message('clang' version is above 4. Using regular clang.)
 }
 else {
+    message('clang' version is not above 4. Attempting to use highest specific version.)
     system("clang-5 --version") {
         QMAKE_CXX = clang-5
         message('clang-5' found.)

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -1,3 +1,16 @@
+# Makes sure the "clang++" command used to invoke the compilation is abvove version 8.
+# If it's at or above version 7 then we can use the default clang++ otherwise we'll
+# specifically need clang++-8.
+CLANG_VERSION = $$system("clang++ -dumpversion")
+!greaterThan(CLANG_VERSION, 7) {
+    message('clang++' version is not above 8. Manually using 'clang++-8'.)
+    !system(clang++-8 --version) {
+        error(At least clang++-8 required.)
+    }
+    #clang++-8 is needed for C++17 features. travis does not supply this by default.
+    QMAKE_CXX = clang++-8
+}
+
 include(clang-gcc-common-switches.pri)
 
 QMAKE_CXXFLAGS += -Wmost

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -1,14 +1,17 @@
-# Makes sure the "g++" command used to invoke the compilation is abvove version 7.
-# If it's at or above version 7 then we can use the default g++, otherwise we'll
-# specifically need g++-7.
 GCC_VERSION = $$system("g++ -dumpversion")
-!greaterThan(GCC_VERSION, 6) {
-    message('g++' version is not above 7. Manually using 'g++-7'.)
-    !system(g++-7 --version) {
-        error(At least g++-7 required.)
+greaterThan(GCC_VERSION, 6) {
+    message('g++' version is above 6. Using regular g++.)
+}
+else {
+    message('g++' version is not above 6. Attempting to use highest specific version.)
+    system(g++-7 --version) {
+        message('g++-7' found.)
+        QMAKE_CXX = g++-7
     }
-    #g++-7 is needed for C++17 features. travis does not supply this by default.
-    QMAKE_CXX = g++-7
+    system(g++-8 --version) {
+        message('g++-8' found.)
+        QMAKE_CXX = g++-8
+    }
 }
 
 include(clang-gcc-common-switches.pri)

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -166,6 +166,8 @@ The following environmental variables are relevant for building the project.
 | `NO_X11`              | If set the application will be compiled without X11 specific libraries. This disables certain things like sending keystrokes from VR.  |
 | `NO_DBUS`              | If set the application will be compiled without DBUS specific functionality. This disables certain things like media keys.  |
 | `MAKE_JOBS`              | Argument to `make --jobs`. Defaults to nothing (unlimited amount of jobs).  |
+| `CLANG_TIDY_EXECUTABLE`              | Name of the `clang-tidy` executable. Defaults to `clang-tidy`. Used for specifying a specific version or path, for example `clang-tidy-7`.  |
+
 
 # Building
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -132,7 +132,6 @@ export QT_SELECT=opt-qt512
 
 ## Ubuntu 18.04 Bionic
 ```bash
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-bionic
 sudo apt update
 sudo apt install g++-7
@@ -166,8 +165,7 @@ The following environmental variables are relevant for building the project.
 | `USE_TIDY`              | If set a compilation database will be created and the project linted. Can only be used with `clang`.  |
 | `NO_X11`              | If set the application will be compiled without X11 specific libraries. This disables certain things like sending keystrokes from VR.  |
 | `NO_DBUS`              | If set the application will be compiled without DBUS specific functionality. This disables certain things like media keys.  |
-
-If an environment variable isn't set a default value will be provided. The default values are shown in the table below.
+| `MAKE_JOBS`              | Argument to `make --jobs`. Defaults to nothing (unlimited amount of jobs).  |
 
 # Building
 


### PR DESCRIPTION
## This PR:
* Adds a config file for CircleCI.
* Updates the Linux build process to be more robust (more compiler versions supported).
* Updates documentation for building on Linux.

## Considerations:
* Travis and Circle are both running the same versions of software, however automatic updates to the image, ppas or other variables could produce different results.
* It is planned for Travis and CircleCI to both run during a transition period. This is to see if any inconsistencies pop up.

## Additional information:
* It has been [heavily](https://www.reddit.com/r/programming/comments/atjltu/layoffs_at_travis_ci_their_team_was_being/) speculated that Travis is taking a turn for the worse. CircleCI was recommended as a replacement.
* Travis does not currently allow us to have it create artifacts in the same way that our AppVeyor setup does, while CircleCI does. Changing to CircleCI is seen as necessary for shipping CI created binaries.