### PR TITLE
Velocity fade dependent setting removal

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1030,15 +1030,7 @@ void OverlayController::mainEventLoop()
         rightSpeed
             = std::sqrt( vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2] );
     }
-    auto hmdSpeed = 0.0f;
-    if ( devicePoses[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid
-         && devicePoses[vr::k_unTrackedDeviceIndex_Hmd].eTrackingResult
-                == vr::TrackingResult_Running_OK )
-    {
-        auto& vel = devicePoses[vr::k_unTrackedDeviceIndex_Hmd].vVelocity.v;
-        hmdSpeed
-            = std::sqrt( vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2] );
-    }
+
     m_moveCenterTabController.eventLoopTick(
         vr::VRCompositor()->GetTrackingSpace(), devicePoses );
     m_utilitiesTabController.eventLoopTick();

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1044,8 +1044,7 @@ void OverlayController::mainEventLoop()
     m_utilitiesTabController.eventLoopTick();
     m_statisticsTabController.eventLoopTick(
         devicePoses, leftSpeed, rightSpeed );
-    m_chaperoneTabController.eventLoopTick(
-        devicePoses, leftSpeed, rightSpeed, hmdSpeed );
+    m_chaperoneTabController.eventLoopTick( devicePoses );
     m_audioTabController.eventLoopTick();
 
     if ( vr::VROverlay()->IsDashboardVisible() )

--- a/src/res/qml/ChaperoneWarningsPage.qml
+++ b/src/res/qml/ChaperoneWarningsPage.qml
@@ -384,95 +384,6 @@ MyStackViewPage {
             }
         }
 
-
-        ColumnLayout {
-            spacing: 0
-            MyToggleButton {
-                id: velModifierToggle
-                text: "Velocity Dependent Fade/Activation Distance"
-                onCheckedChanged: {
-                    ChaperoneTabController.chaperoneVelocityModifierEnabled = checked
-                }
-            }
-            RowLayout {
-                MyText {
-                    text: "Distance Modifier: "
-                    Layout.preferredWidth: 250
-                }
-                MyPushButton2 {
-                    id: velModifierMinusButton
-                    Layout.preferredWidth: 40
-                    text: "-"
-                    onClicked: {
-                        var val = ChaperoneTabController.chaperoneVelocityModifier - 0.01
-                        if (val < 0.0) {
-                            val = 0.0;
-                        }
-                        ChaperoneTabController.chaperoneVelocityModifier = val.toFixed(2)
-                    }
-                }
-
-                MySlider {
-                    id: velModifierSlider
-                    from: 0
-                    to: 1.0
-                    stepSize: 0.01
-                    value: 0.3
-                    Layout.fillWidth: true
-                    onPositionChanged: {
-                        var val = this.from + ( this.position  * (this.to - this.from))
-                        velModifierText.text = val.toFixed(2)
-                    }
-                    onValueChanged: {
-                        var val = velModifierSlider.value.toFixed(2)
-                        if (val < 0.0) {
-                            val = 0.0
-                        }
-                        ChaperoneTabController.chaperoneVelocityModifier = val
-                        velModifierText.text = val
-                    }
-                }
-
-                MyPushButton2 {
-                    id: velModifierPlusButton
-                    Layout.preferredWidth: 40
-                    text: "+"
-                    onClicked: {
-                        var val = ChaperoneTabController.chaperoneVelocityModifier + 0.01
-                        if (val > 1.0) {
-                            val = 1.0;
-                        }
-                        ChaperoneTabController.chaperoneVelocityModifier = val.toFixed(2)
-                    }
-                }
-
-                MyTextField {
-                    id: velModifierText
-                    text: "0.00"
-                    keyBoardUID: 804
-                    Layout.preferredWidth: 100
-                    Layout.leftMargin: 10
-                    horizontalAlignment: Text.AlignHCenter
-                    function onInputEvent(input) {
-                        var val = parseFloat(input)
-                        if (!isNaN(val)) {
-                            if (val < 0.0) {
-                                val = 0.0
-                            }
-                            val = val.toFixed(2)
-                            ChaperoneTabController.chaperoneVelocityModifier = val
-                            text = val
-                        } else {
-                            text = ChaperoneTabController.chaperoneVelocityModifier.toFixed(2)
-                        }
-                    }
-                }
-            }
-        }
-
-
-        Item { Layout.fillHeight: true; Layout.fillWidth: true }
-
         Component.onCompleted: {
             switchBeginnerToggle.checked = ChaperoneTabController.chaperoneSwitchToBeginnerEnabled
             var d = ChaperoneTabController.chaperoneSwitchToBeginnerDistance.toFixed(2)
@@ -500,12 +411,6 @@ MyStackViewPage {
                 openDashboardDistanceSlider.value = d
             }
             openDashboardDistanceText.text = d
-            velModifierToggle.checked = ChaperoneTabController.chaperoneVelocityModifierEnabled
-            d = ChaperoneTabController.chaperoneVelocityModifier.toFixed(2)
-            if (d <= velModifierSlider.to) {
-                velModifierSlider.value = d
-            }
-            velModifierText.text = d
         }
 
         Connections {
@@ -552,16 +457,6 @@ MyStackViewPage {
                     openDashboardDistanceSlider.value = d
                 }
                 openDashboardDistanceText.text = d
-            }
-            onChaperoneVelocityModifierEnabledChanged: {
-                velModifierToggle.checked = ChaperoneTabController.chaperoneVelocityModifierEnabled
-            }
-            onChaperoneVelocityModifierChanged: {
-                var d = ChaperoneTabController.chaperoneVelocityModifier.toFixed(2)
-                if (d <= velModifierSlider.to && Math.abs(velModifierSlider.value - d) > 0.0008) {
-                    velModifierSlider.value = d
-                }
-                velModifierText.text = d
             }
         }
     }

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -39,7 +39,7 @@ void ChaperoneTabController::initStage1()
     settings->endGroup();
     reloadChaperoneProfiles();
 
-    eventLoopTick( nullptr, 0.0f, 0.0f, 0.0f );
+    eventLoopTick( nullptr );
 }
 
 void ChaperoneTabController::initStage2( OverlayController* var_parent )
@@ -548,22 +548,8 @@ void ChaperoneTabController::handleChaperoneWarnings( float distance )
 }
 
 void ChaperoneTabController::eventLoopTick(
-    vr::TrackedDevicePose_t* devicePoses,
-    float leftSpeed,
-    float rightSpeed,
-    float hmdSpeed )
+    vr::TrackedDevicePose_t* devicePoses )
 {
-    float newFadeDistance = m_fadeDistance;
-    if ( m_fadeDistanceModified != newFadeDistance )
-    {
-        m_fadeDistanceModified = newFadeDistance;
-        vr::VRSettings()->SetFloat(
-            vr::k_pch_CollisionBounds_Section,
-            vr::k_pch_CollisionBounds_FadeDistance_Float,
-            m_fadeDistanceModified );
-        vr::VRSettings()->Sync();
-    }
-
     if ( devicePoses )
     {
         m_isHMDActive = false;
@@ -728,7 +714,7 @@ float ChaperoneTabController::boundsVisibility() const
 
 void ChaperoneTabController::setBoundsVisibility( float value, bool notify )
 {
-    if ( m_visibility != value )
+    if ( fabs( m_visibility - m_visibility ) > 0.005f )
     {
         if ( value <= 0.3f )
         {
@@ -758,7 +744,7 @@ float ChaperoneTabController::fadeDistance() const
 
 void ChaperoneTabController::setFadeDistance( float value, bool notify )
 {
-    if ( m_fadeDistance != value )
+    if ( fabs( m_fadeDistance - value ) > 0.005f )
     {
         m_fadeDistance = value;
         vr::VRSettings()->SetFloat(
@@ -780,7 +766,7 @@ float ChaperoneTabController::height() const
 
 void ChaperoneTabController::setHeight( float value, bool notify )
 {
-    if ( m_height != value )
+    if ( fabs( m_height - value ) > 0.005f )
     {
         m_height = value;
         // TODO revert?
@@ -817,7 +803,7 @@ void ChaperoneTabController::setHeight( float value, bool notify )
 
 void ChaperoneTabController::updateHeight( float value, bool notify )
 {
-    if ( m_height != value )
+    if ( fabs( m_height - value ) > 0.005f )
     {
         m_height = value;
         if ( notify )
@@ -1005,7 +991,7 @@ void ChaperoneTabController::setChaperoneSwitchToBeginnerEnabled( bool value,
 void ChaperoneTabController::setChaperoneSwitchToBeginnerDistance( float value,
                                                                    bool notify )
 {
-    if ( m_chaperoneSwitchToBeginnerDistance != value )
+    if ( fabs( m_chaperoneSwitchToBeginnerDistance - value ) > 0.005f )
     {
         m_chaperoneSwitchToBeginnerDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1050,7 +1036,7 @@ void ChaperoneTabController::setChaperoneHapticFeedbackEnabled( bool value,
 void ChaperoneTabController::setChaperoneHapticFeedbackDistance( float value,
                                                                  bool notify )
 {
-    if ( m_chaperoneHapticFeedbackDistance != value )
+    if ( fabs( m_chaperoneHapticFeedbackDistance - value ) > 0.005f )
     {
         m_chaperoneHapticFeedbackDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1146,7 +1132,7 @@ void ChaperoneTabController::setChaperoneAlarmSoundAdjustVolume( bool value,
 void ChaperoneTabController::setChaperoneAlarmSoundDistance( float value,
                                                              bool notify )
 {
-    if ( m_chaperoneAlarmSoundDistance != value )
+    if ( fabs( m_chaperoneAlarmSoundDistance - value ) > 0.005f )
     {
         m_chaperoneAlarmSoundDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1187,7 +1173,7 @@ void ChaperoneTabController::setChaperoneShowDashboardEnabled( bool value,
 void ChaperoneTabController::setChaperoneShowDashboardDistance( float value,
                                                                 bool notify )
 {
-    if ( m_chaperoneShowDashboardDistance != value )
+    if ( fabs( m_chaperoneShowDashboardDistance - value ) > 0.005f )
     {
         m_chaperoneShowDashboardDistance = value;
         auto settings = OverlayController::appSettings();

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -714,7 +714,7 @@ float ChaperoneTabController::boundsVisibility() const
 
 void ChaperoneTabController::setBoundsVisibility( float value, bool notify )
 {
-    if ( fabs( m_visibility - m_visibility ) > 0.005f )
+    if ( fabs( static_cast<double>( m_visibility - m_visibility ) ) > 0.005 )
     {
         if ( value <= 0.3f )
         {
@@ -744,7 +744,7 @@ float ChaperoneTabController::fadeDistance() const
 
 void ChaperoneTabController::setFadeDistance( float value, bool notify )
 {
-    if ( fabs( m_fadeDistance - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_fadeDistance - value ) ) > 0.005 )
     {
         m_fadeDistance = value;
         vr::VRSettings()->SetFloat(
@@ -766,7 +766,7 @@ float ChaperoneTabController::height() const
 
 void ChaperoneTabController::setHeight( float value, bool notify )
 {
-    if ( fabs( m_height - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_height - value ) ) > 0.005 )
     {
         m_height = value;
         // TODO revert?
@@ -803,7 +803,7 @@ void ChaperoneTabController::setHeight( float value, bool notify )
 
 void ChaperoneTabController::updateHeight( float value, bool notify )
 {
-    if ( fabs( m_height - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_height - value ) ) > 0.005 )
     {
         m_height = value;
         if ( notify )
@@ -991,7 +991,9 @@ void ChaperoneTabController::setChaperoneSwitchToBeginnerEnabled( bool value,
 void ChaperoneTabController::setChaperoneSwitchToBeginnerDistance( float value,
                                                                    bool notify )
 {
-    if ( fabs( m_chaperoneSwitchToBeginnerDistance - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_chaperoneSwitchToBeginnerDistance
+                                    - value ) )
+         > 0.005 )
     {
         m_chaperoneSwitchToBeginnerDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1036,7 +1038,9 @@ void ChaperoneTabController::setChaperoneHapticFeedbackEnabled( bool value,
 void ChaperoneTabController::setChaperoneHapticFeedbackDistance( float value,
                                                                  bool notify )
 {
-    if ( fabs( m_chaperoneHapticFeedbackDistance - value ) > 0.005f )
+    if ( fabs(
+             static_cast<double>( m_chaperoneHapticFeedbackDistance - value ) )
+         > 0.005 )
     {
         m_chaperoneHapticFeedbackDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1132,7 +1136,8 @@ void ChaperoneTabController::setChaperoneAlarmSoundAdjustVolume( bool value,
 void ChaperoneTabController::setChaperoneAlarmSoundDistance( float value,
                                                              bool notify )
 {
-    if ( fabs( m_chaperoneAlarmSoundDistance - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_chaperoneAlarmSoundDistance - value ) )
+         > 0.005 )
     {
         m_chaperoneAlarmSoundDistance = value;
         auto settings = OverlayController::appSettings();
@@ -1173,7 +1178,8 @@ void ChaperoneTabController::setChaperoneShowDashboardEnabled( bool value,
 void ChaperoneTabController::setChaperoneShowDashboardDistance( float value,
                                                                 bool notify )
 {
-    if ( fabs( m_chaperoneShowDashboardDistance - value ) > 0.005f )
+    if ( fabs( static_cast<double>( m_chaperoneShowDashboardDistance - value ) )
+         > 0.005 )
     {
         m_chaperoneShowDashboardDistance = value;
         auto settings = OverlayController::appSettings();

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <thread>
 #include <openvr.h>
+#include <cmath>
 
 class QQuickWindow;
 // application namespace
@@ -128,7 +129,6 @@ private:
 
     float m_visibility = 0.6f;
     float m_fadeDistance = 0.7f;
-    float m_fadeDistanceModified = 0.7f;
     float m_height = 2.0f;
     bool m_centerMarker = false;
     bool m_playSpaceMarker = false;
@@ -180,10 +180,7 @@ public:
     void initStage1();
     void initStage2( OverlayController* parent );
 
-    void eventLoopTick( vr::TrackedDevicePose_t* devicePoses,
-                        float leftSpeed,
-                        float rightSpeed,
-                        float hmdSpeed );
+    void eventLoopTick( vr::TrackedDevicePose_t* devicePoses );
     void handleChaperoneWarnings( float distance );
 
     float boundsVisibility() const;

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -60,8 +60,6 @@ struct ChaperoneProfile
     float chaperoneAlarmSoundDistance = 0.0f;
     bool enableChaperoneShowDashboard = false;
     float chaperoneShowDashboardDistance = 0.0f;
-    bool enableChaperoneVelocityModifier = false;
-    float chaperoneVelocityModifier = 0.0f;
 };
 
 class ChaperoneTabController : public QObject
@@ -125,14 +123,6 @@ class ChaperoneTabController : public QObject
             WRITE setChaperoneShowDashboardDistance NOTIFY
                 chaperoneShowDashboardDistanceChanged )
 
-    Q_PROPERTY( bool chaperoneVelocityModifierEnabled READ
-                    isChaperoneVelocityModifierEnabled WRITE
-                        setChaperoneVelocityModifierEnabled NOTIFY
-                            chaperoneVelocityModifierEnabledChanged )
-    Q_PROPERTY( float chaperoneVelocityModifier READ chaperoneVelocityModifier
-                    WRITE setChaperoneVelocityModifier NOTIFY
-                        chaperoneVelocityModifierChanged )
-
 private:
     OverlayController* parent;
 
@@ -165,10 +155,6 @@ private:
     bool m_enableChaperoneShowDashboard = false;
     float m_chaperoneShowDashboardDistance = 0.5f;
     bool m_chaperoneShowDashboardActive = false;
-
-    bool m_enableChaperoneVelocityModifier = false;
-    float m_chaperoneVelocityModifier = 0.0f;
-    float m_chaperoneVelocityModifierCurrent = 1.0f;
 
     unsigned settingsUpdateCounter = 0;
 
@@ -229,9 +215,6 @@ public:
     bool isChaperoneShowDashboardEnabled() const;
     float chaperoneShowDashboardDistance() const;
 
-    bool isChaperoneVelocityModifierEnabled() const;
-    float chaperoneVelocityModifier() const;
-
     void reloadChaperoneProfiles();
     void saveChaperoneProfiles();
 
@@ -268,9 +251,6 @@ public slots:
 
     void setChaperoneShowDashboardEnabled( bool value, bool notify = true );
     void setChaperoneShowDashboardDistance( float value, bool notify = true );
-
-    void setChaperoneVelocityModifierEnabled( bool value, bool notify = true );
-    void setChaperoneVelocityModifier( float value, bool notify = true );
 
     void flipOrientation( double degrees = 180 );
     void reloadFromDisk();
@@ -315,9 +295,6 @@ signals:
 
     void chaperoneShowDashboardEnabledChanged( bool value );
     void chaperoneShowDashboardDistanceChanged( float value );
-
-    void chaperoneVelocityModifierEnabledChanged( bool value );
-    void chaperoneVelocityModifierChanged( float value );
 
     void chaperoneProfilesUpdated();
 };


### PR DESCRIPTION
fixes #275

Removes the velocity dependent fade feature.

due to performance difficulties, and the fact it makes the platform unstable on some systems, and to fix it would require reducing its effectiveness to being irrelevant.


**Also** changed floating point conversions in ChaperoneTabController.cpp to use a delta value  of > 0.005 rather than exact comparison