### PR TITLE
Add `make install` to Linux, fix AppImage not working on older distros, revert chaperone changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
                 command: |
                     sudo add-apt-repository ppa:ubuntu-toolchain-r/test
                     sudo apt-get update
-                    sudo apt-get install g++-9 -y
+                    sudo apt-get install g++-7 -y
             - run:
                 name: Add required QT repos
                 command: |

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -94,3 +94,16 @@ win32 {
     # for running executables.
     QMAKE_POST_LINK = cmd /c $$WINDEPLOYQT_FULL_LINE
 }
+
+# Add make install support
+unix {
+    isEmpty(PREFIX){
+        PREFIX = /opt/OpenVR-AdvancedSettings
+    }
+
+    application.path = $$PREFIX
+    application.files = $$COPY_DEST_DIR
+
+    INSTALLS += application
+}
+

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -13,6 +13,7 @@
   * [Ubuntu 18.04 Bionic](#ubuntu-1804-bionic)
 - [Locations and Environment Variables](#locations-and-environment-variables)
 - [Building](#building)
+- [Installing](#installing)
 - [Contributing](#contributing)
 
 # Requirements
@@ -174,6 +175,12 @@ The following environmental variables are relevant for building the project.
 With the programs above installed and environment variables set, go into the root folder of the repository and run `./build_scripts/linux/build_linux.sh`.
 
 If you copy the `third-party/openvr/lib/linux64/libopenvr_api.so` file into `/lib` you can run the `AdvancedSettings` file without anything else. Otherwise you'll need to run the `run-with-library.sh` file.
+
+# Installing
+
+The application can be installed by running `sudo make install` in the directory of the `Makefile`. 
+This will copy the build directory to `/opt/OpenVR-AdvancedSettings/AdvancedSettings` by default.
+The `PREFIX` location can be changed while running `qmake` by writing `qmake PREFIX=/your/dir/here`, then `make` and `sudo make install`.
 
 # Contributing
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -174,8 +174,6 @@ The following environmental variables are relevant for building the project.
 
 With the programs above installed and environment variables set, go into the root folder of the repository and run `./build_scripts/linux/build_linux.sh`.
 
-If you copy the `third-party/openvr/lib/linux64/libopenvr_api.so` file into `/lib` you can run the `AdvancedSettings` file without anything else. Otherwise you'll need to run the `run-with-library.sh` file.
-
 # Installing
 
 The application can be installed by running `sudo make install` in the directory of the `Makefile`. 

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -572,6 +572,27 @@ void ChaperoneTabController::eventLoopTick(
     float rightSpeed,
     float hmdSpeed )
 {
+    m_chaperoneVelocityModifierCurrent = 1.0f;
+    if ( m_enableChaperoneVelocityModifier )
+    {
+        float mod = m_chaperoneVelocityModifier
+                    * std::max( { leftSpeed, rightSpeed, hmdSpeed } );
+        if ( mod > 0.02f )
+        {
+            m_chaperoneVelocityModifierCurrent += mod;
+        }
+    }
+    float newFadeDistance = m_fadeDistance * m_chaperoneVelocityModifierCurrent;
+    if ( m_fadeDistanceModified != newFadeDistance )
+    {
+        m_fadeDistanceModified = newFadeDistance;
+        vr::VRSettings()->SetFloat(
+            vr::k_pch_CollisionBounds_Section,
+            vr::k_pch_CollisionBounds_FadeDistance_Float,
+            m_fadeDistanceModified );
+        vr::VRSettings()->Sync();
+    }
+
     if ( devicePoses )
     {
         m_isHMDActive = false;
@@ -664,28 +685,6 @@ void ChaperoneTabController::eventLoopTick(
 
     if ( settingsUpdateCounter >= k_chaperoneSettingsUpdateCounter )
     {
-        m_chaperoneVelocityModifierCurrent = 1.0f;
-        if ( m_enableChaperoneVelocityModifier )
-        {
-            float mod = m_chaperoneVelocityModifier
-                        * std::max( { leftSpeed, rightSpeed, hmdSpeed } );
-            if ( mod > 0.02f )
-            {
-                m_chaperoneVelocityModifierCurrent += mod;
-            }
-        }
-        float newFadeDistance
-            = m_fadeDistance * m_chaperoneVelocityModifierCurrent;
-        if ( m_fadeDistanceModified != newFadeDistance )
-        {
-            m_fadeDistanceModified = newFadeDistance;
-            vr::VRSettings()->SetFloat(
-                vr::k_pch_CollisionBounds_Section,
-                vr::k_pch_CollisionBounds_FadeDistance_Float,
-                m_fadeDistanceModified );
-            vr::VRSettings()->Sync();
-        }
-
         if ( parent->isDashboardVisible() )
         {
             vr::EVRSettingsError vrSettingsError;


### PR DESCRIPTION
## This PR: 
* Removes unnecessary documentation from building on linux. The rpath is now set to the current directory so script file is no longer necessary or included.
* Reverts the changes to the chaperone velocity modifier. The changes didn't fix the problem on Manjaro and broke the feature for everybody else. Fixes #252.
* Adds the `make install` command for building on Linux. This copies the build directory into `/opt/OpenVR-AdvancedSettings`, acting as a way to use the application in "production" without using the AppImage.
* Downgrades the version of `gcc` used to build the AppImage. The current version used makes the AppImage not work on LTS releases of Ubuntu 18.04 and derivates (Linux Mint 19.1). Fixes #266.