### PR TITLE
Update Linux build docs, add public Discord link to readme, move TOC

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,8 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/8oivf5xws6vsq2x3/branch/master?svg=true)](https://ci.appveyor.com/project/icewind1991/openvr-advancedsettings/branch/master)
 [![Build Status](https://travis-ci.org/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings.svg?branch=master)](https://travis-ci.org/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings)
 
+[![Discord Shield](https://discordapp.com/api/guilds/593808397304987648/widget.png?style=shield)](https://discordapp.com/invite/cW6cRyv)
+
 - [Features](#features)
 - [Usage](#usage)
   * [Installer](#installer)

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,11 @@
 
 [![Discord Shield](https://discordapp.com/api/guilds/593808397304987648/widget.png?style=shield)](https://discordapp.com/invite/cW6cRyv)
 
+# OpenVR Advanced Settings Overlay
+Adds an overlay to the OpenVR dashboard that allows access to advanced settings and useful utilities.
+
+![Example Screenshot](docs/screenshots/InVRScreenshot.png)
+
 - [Features](#features)
 - [Usage](#usage)
   * [Installer](#installer)
@@ -43,11 +48,6 @@
 - [Notes:](#notes-)
 - [Common Issues](#common-issues)
 - [License](#license)
-
-# OpenVR Advanced Settings Overlay
-Adds an overlay to the OpenVR dashboard that allows access to advanced settings and useful utilities.
-
-![Example Screenshot](docs/screenshots/InVRScreenshot.png)
 
 # Features
 

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -101,6 +101,8 @@ unix {
         PREFIX = /opt/OpenVR-AdvancedSettings
     }
 
+    message(PREFIX value is: \'$$PREFIX\'. `make install` will install to this location.)
+
     application.path = $$PREFIX
     application.files = $$COPY_DEST_DIR
 

--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -58,19 +58,23 @@ win32 {
 
 unix:!macx {
     !noX11 {
+        message(X11 features enabled.)
         SOURCES += src/keyboard_input/input_sender_X11.cpp
         CONFIG += x11
         LIBS += -lXtst
     }
     else {
+        message(X11 features disabled.)
         SOURCES += src/keyboard_input/input_sender_dummy.cpp
     }
 
     !noDBUS {
+        message(DBUS features enabled.)
         SOURCES += src/media_keys/media_keys_dbus.cpp
         QT += dbus
     }
     else {
+        message(DBUS features disabled.)
         SOURCES += src/media_keys/media_keys_dummy.cpp
     }
 

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -1,40 +1,80 @@
 - [Requirements](#requirements)
-  * [Compiler and Build Essentials](#compiler-and-build-essentials)
-  * [Qt](#qt)
-  * [Official Qt Installer](#official-qt-installer)
+    * [Compiler and Build Essentials](#compiler-and-build-essentials)
+        + [Ubuntu](#ubuntu)
+        + [Arch/Manjaro](#arch-manjaro)
+    * [Qt](#qt)
+        * [Package Manager](#package-manager)
+        + [Ubuntu](#ubuntu-1)
+        + [Arch/Manjaro](#arch-manjaro-1)
+    * [Official Qt Installer](#official-qt-installer)
     + [`qtchooser`](#-qtchooser-)
-  * [Unofficial Ubuntu Packages](#unofficial-ubuntu-packages)
-  * [`qtchooser` and versions](#-qtchooser--and-versions)
-  * [X11](#x11)
-  * [DBUS](#dbus)
-  * [`clang-tidy` and `bear`](#-clang-tidy--and--bear-)
-- [TL;DR: for Ubuntu](#tl-dr--for-ubuntu)
-  * [Ubuntu 16.04 Xenial](#ubuntu-1604-xenial)
-  * [Ubuntu 18.04 Bionic](#ubuntu-1804-bionic)
-- [Locations and Environment Variables](#locations-and-environment-variables)
+    * [Unofficial Ubuntu Packages](#unofficial-ubuntu-packages)
+    + [Arch/Manjaro](#arch-manjaro-2)
+    * [`qtchooser` and versions](#-qtchooser--and-versions)
+    * [X11](#x11)
+    * [DBUS](#dbus)
+    * [`clang-tidy` and `bear`](#-clang-tidy--and--bear-)
+- [TL;DRs](#tl-drs)
+    * [Ubuntu 16.04 Xenial](#ubuntu-1604-xenial)
+    * [Ubuntu 18.04 Bionic](#ubuntu-1804-bionic)
+    * [Ubuntu 19.04 Disco](#ubuntu-1904-disco)
+    * [Arch/Manjaro](#arch-manjaro-3)
 - [Building](#building)
+- [Configuring](#configuring)
 - [Installing](#installing)
 - [Contributing](#contributing)
 
 # Requirements
 ## Compiler and Build Essentials
 
-You will need either `clang` og `g++`. At least `g++-7` or `clang` version `5.0` is required due to C++17 support.
-You will additionally need the `build-essential` and `libgl1-mesa-dev` packages.
+You will need either `clang` version `>=5.0` or `gcc` version `>=7` due to C++17 support.
+You will additionally need the basic build packages for your distro and OpenGL development headers.
 
-If they are available from your package manager they can be installed with `sudo apt install build-essential libgl1-mesa-dev`. If the versions in your package manager are not up to date, you can get the packages on Ubuntu with 
+### Ubuntu
+
+For Ubuntu versions older than 18.04 (only 16.04 is officially tested) you'll need to get a backported `gcc`:
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt update
-sudo apt install g++-7
+sudo apt install build-essential g++-7 libgl1-mesa-dev
 ```
+
+For Ubuntu versions of 18.04 or newer `build-essential` will contain an appropriate `gcc` version:
+```bash
+sudo apt install build-essential libgl1-mesa-dev
+```
+
+### Arch/Manjaro
+
+`base-devel` contains `gcc` and `mesa` contains the necessary OpenGL things.
+
+```bash
+sudo pacman -S base-devel mesa
+```
+
 ## Qt
 
 At least version `5.12` is required.
 
+## Package Manager
+
+Ubuntu newer than than 19.04 and Arch/Manjaro will have up to date Qt packages in the official repositories.
+
+### Ubuntu
+
+```bash
+sudo apt install qt5-default qtmultimedia5-dev qtdeclarative5-dev
+```
+
+### Arch/Manjaro
+
+```bash
+sudo pacman -S qt5-base qt5-multimedia
+```
+
 ## Official Qt Installer
 
-The easiest way to get it is from the [official Qt installer](https://www.qt.io/download-qt-installer).
+The easiest way to get it if your packages aren't up to date is from the [official Qt installer](https://www.qt.io/download-qt-installer).
 
 ### `qtchooser`
 After installing using the official installer you will likely need to `qtchooser -install <name> <qmake-location>` in order for Qt to use the correct version. See the `qtchooser` section below.
@@ -51,13 +91,19 @@ sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial
 sudo apt-get update
 sudo apt install qt512-meta-full
 ```
+
 For Ubuntu 18.04
 ```bash
 sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-bionic
 sudo apt-get update
 sudo apt install qt512-meta-full
 ```
+
 If you choose the wrong Ubuntu version you will get an error from `apt` about there not being a `Release` file. Try the other one instead.
+
+### Arch/Manjaro
+
+The `qt5-declarative` and `qt5-multimedia` packages are required.
 
 ## `qtchooser` and versions
 
@@ -93,30 +139,44 @@ export QT_SELECT=opt-qt512
 
 Run `qmake --version` again to make sure the correct version is set.
 
-If you don't see the required version in the list of currently installed versions you will need to install it. You do this with `qtchooser -install <name> <path-to-qmake>`. If you used the PPA above then you'll need to write 
+If you don't see the required version in the list of currently installed versions you will need to install it.
+You do this with `qtchooser -install <name> <path-to-qmake>`.
+If you used the Ubuntu PPA above then you'll need to write
 ```bash
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 ```
 
 Afterwards you should set the `QT_SELECT` environment variable to the name you chose (we used `opt-qt512`).
+```bash
+export QT_SELECT=opt-qt512
+```
 
 ## X11
 
-X11 packages are currently needed for sending keystrokes to the desktop from VR. Install the packages with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`. 
+X11 packages are currently needed for sending keystrokes to the desktop from VR.
+Install the packages on Ubuntu with `sudo apt-get install libx11-dev libxt-dev libxtst-dev`.
+
+This feature and dependency can be disabled during compilation.
 
 ## DBUS
 
 DBUS is  needed for controlling media players from VR. 
 
+This feature and dependency can be disabled during compilation.
+
 ## `clang-tidy` and `bear`
 
-In order to use `clang-tidy` you will need `bear clang-tidy` in addition to the above (and `clang`). You will only need this if you're going to make contributions to the codebase.
+This is only relevant for building on CI servers.
+Unless you're checking code quality you will not need this.
+
+In order to use `clang-tidy` you will need `bear clang-tidy` in addition to the above (and `clang`).
+You will only need this if you're going to make contributions to the codebase.
 
 ```bash
 sudo apt install bear clang-tidy
 ```
 
-# TL;DR: for Ubuntu
+# TL;DRs
 ## Ubuntu 16.04 Xenial
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -126,7 +186,6 @@ sudo apt install g++-7
 sudo apt-get install build-essential libgl1-mesa-dev
 sudo apt-get install qt512-meta-full
 sudo apt-get install libx11-dev libxt-dev libxtst-dev
-sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 export QT_SELECT=opt-qt512
 ```
@@ -139,7 +198,6 @@ sudo apt install g++-7
 sudo apt-get install build-essential libgl1-mesa-dev
 sudo apt-get install qt512-meta-full
 sudo apt-get install libx11-dev libxt-dev libxtst-dev
-sudo apt-get install bear clang-tidy
 qtchooser -install opt-qt512 /opt/qt512/bin/qmake
 export QT_SELECT=opt-qt512
 ```
@@ -148,31 +206,64 @@ export QT_SELECT=opt-qt512
 
 ```bash
 sudo apt install build-essential libgl1-mesa-dev
-sudo apt install g++7
 sudo apt install qt5-default qtmultimedia5-dev libqt5multimediawidgets5 libqt5multimedia5-plugins libqt5multimedia5 qml-module-qtquick-extras qml-module-qtquick-controls2 qml-module-qtquick-dialogs qtdeclarative5-dev
 sudo apt-get install libx11-dev libxt-dev libxtst-dev
-sudo apt install bear clang-tidy
 ```
 You should not need to use `qtchooser` to set the Qt version on 19.04.
 
+## Arch/Manjaro
 
-# Locations and Environment Variables
-
-The following environmental variables are relevant for building the project.
-
-| Environment Variable  | Purpose |
-| --------------------  | ------------- |
-| `QMAKE_SPEC`              | The [mkspec](https://forum.qt.io/topic/70970/what-is-mkspecs-used-for-how-to-configure-for-my-hardware) to compile to. Either `linux-g++` or `linux-clang`. Defaults to `linux-g++`.   |
-| `USE_TIDY`              | If set a compilation database will be created and the project linted. Can only be used with `clang`.  |
-| `NO_X11`              | If set the application will be compiled without X11 specific libraries. This disables certain things like sending keystrokes from VR.  |
-| `NO_DBUS`              | If set the application will be compiled without DBUS specific functionality. This disables certain things like media keys.  |
-| `MAKE_JOBS`              | Argument to `make --jobs`. Defaults to nothing (unlimited amount of jobs).  |
-| `CLANG_TIDY_EXECUTABLE`              | Name of the `clang-tidy` executable. Defaults to `clang-tidy`. Used for specifying a specific version or path, for example `clang-tidy-7`.  |
-
+```bash
+sudo pacman -S base-devel mesa
+sudo pacman -S qt5-declarative qt5-multimedia
+sudo pacman -S xorg-server
+sudo pacman -S dbus
+```
 
 # Building
 
-With the programs above installed and environment variables set, go into the root folder of the repository and run `./build_scripts/linux/build_linux.sh`.
+You will need the requirements above.
+
+If you want a default build run `qmake; make` in the project directory.
+This is what most users will want.
+
+Build artifacts can then be cleaned up with `make clean`.
+
+# Configuring
+
+Configuration changes must be made in the `qmake` step by passing arguments.
+If you don't know why you would change any of these then you don't need to.
+
+If you wanted to use `clang` instead of `gcc` you would type
+```bash
+qmake -spec linux-clang
+```
+
+The following values can be appended to the `CONFIG` internal variable in order to enable or disable features.
+
+| Value | Purpose |
+| ----- | ------- |
+| `noX11` | Disables X11 specific features (VR to keyboard input). |
+| `noDBUS` | Disables DBUS specific features (control media players). |
+
+The values are case sensitive.
+
+If you wanted to disable X11 specific features you would type
+```bash
+qmake CONFIG+=noX11
+```
+
+If you want to disable both X11 and DBUS features you would type
+```bash
+qmake CONFIG+=noX11 CONFIG+=noDBUS
+```
+
+The location for `make install` can be configured in the `qmake` step.
+This is done by setting the `PREFIX` variable.
+```bash
+qmake PREFIX=/my/path/
+```
+If no `PREFIX` variable is set a default value will be used.
 
 # Installing
 


### PR DESCRIPTION
## This PR:
* Updates the Linux build docs to be more true to the Linux way.
* Adds a public Discord button on the readme. Fixes #279 
* Moves the Table of Contents on the readme below the introductory header and image.

## Considerations:
* The `build_linux.sh` script previously mentioned in the docs is still being used for CI, due to it being way easier to have control flow in a shell script than in the CI config files.