### PR TITLE
Add version checking feature

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1638,12 +1638,15 @@ void OverlayController::OnNetworkReply( QNetworkReply* reply )
                     << "." << m_remoteVersionMinor << "."
                     << m_remoteVersionPatch << ") available.";
             }
-            else if ( m_optionalMessage.length() > 0 )
+            else
             {
+                if ( m_optionalMessage.length() > 0 )
+                {
+                    setVersionCheckText( m_optionalMessage );
+                }
                 setNewVersionDetected( false );
                 LOG( INFO )
                     << "Version Check: Installed version is latest release.";
-                setVersionCheckText( m_optionalMessage );
             }
         }
         else

--- a/src/res/qml/RootPage.qml
+++ b/src/res/qml/RootPage.qml
@@ -404,13 +404,38 @@ MyStackViewPage {
                        Layout.fillWidth: true
                    }
 
-                   MyText {
-                       id: summaryVersionText
-                       text: "v0.0.0"
-                       font.pointSize: 16
-                       Layout.fillWidth: true
-                       horizontalAlignment: Text.AlignRight
+                   RowLayout {
+
+                           Rectangle {
+                               id: summaryVersionCheckTextRect
+                               visible: true
+                               color: "#1b2939"
+                               MyText {
+                                   id: summaryVersionCheckText
+                                   text: ""
+                                   color: "#fffec8"
+                                   font.pointSize: 22
+                                   minimumPointSize: 11
+                                   fontSizeMode: Text.Fit
+                                   leftPadding: 8
+                                   rightPadding: 8
+                                   horizontalAlignment: Text.AlignHCenter
+                                   width: parent.width
+                                   wrapMode: Text.Wrap
+                               }
+                               height: 40
+                               Layout.fillWidth: true
+                           }
+
+                       MyText {
+                           id: summaryVersionText
+                           text: "v0.0.0"
+                           font.pointSize: 16
+                           horizontalAlignment: Text.AlignRight
+                       }
                    }
+
+
                }
            }
        }
@@ -421,6 +446,13 @@ MyStackViewPage {
        reloadVideoProfiles()
 
        summaryVersionText.text = applicationVersion
+       summaryVersionCheckText.text = OverlayController.versionCheckText
+       if (OverlayController.newVersionDetected)
+       {
+           summaryVersionCheckTextRect.color = "#ff0000"
+       } else {
+           summaryVersionCheckTextRect.color = "#1b2939"
+       }
 
 
        if (MoveCenterTabController.trackingUniverse === 0) {
@@ -437,6 +469,36 @@ MyStackViewPage {
        summaryMicVolumeSlider.value = AudioTabController.micVolume
        summaryMicMuteToggle.checked = AudioTabController.micMuted
        summaryPttToggle.checked = AudioTabController.pttEnabled
+   }
+
+   Connections {
+       target: OverlayController
+       onNewVersionDetectedChanged: {
+           if (OverlayController.newVersionDetected)
+           {
+               summaryVersionCheckTextRect.color = "#ff0000"
+           } else {
+               summaryVersionCheckTextRect.color = "#1b2939"
+           }
+       }
+       onVersionCheckTextChanged: {
+           summaryVersionCheckText.text = OverlayController.versionCheckText
+       }
+       onDisableVersionCheckChanged: {
+           if (OverlayController.disableVersionCheck)
+           {
+               summaryVersionCheckText.visible = false
+               summaryVersionCheckTextRect.color = "#1b2939"
+           } else {
+               summaryVersionCheckText.visible = true
+               if (OverlayController.newVersionDetected)
+               {
+                   summaryVersionCheckTextRect.color = "#ff0000"
+               } else {
+                   summaryVersionCheckTextRect.color = "#1b2939"
+               }
+           }
+       }
    }
 
    Connections {

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -61,6 +61,14 @@ MyStackViewPage {
             }
         }
 
+        MyToggleButton {
+            id: disableVersionCheckToggle
+            text: "Disable Notification of Newer Version Availability"
+            onCheckedChanged: {
+                OverlayController.setDisableVersionCheck(checked, true)
+            }
+        }
+
         RowLayout {
             Layout.fillWidth: true
 
@@ -200,6 +208,7 @@ MyStackViewPage {
             customTickRateMsLabel.visible = vsyncDisabledToggle.checked
             debugStateRow.visible = OverlayController.enableDebug
             debugStateText.text = OverlayController.debugState
+            disableVersionCheckToggle.checked = OverlayController.disableVersionCheck
 
             seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion && MoveCenterTabController.enableSeatedMotion
         }
@@ -252,6 +261,9 @@ MyStackViewPage {
 
             onDebugStateChanged: {
                 debugStateText.text = OverlayController.debugState
+            }
+            onDisableVersionCheckChanged: {
+                disableVersionCheckToggle.checked = OverlayController.disableVersionCheck
             }
         }
     }

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,0 +1,1 @@
+{ "major": 4, "minor": 0, "patch": 0, "updateMessage": "", "optionalMessage": "" }


### PR DESCRIPTION
Addresses #305

This adds the ability to check the github repository for a json file containing information on the latest version. The json can also supply a custom message for when an update is needed as well as an optional message to be displayed even when no update is needed.

This does not do any auto updating. It only checks version numbers and informs the user if a newer one is available.

I've opted for a single enable/disable option in the settings tab for simplicity's sake. I've made the notification an non-obstructive bottom bar on the root tab rather than a pop up, so the desire to disable it's display for clutter's sake should be minimal. The only use case I see for disabling would be for concerns about preventing network connections.

For testing, please edit the application_strings::versionCheckUrl defined in overlaycontroller.h because it points to a file that won't exist on master branch until this is merged.