### PR TITLE
Seated debug

### DIFF
--- a/src/res/qml/PlayspacePage.qml
+++ b/src/res/qml/PlayspacePage.qml
@@ -530,11 +530,12 @@ MyStackViewPage {
             if (MoveCenterTabController.trackingUniverse === 0) {
                 spaceModeText.text = "Sitting"
                 spaceSeatedRecenter.visible = true
-                offsetsGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                rotationGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                resetButtonRow.visible = MoveCenterTabController.enableSeatedMotion
-                profileSection.visible = MoveCenterTabController.enableSeatedMotion
-                seatedDisableWarningText.visible = !MoveCenterTabController.enableSeatedMotion
+                var boolEnableSeatedMotion = MoveCenterTabController.enableSeatedMotion
+                offsetsGroupBox.visible = boolEnableSeatedMotion
+                rotationGroupBox.visible = boolEnableSeatedMotion
+                resetButtonRow.visible = boolEnableSeatedMotion
+                profileSection.visible = boolEnableSeatedMotion
+                seatedDisableWarningText.visible = !boolEnableSeatedMotion
 
             } else if (MoveCenterTabController.trackingUniverse === 1) {
                 spaceModeText.text = "Standing"
@@ -570,8 +571,9 @@ MyStackViewPage {
                 spaceRotationSlider.value = ( MoveCenterTabController.rotation / 100 )
             }
             onTempRotationChanged: {
-                spaceRotationSlider.value = ( MoveCenterTabController.tempRotation / 100 )
-                spaceRotationText.text = ( MoveCenterTabController.tempRotation / 100 ) + "°"
+                var intTempRotation = MoveCenterTabController.tempRotation
+                spaceRotationSlider.value = ( intTempRotation / 100 )
+                spaceRotationText.text = ( intTempRotation / 100 ) + "°"
             }
             onAdjustChaperoneChanged: {
                 spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
@@ -589,22 +591,24 @@ MyStackViewPage {
                 if (MoveCenterTabController.trackingUniverse === 0) {
                     spaceModeText.text = "Sitting"
                     spaceSeatedRecenter.visible = true
-                    offsetsGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                    rotationGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                    resetButtonRow.visible = MoveCenterTabController.enableSeatedMotion
-                    profileSection.visible = MoveCenterTabController.enableSeatedMotion
-                    seatedDisableWarningText.visible = !MoveCenterTabController.enableSeatedMotion
+                    var boolEnableSeatedMotion = MoveCenterTabController.enableSeatedMotion
+                    offsetsGroupBox.visible = boolEnableSeatedMotion
+                    rotationGroupBox.visible = boolEnableSeatedMotion
+                    resetButtonRow.visible = boolEnableSeatedMotion
+                    profileSection.visible = boolEnableSeatedMotion
+                    seatedDisableWarningText.visible = !boolEnableSeatedMotion
                 }
             }
             onTrackingUniverseChanged: {
                 if (MoveCenterTabController.trackingUniverse === 0) {
                     spaceModeText.text = "Sitting"
                     spaceSeatedRecenter.visible = true
-                    offsetsGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                    rotationGroupBox.visible = MoveCenterTabController.enableSeatedMotion
-                    resetButtonRow.visible = MoveCenterTabController.enableSeatedMotion
-                    profileSection.visible = MoveCenterTabController.enableSeatedMotion
-                    seatedDisableWarningText.visible = !MoveCenterTabController.enableSeatedMotion
+                    var boolEnableSeatedMotion = MoveCenterTabController.enableSeatedMotion
+                    offsetsGroupBox.visible = boolEnableSeatedMotion
+                    rotationGroupBox.visible = boolEnableSeatedMotion
+                    resetButtonRow.visible = boolEnableSeatedMotion
+                    profileSection.visible = boolEnableSeatedMotion
+                    seatedDisableWarningText.visible = !boolEnableSeatedMotion
                 } else if (MoveCenterTabController.trackingUniverse === 1) {
                     spaceModeText.text = "Standing"
                     spaceSeatedRecenter.visible = false

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -165,6 +165,22 @@ MyStackViewPage {
             Layout.fillHeight: true
         }
 
+        RowLayout {
+            Layout.fillWidth: true
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            MyToggleButton {
+                id: debugToggle
+                text: "Debug"
+                onCheckedChanged: {
+                    OverlayController.setEnableDebug(checked, true)
+                }
+            }
+
+        }
 
         Component.onCompleted: {
             settingsAutoStartToggle.checked = SettingsTabController.autoStartEnabled

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -167,6 +167,8 @@ MyStackViewPage {
 
         RowLayout {
             Layout.fillWidth: true
+            // set visible to true here in builds when we need a debug toggle checkbox, otherwise false when on master branch.
+            visible: false
 
             Item {
                 Layout.fillWidth: true

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -632,7 +632,7 @@ void ChaperoneTabController::eventLoopTick(
             if ( m_updateTicksChaperoneReload >= 500 )
             {
                 m_updateTicksChaperoneReload = 0;
-                LOG( WARNING ) << "Attempting to Reloading Chaperone Data";
+                LOG( WARNING ) << "Attempting to reload chaperone data";
                 parent->chaperoneUtils().loadChaperoneData();
             }
         }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1253,7 +1253,15 @@ void MoveCenterTabController::incomingSeatedReset()
 {
     if ( m_enableSeatedMotion )
     {
-        updateSeatedResetData();
+        if ( !m_selfRequestedSeatedRecenter )
+        {
+            m_selfRequestedSeatedRecenter = true;
+            vr::VRSystem()->ResetSeatedZeroPose();
+        }
+        else
+        {
+            updateSeatedResetData();
+        }
     }
     else if ( parent->enableDebug() && parent->debugState() == 1 )
     {
@@ -1466,6 +1474,10 @@ void MoveCenterTabController::zeroOffsets()
 
 void MoveCenterTabController::sendSeatedRecenter()
 {
+    if ( parent->enableDebug() && parent->debugState() == 7 )
+    {
+        m_selfRequestedSeatedRecenter = true;
+    }
     vr::VRSystem()->ResetSeatedZeroPose();
 }
 
@@ -1516,6 +1528,8 @@ void MoveCenterTabController::updateSeatedResetData()
     {
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
+    // done with this recenter, so set self request back to false for next time.
+    m_selfRequestedSeatedRecenter = false;
     // set pending update here, will be processed on next instance of motion or
     // running the reset() function.
     m_pendingSeatedRecenter = true;

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1261,27 +1261,27 @@ void MoveCenterTabController::incomingSeatedReset()
     }
     else if ( parent->enableDebug() && parent->debugState() == 2 )
     {
-        Sleep( 20 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
     else if ( parent->enableDebug() && parent->debugState() == 3 )
     {
-        Sleep( 100 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
     else if ( parent->enableDebug() && parent->debugState() == 4 )
     {
-        Sleep( 200 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 200 ) );
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
     else if ( parent->enableDebug() && parent->debugState() == 5 )
     {
-        Sleep( 500 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
     else if ( parent->enableDebug() && parent->debugState() == 6 )
     {
-        Sleep( 1000 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
     }
 }

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -176,6 +176,7 @@ private:
     bool m_pendingZeroOffsets = true;
     bool m_pendingSeatedRecenter = false;
     bool m_pendingSeatedReloadFromDisk = false;
+    bool m_selfRequestedSeatedRecenter = false;
     bool m_dashWasOpenPreviousFrame = false;
     bool m_roomSetupModeDetected = false;
     bool m_seatedModeDetected = false;

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -100,6 +100,8 @@ class MoveCenterTabController : public QObject
             setUniverseCenteredRotation NOTIFY universeCenteredRotationChanged )
     Q_PROPERTY( bool enableSeatedMotion READ enableSeatedMotion WRITE
                     setEnableSeatedMotion NOTIFY enableSeatedMotionChanged )
+    Q_PROPERTY( bool simpleRecenter READ simpleRecenter WRITE setSimpleRecenter
+                    NOTIFY simpleRecenterChanged )
 
 private:
     OverlayController* parent;
@@ -136,7 +138,6 @@ private:
     float m_gravityFloor = 0.0f;
     float m_gravityStrength = 9.8f;
     float m_flingStrength = 1.0f;
-    float m_seatedHeight = 1.0f;
     bool m_momentumSave = false;
     bool m_lockXToggle = false;
     bool m_lockYToggle = false;
@@ -175,7 +176,6 @@ private:
     bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_pendingSeatedRecenter = false;
-    bool m_pendingSeatedReloadFromDisk = false;
     bool m_selfRequestedSeatedRecenter = false;
     bool m_dashWasOpenPreviousFrame = false;
     bool m_roomSetupModeDetected = false;
@@ -185,6 +185,7 @@ private:
     bool m_oldStyleMotion = false;
     bool m_universeCenteredRotation = false;
     bool m_enableSeatedMotion = false;
+    bool m_simpleRecenter = false;
     unsigned settingsUpdateCounter = 0;
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
@@ -192,7 +193,6 @@ private:
     double m_velocity[3] = { 0.0, 0.0, 0.0 };
     std::chrono::steady_clock::time_point m_lastGravityUpdateTimePoint;
     std::chrono::steady_clock::time_point m_lastDragUpdateTimePoint;
-    std::chrono::steady_clock::time_point m_lastSeatedRecenterTimePoint;
     vr::HmdQuad_t* m_collisionBoundsForReset;
     uint32_t m_collisionBoundsCountForReset = 0;
     vr::HmdMatrix34_t m_universeCenterForReset
@@ -258,6 +258,7 @@ public:
     bool oldStyleMotion() const;
     bool universeCenteredRotation() const;
     bool enableSeatedMotion() const;
+    bool simpleRecenter() const;
     bool isInitComplete() const;
     double getHmdYawTotal();
     void resetHmdYawTotal();
@@ -334,6 +335,7 @@ public slots:
     void setOldStyleMotion( bool value, bool notify = true );
     void setUniverseCenteredRotation( bool value, bool notify = true );
     void setEnableSeatedMotion( bool value, bool notify = true );
+    void setSimpleRecenter( bool value, bool notify = true );
 
     void shutdown();
     void reset();
@@ -378,6 +380,7 @@ signals:
     void oldStyleMotionChanged( bool value );
     void universeCenteredRotationChanged( bool value );
     void enableSeatedMotionChanged( bool value );
+    void simpleRecenterChanged( bool value );
 
     void offsetProfilesUpdated();
 };

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -175,6 +175,7 @@ private:
     bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_pendingSeatedRecenter = false;
+    bool m_pendingSeatedReloadFromDisk = false;
     bool m_dashWasOpenPreviousFrame = false;
     bool m_roomSetupModeDetected = false;
     bool m_seatedModeDetected = false;
@@ -190,6 +191,7 @@ private:
     double m_velocity[3] = { 0.0, 0.0, 0.0 };
     std::chrono::steady_clock::time_point m_lastGravityUpdateTimePoint;
     std::chrono::steady_clock::time_point m_lastDragUpdateTimePoint;
+    std::chrono::steady_clock::time_point m_lastSeatedRecenterTimePoint;
     vr::HmdQuad_t* m_collisionBoundsForReset;
     uint32_t m_collisionBoundsCountForReset = 0;
     vr::HmdMatrix34_t m_universeCenterForReset


### PR DESCRIPTION
This pull request attempts to further fix buggy behavior with non lighthouse headsets (tested on WMR) when doing a seated recenter. It accomplishes this by sending a recenter request from OVRAS itself any time there is a VREvent detecting a recenter happening. (there's code to prevent an endless loop)

This also adds an option that can be added directly to the ini file: under [playspaceSettings] settings simpleRecenter=true will restore the old functionality of a single recenter rather than the loop back double recenter. However I couldn't notice any jolting behavior even with the double recenter on Vive, so for now I'm leaving this as a direct .ini file option only and defaulting to the new loopback recenter on all HMDs. 