### PR TITLE
Implement "Add Left/Right Haptic Click" binds

### DIFF
--- a/src/openvr/ivrinput.cpp
+++ b/src/openvr/ivrinput.cpp
@@ -140,6 +140,8 @@ SteamIVRInput::SteamIVRInput()
       m_pushToTalk( action_keys::pushToTalk ),
       m_leftHaptic( action_keys::hapticsLeft ),
       m_rightHaptic( action_keys::hapticsRight ),
+      m_addLeftHapticClick( action_keys::addLeftHapticClick ),
+      m_addRightHapticClick( action_keys::addRightHapticClick ),
       m_proxSensor( action_keys::proxSensor ),
       m_leftHand( input_keys::leftHand ), m_rightHand( input_keys::rightHand ),
       m_sets( { m_mainSet.activeActionSet(),
@@ -315,6 +317,16 @@ bool SteamIVRInput::chaperoneToggle()
 bool SteamIVRInput::proxState()
 {
     return isDigitalActionActivatedConstant( m_proxSensor );
+}
+
+bool SteamIVRInput::addLeftHapticClick()
+{
+    return isDigitalActionActivatedConstant( m_addLeftHapticClick );
+}
+
+bool SteamIVRInput::addRightHapticClick()
+{
+    return isDigitalActionActivatedConstant( m_addRightHapticClick );
 }
 
 bool SteamIVRInput::keyboardOne()

--- a/src/openvr/ivrinput.h
+++ b/src/openvr/ivrinput.h
@@ -58,6 +58,9 @@ namespace action_keys
     constexpr auto hapticsLeft = "/actions/haptic/out/HapticsLeft";
     constexpr auto hapticsRight = "/actions/haptic/out/HapticsRight";
     constexpr auto proxSensor = "/actions/haptic/in/ProxSensor";
+    constexpr auto addLeftHapticClick = "/actions/haptic/in/AddLeftHapticClick";
+    constexpr auto addRightHapticClick
+        = "/actions/haptic/in/AddRightHapticClick";
 
     constexpr auto chaperoneToggle = "/actions/misc/in/ChaperoneToggle";
 
@@ -144,6 +147,8 @@ public:
     bool zAxisLockToggle();
     bool chaperoneToggle();
     bool proxState();
+    bool addLeftHapticClick();
+    bool addRightHapticClick();
 
     bool pushToTalk();
 
@@ -225,6 +230,8 @@ private:
     // haptic bindings
     DigitalAction m_leftHaptic;
     DigitalAction m_rightHaptic;
+    DigitalAction m_addLeftHapticClick;
+    DigitalAction m_addRightHapticClick;
 
     // prox Sensor
     DigitalAction m_proxSensor;

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -608,6 +608,10 @@ void OverlayController::processChaperoneBindings()
             !( m_chaperoneTabController.disableChaperone() ), true );
     }
     m_chaperoneTabController.setProxState( m_actions.proxState() );
+    m_chaperoneTabController.addLeftHapticClick(
+        m_actions.addLeftHapticClick() );
+    m_chaperoneTabController.addRightHapticClick(
+        m_actions.addRightHapticClick() );
 }
 
 void OverlayController::processPushToTalkBindings()

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -47,6 +47,16 @@
       "name": "/actions/haptic/out/HapticsRight",
       "type": "vibration"
     },
+    {
+      "name": "/actions/haptic/in/AddLeftHapticClick",
+      "requirement": "optional",
+      "type": "boolean"
+    },
+    {
+      "name": "/actions/haptic/in/AddRightHapticClick",
+      "requirement": "optional",
+      "type": "boolean"
+    },
     
     {
       "name": "/actions/motion/in/LeftHandSpaceTurn",
@@ -222,6 +232,8 @@
 
         "/actions/haptic/out/HapticsLeft" : "Haptics Left",
         "/actions/haptic/out/HapticsRight" : " Haptics Right",
+        "/actions/haptic/in/AddLeftHapticClick" : " Add Left Haptic Click",
+        "/actions/haptic/in/AddRightHapticClick" : " Add Right Haptic Click",
 		
         "/actions/motion/in/LeftHandSpaceTurn" : "Left Hand Space Turn",
         "/actions/motion/in/RightHandSpaceTurn" : "Right Hand Space Turn",

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -1740,6 +1740,62 @@ void ChaperoneTabController::setLeftInputHandle(
     m_leftInputHandle = handle;
 }
 
+void ChaperoneTabController::addLeftHapticClick( bool leftHapticClickPressed )
+{
+    // detect new press
+    if ( leftHapticClickPressed && !m_leftHapticClickActivated )
+    {
+        // play activation haptic sequence
+        vr::VRInput()->TriggerHapticVibrationAction(
+            m_leftActionHandle, 0.0f, 0.08f, 300.0f, 0.7f, m_leftInputHandle );
+        m_leftHapticClickActivated = true;
+        return;
+    }
+
+    // detect new release
+    if ( !leftHapticClickPressed && m_leftHapticClickActivated )
+    {
+        // play deactivation haptic sequence
+        vr::VRInput()->TriggerHapticVibrationAction(
+            m_leftActionHandle, 0.0f, 0.08f, 120.0f, 0.7f, m_leftInputHandle );
+
+        m_leftHapticClickActivated = false;
+        return;
+    }
+}
+
+void ChaperoneTabController::addRightHapticClick( bool rightHapticClickPressed )
+{
+    // detect new press
+    if ( rightHapticClickPressed && !m_rightHapticClickActivated )
+    {
+        // play activation haptic sequence
+        vr::VRInput()->TriggerHapticVibrationAction( m_rightActionHandle,
+                                                     0.0f,
+                                                     0.08f,
+                                                     300.0f,
+                                                     0.7f,
+                                                     m_rightInputHandle );
+        m_rightHapticClickActivated = true;
+        return;
+    }
+
+    // detect new release
+    if ( !rightHapticClickPressed && m_rightHapticClickActivated )
+    {
+        // play deactivation haptic sequence
+        vr::VRInput()->TriggerHapticVibrationAction( m_rightActionHandle,
+                                                     0.0f,
+                                                     0.08f,
+                                                     120.0f,
+                                                     0.7f,
+                                                     m_rightInputHandle );
+
+        m_rightHapticClickActivated = false;
+        return;
+    }
+}
+
 void ChaperoneTabController::setProxState( bool value )
 {
     if ( value )

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -177,6 +177,8 @@ private:
     bool m_isHMDActive = false;
     bool m_isProxActive = false;
     bool m_HMDHasProx = false;
+    bool m_leftHapticClickActivated = false;
+    bool m_rightHapticClickActivated = false;
 
     int m_updateTicksChaperoneReload = 0;
 
@@ -238,6 +240,10 @@ public:
     Q_INVOKABLE QString getChaperoneProfileName( unsigned index );
 
     float getBoundsMaxY();
+
+    // actions
+    void addLeftHapticClick( bool leftHapticClickPressed );
+    void addRightHapticClick( bool rightHapticClickPressed );
 
 public slots:
     void setBoundsVisibility( float value, bool notify = true );


### PR DESCRIPTION
Addresses #244. This adds two actions to the "Haptics" tab of Advanced Settings's steamvr input bindings. "Add Left Haptic Click" and "Add Right Haptic Click". This is intended to remedy the situation on index controllers where the joystick's physical click isn't always felt. It's intended to be bound to "Thumb Stick" use as "BUTTON", "click".

This action could be bound to any controller button to add haptic feedback as well. It will play a different haptic sequence on activation and deactivation of the button.