### PR TITLE
Move windeployqt call from build script to Qmake

### DIFF
--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -65,3 +65,28 @@ packageFilesCopy.path = $$COPY_DEST_DIR
 win32:openvrApiCopy.files = third-party/openvr/bin/win64/openvr_api.dll
 unix:openvrApiCopy.files = third-party/openvr/lib/linux64/libopenvr_api.so
 openvrApiCopy.path = $$COPY_DEST_DIR
+
+# Deploy resources and DLLs to exe dir on Windows
+win32 {
+    WINDEPLOYQT_LOCATION = $$dirname(QMAKE_QMAKE)/windeployqt.exe
+
+    CONFIG( debug, debug|release ) {
+        WINDEPLOYQT_BUILD_TARGET += "--debug"
+    } else {
+        WINDEPLOYQT_BUILD_TARGET += "--release"
+    }
+
+    WINDEPLOYQT_OPTIONS = --dir $$COPY_DEST_DIR/qtdata \
+                          --libdir $$COPY_DEST_DIR \
+                          --plugindir $$COPY_DEST_DIR/qtdata/plugins \
+                          --no-system-d3d-compiler \
+                          --no-opengl-sw \
+                          $$WINDEPLOYQT_BUILD_TARGET \
+                          --qmldir $$PWD/src/res/qml \
+                          $$COPY_DEST_DIR/AdvancedSettings.exe
+    WINDEPLOYQT_FULL_LINE = "$$WINDEPLOYQT_LOCATION $$WINDEPLOYQT_OPTIONS"
+
+    # Force windeployqt to run in cmd, because powershell has different syntax
+    # for running executables.
+    QMAKE_POST_LINK = cmd /c $$WINDEPLOYQT_FULL_LINE
+}

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -45,7 +45,7 @@ include($$include_dir/sources.pri)
 include($$include_dir/resources.pri)
 
 # Copy extra files
-COPIES += resCopy readmeCopy licenseCopy packageFilesCopy openvrApiCopy
+COPIES += resCopy readmeCopy licenseCopy packageFoldersCopy openvrApiCopy packageFilesCopy
 COPY_DEST_DIR = $$OUT_PWD/$$DESTDIR
 
 resCopy.files = src/res/*
@@ -59,7 +59,11 @@ licenseCopy.files = LICENSE \
                     third-party/easylogging++/LICENSE-MIT
 licenseCopy.path = $$COPY_DEST_DIR
 
-packageFilesCopy.files = src/package_files/*
+packageFoldersCopy.files = src/package_files/default_action_manifests
+packageFoldersCopy.path = $$COPY_DEST_DIR
+
+packageFilesCopy.files = src/package_files/action_manifest.json src/package_files/manifest.vrmanifest
+win32:packageFilesCopy.files += src/package_files/qt.conf src/package_files/restartvrserver.bat src/package_files/startdesktopmode.bat
 packageFilesCopy.path = $$COPY_DEST_DIR
 
 win32:openvrApiCopy.files = third-party/openvr/bin/win64/openvr_api.dll

--- a/build_scripts/win/build.py
+++ b/build_scripts/win/build.py
@@ -81,47 +81,6 @@ def package():
 
     create_batch_file()
 
-
-def deploy():
-    """
-    Runs windeployqt and copies necessary files.
-    """
-    set_current_activity("DEPLOY")
-    set_dirs()
-
-    say("Testing if all required build environment variables are set:")
-    QT_LOC = find_qt_path()
-    say("All required build environment values are set.")
-
-    if is_env_var_set(BUILD_DEBUG_VAR_NAME):
-        COMPILE_MODE = "debug"
-        say(f"{BUILD_DEBUG_VAR_NAME} defined. Deploying '{COMPILE_MODE}' version.")
-    else:
-        COMPILE_MODE = "release"
-        say(f"{BUILD_DEBUG_VAR_NAME} not defined. Deploying '{COMPILE_MODE}' version.")
-
-    say("Adding windeployqt to file.")
-
-    add_line_to_run_bat_file("set PATH=%PATH%;" + QT_LOC + ";")
-
-    add_line_to_run_bat_file("@ECHO Starting windeployqt:")
-
-    #Extremely long line
-    add_line_to_run_bat_file('"' + "windeployqt" + '"'
-                             + " --dir " + get_deploy_dir()
-                             + "\\qtdata --libdir " + get_deploy_dir()
-                             + " --plugindir " + get_deploy_dir() + "\\qtdata\\plugins --no-system-d3d-compiler --no-opengl-sw --"
-                             + COMPILE_MODE + " --qmldir " + get_project_dir() + "\\src\\res\\qml\\ " + get_deploy_dir() + "\\AdvancedSettings.exe")
-    add_error_handling_line_to_bat_file()
-    add_line_to_run_bat_file("@ECHO windeployqt finished.")
-
-    say("windeployqt added to file.")
-
-    say("Creating batch file:")
-    create_batch_file()
-    say("Batch file created.")
-
-
 def build():
     """
     Runs:
@@ -214,11 +173,6 @@ def build():
 if __name__ == "__main__":
     if argv[1] == "build":
         build()
-    elif argv[1] == "deploy":
-        deploy()
     elif argv[1] == "package":
         package()
-
-
-
 

--- a/build_scripts/win/common.py
+++ b/build_scripts/win/common.py
@@ -10,7 +10,7 @@ import string
 def get_version_string():
     dir_path = os.path.dirname(os.path.realpath(__file__))
     with open(dir_path + "/../compile_version_string.txt", "r") as file:
-        contents = file.readline()
+        contents = file.readline().strip()
         return contents
 
 

--- a/build_windows.cmd
+++ b/build_windows.cmd
@@ -27,12 +27,6 @@ IF ERRORLEVEL 1 EXIT /B %exit_code_failure_build_apps%
 call %project_dir%\build_scripts\win\current_build.bat
 IF ERRORLEVEL 1 EXIT /B %exit_code_failure_build_apps%
 
-ECHO %top_level_activity%: Calling deployment script.
-%PYTHON_LOC%python %project_dir%\build_scripts\win\build.py deploy
-IF ERRORLEVEL 1 EXIT /B %exit_code_failure_build_apps%
-call %project_dir%\build_scripts\win\current_build.bat
-IF ERRORLEVEL 1 EXIT /B %exit_code_failure_build_apps%
-
 REM The average dev doesn't need to package and zip it, just build it and test.
 IF NOT DEFINED BUILD_PACKAGE (
     ECHO %top_level_activity%: BUILD_PACKAGE not set. Not building installer and portable zip versions.


### PR DESCRIPTION
`qmake` is better suited for finding `windeployqt`, since it's in the same directory as `qmake` on windows.

`qmake` is also better suited for finding the build target (release/debug) vs third party scripts.

`windeployqt` is being forced to run in `cmd` because the syntax is different for running executables in powershell, which means `windeployqt` won't be executed and runtime or  package errors will occur.

With the removal of the windeployqt call the deploy step is no longer needed for building on Windows, since all previous deploy tasks are now handle by Qmake.

With this, pressing the build button in Qt Creator will also fully build the project (but not package) leading to better IDE integration.