### PR TITLE
Reduce update rate of chaperone velocity modifiers

### DIFF
--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -574,27 +574,6 @@ void ChaperoneTabController::eventLoopTick(
     float rightSpeed,
     float hmdSpeed )
 {
-    m_chaperoneVelocityModifierCurrent = 1.0f;
-    if ( m_enableChaperoneVelocityModifier )
-    {
-        float mod = m_chaperoneVelocityModifier
-                    * std::max( { leftSpeed, rightSpeed, hmdSpeed } );
-        if ( mod > 0.02f )
-        {
-            m_chaperoneVelocityModifierCurrent += mod;
-        }
-    }
-    float newFadeDistance = m_fadeDistance * m_chaperoneVelocityModifierCurrent;
-    if ( m_fadeDistanceModified != newFadeDistance )
-    {
-        m_fadeDistanceModified = newFadeDistance;
-        vr::VRSettings()->SetFloat(
-            vr::k_pch_CollisionBounds_Section,
-            vr::k_pch_CollisionBounds_FadeDistance_Float,
-            m_fadeDistanceModified );
-        vr::VRSettings()->Sync();
-    }
-
     if ( devicePoses )
     {
         m_isHMDActive = false;
@@ -687,6 +666,28 @@ void ChaperoneTabController::eventLoopTick(
 
     if ( settingsUpdateCounter >= k_chaperoneSettingsUpdateCounter )
     {
+        m_chaperoneVelocityModifierCurrent = 1.0f;
+        if ( m_enableChaperoneVelocityModifier )
+        {
+            float mod = m_chaperoneVelocityModifier
+                        * std::max( { leftSpeed, rightSpeed, hmdSpeed } );
+            if ( mod > 0.02f )
+            {
+                m_chaperoneVelocityModifierCurrent += mod;
+            }
+        }
+        float newFadeDistance
+            = m_fadeDistance * m_chaperoneVelocityModifierCurrent;
+        if ( m_fadeDistanceModified != newFadeDistance )
+        {
+            m_fadeDistanceModified = newFadeDistance;
+            vr::VRSettings()->SetFloat(
+                vr::k_pch_CollisionBounds_Section,
+                vr::k_pch_CollisionBounds_FadeDistance_Float,
+                m_fadeDistanceModified );
+            vr::VRSettings()->Sync();
+        }
+
         if ( parent->isDashboardVisible() )
         {
             vr::EVRSettingsError vrSettingsError;


### PR DESCRIPTION
Having the application call Sync() every frame led to slowdowns on some 4 core CPUs and instant crashes on some older CPUs.

This makes the chaperone velocity modifier only update on every 101st frame. This might not be the ideal framerate, but having it update every frame makes the app crash on start for some users.

On Manjaro with a i7-6700K (4 cores) this led to instant crashes of SteamVR+Steam+OVRAS, with a SEGFAULT in SteamVR.
Issue here:
https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/252

Might also be related to the problem described in https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/255.

This should not be merged before the OP of #252 reports back as it having solved the issue. https://github.com/Zamundaaa @Zamundaaa