### PR TITLE
Add disable vsync and custom tickrate options

### DIFF
--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -72,12 +72,17 @@ constexpr int k_utilitiesSettingsUpdateCounter = 19;
 // k_nonVsyncTickRate determines number of ms we wait to force the next event
 // loop tick when vsync is too late due to dropped frames.
 constexpr int k_nonVsyncTickRate = 20;
+constexpr int k_maxCustomTickRate = 999;
 constexpr int k_hmdRotationCounterUpdateRate = 7;
 
 class OverlayController : public QObject
 {
     Q_OBJECT
     Q_PROPERTY( bool m_desktopMode READ isDesktopMode )
+    Q_PROPERTY( bool vsyncDisabled READ vsyncDisabled WRITE setVsyncDisabled
+                    NOTIFY vsyncDisabledChanged )
+    Q_PROPERTY( int customTickRateMs READ customTickRateMs WRITE
+                    setCustomTickRateMs NOTIFY customTickRateMsChanged )
 
 private:
     vr::VROverlayHandle_t m_ulOverlayHandle = vr::k_ulOverlayHandleInvalid;
@@ -99,6 +104,8 @@ private:
 
     bool m_desktopMode;
     bool m_noSound;
+    bool m_vsyncDisabled = false;
+    int m_customTickRateMs = 20;
 
     QUrl m_runtimePathUrl;
 
@@ -111,6 +118,7 @@ private:
     uint64_t m_currentFrame = 0;
     uint64_t m_lastFrame = 0;
     int m_vsyncTooLateCounter = 0;
+    int m_customTickRateCounter = 0;
 
     input::SteamIVRInput m_actions;
 
@@ -194,6 +202,9 @@ public:
                         vr::VREvent_t* pEvent );
     void mainEventLoop();
 
+    bool vsyncDisabled() const;
+    int customTickRateMs() const;
+
 public slots:
     void renderOverlay();
     void OnRenderRequest();
@@ -207,8 +218,13 @@ public slots:
     void setAlarm01SoundVolume( float vol );
     void cancelAlarm01Sound();
 
+    void setVsyncDisabled( bool value, bool notify = true );
+    void setCustomTickRateMs( int value, bool notify = true );
+
 signals:
     void keyBoardInputSignal( QString input, unsigned long userValue = 0 );
+    void vsyncDisabledChanged( bool value );
+    void customTickRateMsChanged( int value );
 
 private:
     static QSettings* _appSettings;

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -50,16 +50,78 @@ MyStackViewPage {
             }
         }
 
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            MyToggleButton {
+                id: vsyncDisabledToggle
+                text: "Disable App Vsync"
+                onCheckedChanged: {
+                    OverlayController.setVsyncDisabled(checked, true)
+                    customTickRateText.visible = checked
+                    customTickRateLabel.visible = checked
+                    customTickRateMsLabel.visible = checked
+                }
+            }
+
+            MyText {
+                id: customTickRateLabel
+                text: "Custom Tick Rate: "
+                horizontalAlignment: Text.AlignRight
+                Layout.leftMargin: 20
+                Layout.rightMargin: 2
+            }
+
+            MyTextField {
+                id: customTickRateText
+                text: "20"
+                keyBoardUID: 1001
+                Layout.preferredWidth: 140
+                Layout.leftMargin: 10
+                Layout.rightMargin: 1
+                horizontalAlignment: Text.AlignHCenter
+                function onInputEvent(input) {
+                    var val = parseInt(input, 10)
+                    if (!isNaN(val)) {
+                        OverlayController.customTickRateMs = val
+                        text = OverlayController.customTickRateMs
+                    } else {
+                        text = OverlayController.customTickRateMs
+                    }
+                }
+            }
+
+            MyText {
+                id: customTickRateMsLabel
+                text: "ms"
+                horizontalAlignment: Text.AlignLeft
+                Layout.leftMargin: 1
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+        }
+
         Item {
             Layout.fillHeight: true
         }
 
+
         Component.onCompleted: {
             settingsAutoStartToggle.checked = SettingsTabController.autoStartEnabled
             forceReviveToggle.checked = SettingsTabController.forceRevivePage
+
             allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
             oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
             universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
+
+            customTickRateText.text = OverlayController.customTickRateMs
+            vsyncDisabledToggle.checked = OverlayController.vsyncDisabled
+            customTickRateText.visible = vsyncDisabledToggle.checked
+            customTickRateLabel.visible = vsyncDisabledToggle.checked
+            customTickRateMsLabel.visible = vsyncDisabledToggle.checked
         }
 
         Connections {
@@ -82,6 +144,19 @@ MyStackViewPage {
             }
             onUniverseCenteredRotationChanged: {
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
+            }
+        }
+
+        Connections {
+            target: OverlayController
+            onVsyncDisabledChanged: {
+                vsyncDisabledToggle.checked = OverlayController.vsyncDisabled
+                customTickRateText.visible = vsyncDisabledToggle.checked
+                customTickRateLabel.visible = vsyncDisabledToggle.checked
+                customTickRateMsLabel.visible = vsyncDisabledToggle.checked
+            }
+            onCustomTickRateMsChanged: {
+                customTickRateText.text = OverlayController.customTickRateMs
             }
         }
     }

--- a/src/res/qml/audio_page/dialog_boxes/PttNewProfileDialog.qml
+++ b/src/res/qml/audio_page/dialog_boxes/PttNewProfileDialog.qml
@@ -19,7 +19,7 @@ MyDialogOkCancelPopup {
             }
             MyTextField {
                 id: pttNewProfileName
-                keyBoardUID: 590
+                keyBoardUID: 591
                 color: "#cccccc"
                 text: ""
                 Layout.fillWidth: true


### PR DESCRIPTION
This adds a new option to the settings tab to disable vsync (vsync will still default to on for new users). When vsync is disabled a text box for a custom tick rate (default 20ms) will appear. Currently values between 1~999ms are accepted. This addresses #255