### PR TITLE
Add AppImage artifacts to CircleCI, add g++-9 detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ update_and_install_prereqs: &update_and_install_prereqs
     - run:
         name: Install QT packages
         command: |
-            apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y
+            apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
     - run:
         name: Install X11 packages
         command: apt-get install libx11-dev libxt-dev libxtst-dev -y
@@ -121,7 +121,8 @@ jobs:
             - run:
                 name: Install QT packages
                 command: |
-                    apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y
+                    apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
+            - run: ls -R /opt/qt512
             - run:
                 name: Install X11 packages
                 command: apt-get install libx11-dev libxt-dev libxtst-dev -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,62 +73,61 @@ update_and_install_prereqs: &update_and_install_prereqs
         command: ./build_scripts/linux/build_linux.sh
 
 jobs:
-       
     gcc:
         environment:
             QMAKE_SPEC: linux-g++
             QT_SELECT: opt-qt512
             MAKE_JOBS: 2
         docker:
-            - image: "ubuntu:xenial"
+            - image: circleci/buildpack-deps:xenial
         steps:
             - checkout
-            - run: apt-get update &&  apt-get upgrade -y
+            - run: sudo apt-get update && sudo apt-get upgrade -y
             - run:
                 name: Get wget and apt-key
                 command: |
-                    apt-get install wget -y
-                    apt-get install software-properties-common -y
+                    sudo apt-get install wget -y
+                    sudo apt-get install software-properties-common -y
             - run:
                 name: Set up LLVM-8 repo
                 command: |
-                    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -
-                    add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-                    add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-                    apt update -qq
+                    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+                    sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+                    sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
+                    sudo apt-get update -qq
             - run:
                 name: Install LLVM-8 binaries
                 command: |
-                    apt install clang-format-8 -y
-                    apt install clang-tidy-7 -y
-                    apt install clang-8 -y
-                    apt install clang -y
+                    sudo apt-get install clang-format-8 -y
+                    sudo apt-get install clang-tidy-7 -y
+                    sudo apt-get install clang-8 -y
+                    sudo apt-get install clang -y
             - run:
                 name: Run clang-format
                 command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
             - run:
                 name: Install g++-7
                 command: |
-                    add-apt-repository ppa:ubuntu-toolchain-r/test
-                    apt update
-                    apt install g++-7 -y
+                    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+                    sudo apt-get update
+                    sudo apt-get install g++-7 -y
             - run:
                 name: Add required QT repos
                 command: |
-                    add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
-                    apt-get update -qq
-            - run: apt-get install build-essential libgl1-mesa-dev -y
+                    sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
+                    sudo apt-get update -qq
+            - run: sudo apt-get install build-essential libgl1-mesa-dev -y
             - run:
                 name: Install QT packages
                 command: |
-                    apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
+                    sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
             - run: ls -R /opt/qt512
             - run:
                 name: Install X11 packages
-                command: apt-get install libx11-dev libxt-dev libxtst-dev -y
+                command: sudo apt-get install libx11-dev libxt-dev libxtst-dev -y
             - run:
                 name: Install bear/clang-tidy
-                command: apt-get install bear clang-tidy -y
+                command: sudo apt-get install bear clang-tidy -y
             - run:
                 name: Set up qtchooser
                 command: qtchooser -install opt-qt512 /opt/qt512/bin/qmake
@@ -139,6 +138,7 @@ jobs:
                     chmod +x ./build_scripts/linux/format.sh
                     chmod +x ./build_scripts/linux/run-clang-tidy.sh
                     chmod +x ./build_scripts/linux/verify_formatting.sh
+            - run: python ./build_scripts/append_to_version_file.py $(git rev-parse HEAD | cut -c -8)
             - run: clang --version
             - run:
                 name: Run build script
@@ -155,7 +155,7 @@ jobs:
                 name: Copy Artifacts
                 command: |
                     mkdir artifacts
-                    cp ./OpenVR_Advanced_Settings-*.AppImage ./artifacts/
+                    cp -v ./OpenVR_Advanced_Settings-*.AppImage ./artifacts/
             - store_artifacts:
                 path: ./artifacts/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,11 +105,11 @@ jobs:
                 name: Run clang-format
                 command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
             - run:
-                name: Install g++-7
+                name: Install g++
                 command: |
                     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
                     sudo apt-get update
-                    sudo apt-get install g++-7 -y
+                    sudo apt-get install g++-9 -y
             - run:
                 name: Add required QT repos
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ update_and_install_prereqs: &update_and_install_prereqs
             chmod +x ./build_scripts/linux/format.sh
             chmod +x ./build_scripts/linux/run-clang-tidy.sh
             chmod +x ./build_scripts/linux/verify_formatting.sh
-    - run: clang --version
     - run:
         name: Run build script
         command: ./build_scripts/linux/build_linux.sh
@@ -139,7 +138,6 @@ jobs:
                     chmod +x ./build_scripts/linux/run-clang-tidy.sh
                     chmod +x ./build_scripts/linux/verify_formatting.sh
             - run: python ./build_scripts/append_to_version_file.py $(git rev-parse HEAD | cut -c -8)
-            - run: clang --version
             - run:
                 name: Run build script
                 command: ./build_scripts/linux/build_linux.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,12 +83,12 @@ jobs:
             - checkout
             - run: sudo apt-get update && sudo apt-get upgrade -y
             - run:
-                name: Get wget and apt-key
+                name: Get apt-key
+                # Required for LLVM
                 command: |
-                    sudo apt-get install wget -y
                     sudo apt-get install software-properties-common -y
             - run:
-                name: Set up LLVM-8 repo
+                name: Get LLVM repos
                 command: |
                     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
                     sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
@@ -96,6 +96,8 @@ jobs:
                     sudo apt-get update -qq
             - run:
                 name: Install LLVM-8 binaries
+                # clang is required due to a check by Qmake.
+                # clang-tidy-8 has new errors compared to clang-tidy-7, so we haven't upgraded.
                 command: |
                     sudo apt-get install clang-format-8 -y
                     sudo apt-get install clang-tidy-7 -y
@@ -120,7 +122,6 @@ jobs:
                 name: Install QT packages
                 command: |
                     sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
-            - run: ls -R /opt/qt512
             - run:
                 name: Install X11 packages
                 command: sudo apt-get install libx11-dev libxt-dev libxtst-dev -y
@@ -137,7 +138,11 @@ jobs:
                     chmod +x ./build_scripts/linux/format.sh
                     chmod +x ./build_scripts/linux/run-clang-tidy.sh
                     chmod +x ./build_scripts/linux/verify_formatting.sh
-            - run: python ./build_scripts/append_to_version_file.py $(git rev-parse HEAD | cut -c -8)
+            - run:
+                name: Update version number
+                command: |
+                    python ./build_scripts/append_to_version_file.py $(git rev-parse HEAD | cut -c -8)
+                    cat ./build_scripts/compile_version_string.txt
             - run:
                 name: Run build script
                 command: ./build_scripts/linux/build_linux.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,82 @@ jobs:
             MAKE_JOBS: 2
         docker:
             - image: "ubuntu:xenial"
-        steps: *update_and_install_prereqs
+        steps:
+            - checkout
+            - run: apt-get update &&  apt-get upgrade -y
+            - run:
+                name: Get wget and apt-key
+                command: |
+                    apt-get install wget -y
+                    apt-get install software-properties-common -y
+            - run:
+                name: Set up LLVM-8 repo
+                command: |
+                    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -
+                    add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+                    add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
+                    apt update -qq
+            - run:
+                name: Install LLVM-8 binaries
+                command: |
+                    apt install clang-format-8 -y
+                    apt install clang-tidy-7 -y
+                    apt install clang-8 -y
+                    apt install clang -y
+            - run:
+                name: Run clang-format
+                command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
+            - run:
+                name: Install g++-7
+                command: |
+                    add-apt-repository ppa:ubuntu-toolchain-r/test
+                    apt update
+                    apt install g++-7 -y
+            - run:
+                name: Add required QT repos
+                command: |
+                    add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
+                    apt-get update -qq
+            - run: apt-get install build-essential libgl1-mesa-dev -y
+            - run:
+                name: Install QT packages
+                command: |
+                    apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base qtchooser -y
+            - run:
+                name: Install X11 packages
+                command: apt-get install libx11-dev libxt-dev libxtst-dev -y
+            - run:
+                name: Install bear/clang-tidy
+                command: apt-get install bear clang-tidy -y
+            - run:
+                name: Set up qtchooser
+                command: qtchooser -install opt-qt512 /opt/qt512/bin/qmake
+            - run:
+                name: Give build scripts +x
+                command: |
+                    chmod +x ./build_scripts/linux/build_linux.sh
+                    chmod +x ./build_scripts/linux/format.sh
+                    chmod +x ./build_scripts/linux/run-clang-tidy.sh
+                    chmod +x ./build_scripts/linux/verify_formatting.sh
+            - run: clang --version
+            - run:
+                name: Run build script
+                command: ./build_scripts/linux/build_linux.sh
+            - run:
+                name: Get qtdeploylinux
+                command: |
+                    wget -c -nv https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+                    chmod a+x ./linuxdeployqt-continuous-x86_64.AppImage
+            - run:
+                name: Create AppImage
+                command: ./build_scripts/linux/appimage.sh
+            - run:
+                name: Copy Artifacts
+                command: |
+                    mkdir artifacts
+                    cp ./OpenVR_Advanced_Settings-*.AppImage ./artifacts/
+            - store_artifacts:
+                path: ./artifacts/
 
     clang:
         environment:

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -33,4 +33,4 @@ qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -16,6 +16,11 @@ mkdir -p $EXE_DIR/usr/share/icons/hicolor
 mkdir -p $EXE_DIR/usr/share/icons/hicolor/256x256
 mkdir -p $EXE_DIR/usr/share/icons/hicolor/256x256/apps
 
+# https://github.com/probonopd/linuxdeployqt/issues/25
+# linuxdeployqt fails to deploy QtQuick/Dialogs and QtQuick/LocalStorage
+mkdir -p $EXE_DIR/usr/qml/QtQuick/Dialogs
+cp -r /opt/qt512/qml/QtQuick/Dialogs $EXE_DIR/usr/qml/QtQuick
+
 cp $EXE_DIR/AdvancedSettings $EXE_DIR/usr/bin
 cp -r $EXE_DIR/res $EXE_DIR/usr/bin
 cp -r $EXE_DIR/default_action_manifests $EXE_DIR/usr/bin

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -33,4 +33,4 @@ qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -unsupported-allow-new-glibc -appimage -verbose=2 -always-overwrite
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PROJECT_DIR=$SCRIPT_DIR/../../
 BUILD_DIR=$PROJECT_DIR/build/
@@ -19,23 +21,26 @@ mkdir -p $EXE_DIR/usr/share/icons/hicolor/256x256/apps
 # https://github.com/probonopd/linuxdeployqt/issues/25
 # linuxdeployqt fails to deploy QtQuick/Dialogs and QtQuick/LocalStorage
 mkdir -p $EXE_DIR/usr/qml/QtQuick/Dialogs
-cp -r /opt/qt512/qml/QtQuick/Dialogs $EXE_DIR/usr/qml/QtQuick
+cp -avr /opt/qt512/qml/QtQuick/Dialogs $EXE_DIR/usr/qml/QtQuick/
 
-cp $EXE_DIR/AdvancedSettings $EXE_DIR/usr/bin
-cp -r $EXE_DIR/res $EXE_DIR/usr/bin
-cp -r $EXE_DIR/default_action_manifests $EXE_DIR/usr/bin
-cp $EXE_DIR/action_manifest.json $EXE_DIR/usr/bin
-cp $EXE_DIR/libopenvr_api.so $EXE_DIR/usr/bin
-cp $EXE_DIR/manifest.vrmanifest $EXE_DIR/usr/bin
+# https://github.com/probonopd/linuxdeployqt/issues/82
+# linuxdeployqt fails to deploy plugins/imageformats/libqsvg.so
+mkdir -p $EXE_DIR/usr/plugins/imageformats
+cp -av /opt/qt512/plugins/imageformats/libqsvg.so $EXE_DIR/usr/plugins/imageformats/libqsvg.so
+
+mv $EXE_DIR/AdvancedSettings $EXE_DIR/usr/bin
+mv $EXE_DIR/res $EXE_DIR/usr/bin
+mv $EXE_DIR/default_action_manifests $EXE_DIR/usr/bin
+mv $EXE_DIR/action_manifest.json $EXE_DIR/usr/bin
+mv $EXE_DIR/libopenvr_api.so $EXE_DIR/usr/bin
+mv $EXE_DIR/manifest.vrmanifest $EXE_DIR/usr/bin
 
 cp $PROJECT_DIR/src/res/img/icons/thumbicon.png $EXE_DIR/usr/share/icons/hicolor/256x256/apps/AdvancedSettings.png
 
 cp $PROJECT_DIR/src/package_files/linux/AdvancedSettings.desktop $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
 
-#cp ~/.steam/bin32/libsteam.o $EXE_DIR/usr/lib
-
 qmake --version
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PROJECT_DIR=$SCRIPT_DIR/../../
+BUILD_DIR=$PROJECT_DIR/build/
+EXE_DIR=$BUILD_DIR/bin/linux/AdvancedSettings/
+
+#wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+#chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+mkdir -p $EXE_DIR/usr
+mkdir -p $EXE_DIR/usr/bin
+mkdir -p $EXE_DIR/usr/lib
+mkdir -p $EXE_DIR/usr/share
+mkdir -p $EXE_DIR/usr/share/applications
+mkdir -p $EXE_DIR/usr/share/icons
+mkdir -p $EXE_DIR/usr/share/icons/hicolor
+mkdir -p $EXE_DIR/usr/share/icons/hicolor/256x256
+mkdir -p $EXE_DIR/usr/share/icons/hicolor/256x256/apps
+
+cp $EXE_DIR/AdvancedSettings $EXE_DIR/usr/bin
+cp -r $EXE_DIR/res $EXE_DIR/usr/bin
+cp -r $EXE_DIR/default_action_manifests $EXE_DIR/usr/bin
+cp $EXE_DIR/action_manifest.json $EXE_DIR/usr/bin
+cp $EXE_DIR/libopenvr_api.so $EXE_DIR/usr/bin
+cp $EXE_DIR/manifest.vrmanifest $EXE_DIR/usr/bin
+
+cp $PROJECT_DIR/src/res/img/icons/thumbicon.png $EXE_DIR/usr/share/icons/hicolor/256x256/apps/AdvancedSettings.png
+
+cp $PROJECT_DIR/src/package_files/linux/AdvancedSettings.desktop $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
+
+#cp ~/.steam/bin32/libsteam.o $EXE_DIR/usr/lib
+
+qmake --version
+
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version
+
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -unsupported-allow-new-glibc -appimage -verbose=2 -always-overwrite

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -12,6 +12,10 @@ else {
         message('g++-8' found.)
         QMAKE_CXX = g++-8
     }
+    system(g++-9 --version) {
+        message('g++-9' found.)
+        QMAKE_CXX = g++-9
+    }
 }
 
 include(clang-gcc-common-switches.pri)

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -42,7 +42,7 @@ After installing using the official installer you will likely need to `qtchooser
 
 If you don't want to use the offical installer, you can use [this](https://launchpad.net/~beineri) PPA.
 
-You will need at least `qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base`, although if you have the drive space it's probably easier just to get `qt512-meta-full`.
+You will need at least `qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base`, although if you have the drive space it's probably easier just to get `qt512-meta-full`.
 
 For Ubuntu 16.04
 ```bash

--- a/src/package_files/linux/AdvancedSettings.desktop
+++ b/src/package_files/linux/AdvancedSettings.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=OpenVR Advanced Settings
+Comment=OVRAS
+Exec=AdvancedSettings
+Icon=AdvancedSettings
+Categories=Office;


### PR DESCRIPTION
## This PR:
* Makes CircleCI create AppImage executables using GCC.
* Adds a check for `g++-9` to Qmake.

## Considerations:
* The AppImage has only been fully tested as working on Ubuntu 19.04. Due to lack of testers it was not possible to test on more distros.
* The CircleCI config file is a mess right now. The GCC and Clang setups do basically the same thing but they're in separate lists because it's not possible in YAML to append to the build steps.