### PR TITLE
Remove unnecessary init functions, pointers to widget and parent from tab controllers

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -487,7 +487,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_steamVRTabController.initStage2( this );
     m_chaperoneTabController.initStage2( this );
     m_fixFloorTabController.initStage2( this );
-    m_audioTabController.initStage2( this, m_pWindow.get() );
+    m_audioTabController.initStage2();
     m_statisticsTabController.initStage2( this, m_pWindow.get() );
     m_settingsTabController.initStage2( this, m_pWindow.get() );
     m_reviveTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -136,7 +136,6 @@ OverlayController::OverlayController( bool desktopMode,
     m_chaperoneTabController.initStage1();
     m_moveCenterTabController.initStage1();
     m_audioTabController.initStage1();
-    m_statisticsTabController.initStage1();
     m_settingsTabController.initStage1();
     m_reviveTabController.initStage1(
         m_settingsTabController.forceRevivePage() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -491,8 +491,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_statisticsTabController.initStage2( this );
     m_settingsTabController.initStage2( this );
     m_reviveTabController.initStage2( this );
-    m_utilitiesTabController.initStage2( this, m_pWindow.get() );
-    m_videoTabController.initStage2( this, m_pWindow.get() );
+    m_utilitiesTabController.initStage2( this );
     m_moveCenterTabController.initStage2( this, m_pWindow.get() );
 }
 

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -492,7 +492,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_settingsTabController.initStage2( this );
     m_reviveTabController.initStage2( this );
     m_utilitiesTabController.initStage2( this );
-    m_moveCenterTabController.initStage2( this, m_pWindow.get() );
+    m_moveCenterTabController.initStage2( this );
 }
 
 void OverlayController::OnRenderRequest()

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -485,7 +485,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_pPumpEventsTimer->start();
 
     m_steamVRTabController.initStage2( this );
-    m_chaperoneTabController.initStage2( this, m_pWindow.get() );
+    m_chaperoneTabController.initStage2( this );
     m_fixFloorTabController.initStage2( this, m_pWindow.get() );
     m_audioTabController.initStage2( this, m_pWindow.get() );
     m_statisticsTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -490,7 +490,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_audioTabController.initStage2();
     m_statisticsTabController.initStage2( this );
     m_settingsTabController.initStage2( this );
-    m_reviveTabController.initStage2( this, m_pWindow.get() );
+    m_reviveTabController.initStage2( this );
     m_utilitiesTabController.initStage2( this, m_pWindow.get() );
     m_videoTabController.initStage2( this, m_pWindow.get() );
     m_moveCenterTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -486,7 +486,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
 
     m_steamVRTabController.initStage2( this );
     m_chaperoneTabController.initStage2( this );
-    m_fixFloorTabController.initStage2( this, m_pWindow.get() );
+    m_fixFloorTabController.initStage2( this );
     m_audioTabController.initStage2( this, m_pWindow.get() );
     m_statisticsTabController.initStage2( this, m_pWindow.get() );
     m_settingsTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -484,7 +484,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
 
     m_pPumpEventsTimer->start();
 
-    m_steamVRTabController.initStage2( this, m_pWindow.get() );
+    m_steamVRTabController.initStage2( this );
     m_chaperoneTabController.initStage2( this, m_pWindow.get() );
     m_fixFloorTabController.initStage2( this, m_pWindow.get() );
     m_audioTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -489,7 +489,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_fixFloorTabController.initStage2( this );
     m_audioTabController.initStage2();
     m_statisticsTabController.initStage2( this );
-    m_settingsTabController.initStage2( this, m_pWindow.get() );
+    m_settingsTabController.initStage2( this );
     m_reviveTabController.initStage2( this, m_pWindow.get() );
     m_utilitiesTabController.initStage2( this, m_pWindow.get() );
     m_videoTabController.initStage2( this, m_pWindow.get() );

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -135,7 +135,6 @@ OverlayController::OverlayController( bool desktopMode,
     m_steamVRTabController.initStage1();
     m_chaperoneTabController.initStage1();
     m_moveCenterTabController.initStage1();
-    m_fixFloorTabController.initStage1();
     m_audioTabController.initStage1();
     m_statisticsTabController.initStage1();
     m_settingsTabController.initStage1();

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -488,7 +488,7 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
     m_chaperoneTabController.initStage2( this );
     m_fixFloorTabController.initStage2( this );
     m_audioTabController.initStage2();
-    m_statisticsTabController.initStage2( this, m_pWindow.get() );
+    m_statisticsTabController.initStage2( this );
     m_settingsTabController.initStage2( this, m_pWindow.get() );
     m_reviveTabController.initStage2( this, m_pWindow.get() );
     m_utilitiesTabController.initStage2( this, m_pWindow.get() );

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -56,12 +56,8 @@ void AudioTabController::initStage1()
     eventLoopTick();
 }
 
-void AudioTabController::initStage2( OverlayController* var_parent,
-                                     QQuickWindow* var_widget )
+void AudioTabController::initStage2()
 {
-    this->parent = var_parent;
-    this->widget = var_widget;
-
     std::string notifKey = std::string( application_strings::applicationKey )
                            + ".pptnotification";
 

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -54,9 +54,6 @@ class AudioTabController : public PttController
                     setAudioProfileDefault NOTIFY audioProfileDefaultChanged )
 
 private:
-    OverlayController* parent;
-    QQuickWindow* widget;
-
     vr::VROverlayHandle_t m_ulNotificationOverlayHandle
         = vr::k_ulOverlayHandleInvalid;
 
@@ -118,7 +115,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* var_parent, QQuickWindow* var_widget );
+    void initStage2();
 
     void reloadAudioSettings();
     void saveAudioSettings();

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -47,11 +47,9 @@ void ChaperoneTabController::initStage1()
     eventLoopTick( nullptr, 0.0f, 0.0f, 0.0f );
 }
 
-void ChaperoneTabController::initStage2( OverlayController* var_parent,
-                                         QQuickWindow* var_widget )
+void ChaperoneTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 ChaperoneTabController::~ChaperoneTabController()

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -135,7 +135,6 @@ class ChaperoneTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     float m_visibility = 0.6f;
     float m_fadeDistance = 0.7f;
@@ -193,7 +192,7 @@ public:
     ~ChaperoneTabController();
 
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::TrackedDevicePose_t* devicePoses,
                         float leftSpeed,

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -7,11 +7,9 @@ namespace advsettings
 {
 void FixFloorTabController::initStage1() {}
 
-void FixFloorTabController::initStage2( OverlayController* var_parent,
-                                        QQuickWindow* var_widget )
+void FixFloorTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 void FixFloorTabController::eventLoopTick(

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -5,8 +5,6 @@
 // application namespace
 namespace advsettings
 {
-void FixFloorTabController::initStage1() {}
-
 void FixFloorTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;

--- a/src/tabcontrollers/FixFloorTabController.h
+++ b/src/tabcontrollers/FixFloorTabController.h
@@ -53,7 +53,6 @@ private:
     int getControllerType( vr::TrackedDeviceIndex_t controllerRole );
 
 public:
-    void initStage1();
     void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::TrackedDevicePose_t* devicePoses );

--- a/src/tabcontrollers/FixFloorTabController.h
+++ b/src/tabcontrollers/FixFloorTabController.h
@@ -19,7 +19,6 @@ class FixFloorTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     float controllerUpOffsetCorrection
         = 0.062f; // Controller touchpad facing upwards
@@ -55,7 +54,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::TrackedDevicePose_t* devicePoses );
 

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -159,11 +159,9 @@ void MoveCenterTabController::initStage1()
     m_lastGravityUpdateTimePoint = std::chrono::steady_clock::now();
 }
 
-void MoveCenterTabController::initStage2( OverlayController* var_parent,
-                                          QQuickWindow* var_widget )
+void MoveCenterTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
     zeroOffsets();
     outputLogSettings();
 }

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -87,7 +87,6 @@ class MoveCenterTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     int m_trackingUniverse = static_cast<int>( vr::TrackingUniverseStanding );
     float m_offsetX = 0.0f;
@@ -192,7 +191,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::ETrackingUniverseOrigin universe,
                         vr::TrackedDevicePose_t* devicePoses );

--- a/src/tabcontrollers/ReviveTabController.cpp
+++ b/src/tabcontrollers/ReviveTabController.cpp
@@ -297,11 +297,9 @@ void ReviveTabController::initStage1( bool forceRevivePage )
     }
 }
 
-void ReviveTabController::initStage2( OverlayController* var_parent,
-                                      QQuickWindow* var_widget )
+void ReviveTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 void ReviveTabController::eventLoopTick()

--- a/src/tabcontrollers/ReviveTabController.h
+++ b/src/tabcontrollers/ReviveTabController.h
@@ -70,7 +70,6 @@ class ReviveTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     bool m_isOverlayInstalled = false;
     int m_gripButtonMode = 0;
@@ -98,7 +97,7 @@ private:
 
 public:
     void initStage1( bool forceRevivePage );
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick();
 

--- a/src/tabcontrollers/SettingsTabController.cpp
+++ b/src/tabcontrollers/SettingsTabController.cpp
@@ -19,11 +19,9 @@ void SettingsTabController::initStage1()
     }
 }
 
-void SettingsTabController::initStage2( OverlayController* var_parent,
-                                        QQuickWindow* var_widget )
+void SettingsTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 void SettingsTabController::eventLoopTick()

--- a/src/tabcontrollers/SettingsTabController.h
+++ b/src/tabcontrollers/SettingsTabController.h
@@ -20,7 +20,6 @@ class SettingsTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     unsigned settingsUpdateCounter = 0;
 
@@ -29,7 +28,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick();
 

--- a/src/tabcontrollers/StatisticsTabController.cpp
+++ b/src/tabcontrollers/StatisticsTabController.cpp
@@ -5,8 +5,6 @@
 // application namespace
 namespace advsettings
 {
-void StatisticsTabController::initStage1() {}
-
 void StatisticsTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;

--- a/src/tabcontrollers/StatisticsTabController.cpp
+++ b/src/tabcontrollers/StatisticsTabController.cpp
@@ -7,11 +7,9 @@ namespace advsettings
 {
 void StatisticsTabController::initStage1() {}
 
-void StatisticsTabController::initStage2( OverlayController* var_parent,
-                                          QQuickWindow* var_widget )
+void StatisticsTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 void StatisticsTabController::eventLoopTick(

--- a/src/tabcontrollers/StatisticsTabController.h
+++ b/src/tabcontrollers/StatisticsTabController.h
@@ -51,7 +51,6 @@ private:
     unsigned m_totalRatioReprojectedOffset = 0;
 
 public:
-    void initStage1();
     void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::TrackedDevicePose_t* devicePoses,

--- a/src/tabcontrollers/StatisticsTabController.h
+++ b/src/tabcontrollers/StatisticsTabController.h
@@ -26,7 +26,6 @@ class StatisticsTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     bool rotationResetFlag = false;
     float rotationOffset = 0.0f;
@@ -53,7 +52,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick( vr::TrackedDevicePose_t* devicePoses,
                         float leftSpeed,

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -13,11 +13,9 @@ void SteamVRTabController::initStage1()
     reloadSteamVRProfiles();
 }
 
-void SteamVRTabController::initStage2( OverlayController* var_parent,
-                                       QQuickWindow* var_widget )
+void SteamVRTabController::initStage2( OverlayController* var_parent )
 {
     this->parent = var_parent;
-    this->widget = var_widget;
 }
 
 void SteamVRTabController::eventLoopTick()

--- a/src/tabcontrollers/SteamVRTabController.h
+++ b/src/tabcontrollers/SteamVRTabController.h
@@ -44,7 +44,6 @@ class SteamVRTabController : public QObject
 
 private:
     OverlayController* parent;
-    QQuickWindow* widget;
 
     float m_superSampling = 1.0;
     bool m_motionSmoothing = true;
@@ -61,7 +60,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* parent, QQuickWindow* widget );
+    void initStage2( OverlayController* parent );
 
     void eventLoopTick();
 

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -22,11 +22,9 @@ void UtilitiesTabController::initStage1()
     m_alarmTime = QTime( qAlarmHour.toInt(), qAlarmMinute.toInt() );
 }
 
-void UtilitiesTabController::initStage2( OverlayController* var_parent,
-                                         QQuickWindow* var_widget )
+void UtilitiesTabController::initStage2( OverlayController* var_parent )
 {
     this->m_parent = var_parent;
-    this->m_widget = var_widget;
 }
 
 void UtilitiesTabController::sendKeyboardInput( QString input )

--- a/src/tabcontrollers/UtilitiesTabController.h
+++ b/src/tabcontrollers/UtilitiesTabController.h
@@ -29,7 +29,6 @@ class UtilitiesTabController : public QObject
 
 private:
     OverlayController* m_parent;
-    QQuickWindow* m_widget;
 
     unsigned settingsUpdateCounter = 0;
 
@@ -45,7 +44,7 @@ private:
 
 public:
     void initStage1();
-    void initStage2( OverlayController* var_parent, QQuickWindow* var_widget );
+    void initStage2( OverlayController* var_parent );
 
     void eventLoopTick();
 

--- a/src/tabcontrollers/VideoTabController.cpp
+++ b/src/tabcontrollers/VideoTabController.cpp
@@ -14,13 +14,6 @@ void VideoTabController::initStage1()
     reloadVideoConfig();
 }
 
-void VideoTabController::initStage2( OverlayController* var_parent,
-                                     QQuickWindow* var_widget )
-{
-    this->parent = var_parent;
-    this->widget = var_widget;
-}
-
 void VideoTabController::initBrightnessOverlay()
 {
     std::string notifKey = std::string( application_strings::applicationKey )

--- a/src/tabcontrollers/VideoTabController.h
+++ b/src/tabcontrollers/VideoTabController.h
@@ -45,8 +45,6 @@ private:
     // how wide overlay is, Increase this value if edges of view are not
     // dimmed.
     const float k_overlayWidth = 1.0f;
-    OverlayController* parent;
-    QQuickWindow* widget;
 
     vr::VROverlayHandle_t m_brightnessOverlayHandle
         = vr::k_ulOverlayHandleInvalid;
@@ -105,7 +103,6 @@ public:
     float colorOpacityPerc() const;
 
     void initStage1();
-    void initStage2( OverlayController* var_parent, QQuickWindow* var_widget );
     void eventLoopTick();
 
 public slots:


### PR DESCRIPTION
All the original tab controllers used a "design pattern" of giving all controllers a pointer to the Qt window and the OverlayController, even if they didn't need them.

This PR removes the unnecessary members and the entire `initStage2` function for the `VideoTabController`, which was a noop.