### PR TITLE
refactored update counter keys to make more sense

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -146,6 +146,19 @@ OverlayController::OverlayController( bool desktopMode,
             nullptr, "OpenVR Advanced Settings Overlay", "Is OpenVR running?" );
         throw std::runtime_error( std::string( "No Overlay interface" ) );
     }
+    // init Update Rates
+    k_audioSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_audioSettingsUpdateCounter );
+    k_chaperoneSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_chaperoneSettingsUpdateCounter );
+    k_moveCenterSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_moveCenterSettingsUpdateCounter );
+    k_settingsTabSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_settingsTabSettingsUpdateCounter );
+    k_steamVrSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_steamVrSettingsUpdateCounter );
+    k_utilitiesSettingsUpdateCounter
+        = utils::adjustUpdateRate( k_utilitiesSettingsUpdateCounter );
 
     // Init controllers
     m_steamVRTabController.initStage1();

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -30,6 +30,7 @@
 #include "openvr/openvr_init.h"
 
 #include "utils/ChaperoneUtils.h"
+#include "utils/FrameRateUtils.h"
 
 #include "tabcontrollers/SteamVRTabController.h"
 #include "tabcontrollers/ChaperoneTabController.h"
@@ -64,15 +65,15 @@ namespace advsettings
 // These counters set timing for refreshing settings changes in tab ui
 // SettingsUpdateCounter values are set as prime numbers to reduce overlap
 // of simultaneous settings updates.
-// Actual rates of updates are counter * vsync (~11ms)
-// Values chosen based on update speed priority
-// Avoid setting values to the same numbers.
-constexpr int k_audioSettingsUpdateCounter = 89;
-constexpr int k_chaperoneSettingsUpdateCounter = 101;
-constexpr int k_moveCenterSettingsUpdateCounter = 83;
-constexpr int k_settingsTabSettingsUpdateCounter = 157;
-constexpr int k_steamVrSettingsUpdateCounter = 97;
-constexpr int k_utilitiesSettingsUpdateCounter = 19;
+// updates are counter * vsync (~11ms) But are modified based on refresh rate
+// assuming 90 hz base Values chosen based on update speed priority Avoid
+// setting values to the same numbers.
+static unsigned int k_audioSettingsUpdateCounter = 89;
+static unsigned int k_chaperoneSettingsUpdateCounter = 101;
+static unsigned int k_moveCenterSettingsUpdateCounter = 83;
+static unsigned int k_settingsTabSettingsUpdateCounter = 157;
+static unsigned int k_steamVrSettingsUpdateCounter = 97;
+static unsigned int k_utilitiesSettingsUpdateCounter = 19;
 // k_nonVsyncTickRate determines number of ms we wait to force the next event
 // loop tick when vsync is too late due to dropped frames.
 constexpr int k_nonVsyncTickRate = 20;

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -21,8 +21,6 @@ void AudioTabController::initStage1()
     audioManager.reset( new AudioManagerDummy() );
 #endif
     audioManager->init( this );
-    m_k_audioSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_audioSettingsUpdateCounter );
     initOverride();
     m_playbackDevices = audioManager->getPlaybackDevices();
     m_recordingDevices = audioManager->getRecordingDevices();
@@ -160,7 +158,7 @@ void AudioTabController::eventLoopTick()
         return;
     }
 
-    if ( settingsUpdateCounter >= m_k_audioSettingsUpdateCounter )
+    if ( settingsUpdateCounter >= k_audioSettingsUpdateCounter )
     {
         vr::EVRSettingsError vrSettingsError;
         char mirrorDeviceId[1024];

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -4,7 +4,6 @@
 #include "AudioManager.h"
 #include "PttController.h"
 #include <memory>
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -74,8 +73,6 @@ private:
     bool m_isDefaultAudioProfile = false;
     bool m_isPlaybackOverride = false;
     bool m_isRecordingOverride = false;
-
-    unsigned int m_k_audioSettingsUpdateCounter = 90;
 
     int m_defaultProfileIndex = -1;
 

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -15,8 +15,6 @@ void ChaperoneTabController::initStage1()
     }
 
     reloadChaperoneProfiles();
-    m_k_chaperoneSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_chaperoneSettingsUpdateCounter );
     eventLoopTick( nullptr );
 }
 
@@ -618,7 +616,7 @@ void ChaperoneTabController::eventLoopTick(
         }
     }
 
-    if ( settingsUpdateCounter >= m_k_chaperoneSettingsUpdateCounter )
+    if ( settingsUpdateCounter >= k_chaperoneSettingsUpdateCounter )
     {
         if ( parent->isDashboardVisible() )
         {

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -7,7 +7,6 @@
 #include <thread>
 #include <openvr.h>
 #include <cmath>
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -158,8 +157,6 @@ private:
     bool m_autosaveComplete = false;
 
     int m_updateTicksChaperoneReload = 0;
-
-    unsigned int m_k_chaperoneSettingsUpdateCounter = 101;
 
     vr::VRActionHandle_t m_rightActionHandle;
     vr::VRActionHandle_t m_leftActionHandle;

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -40,8 +40,6 @@ namespace advsettings
 void MoveCenterTabController::initStage1()
 {
     reloadOffsetProfiles();
-    m_k_moveCenterSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_moveCenterSettingsUpdateCounter );
     m_lastDragUpdateTimePoint = std::chrono::steady_clock::now();
     m_lastGravityUpdateTimePoint = std::chrono::steady_clock::now();
 }

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -5,7 +5,6 @@
 #include <openvr.h>
 #include <chrono>
 #include <qmath.h>
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -167,8 +166,6 @@ private:
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
-
-    unsigned int m_k_moveCenterSettingsUpdateCounter = 83;
 
     double m_velocity[3] = { 0.0, 0.0, 0.0 };
     std::chrono::steady_clock::time_point m_lastGravityUpdateTimePoint;

--- a/src/tabcontrollers/SettingsTabController.cpp
+++ b/src/tabcontrollers/SettingsTabController.cpp
@@ -9,8 +9,6 @@ void SettingsTabController::initStage1()
 {
     m_autoStartEnabled = vr::VRApplications()->GetApplicationAutoLaunch(
         application_strings::applicationKey );
-    m_k_settingsTabSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_settingsTabSettingsUpdateCounter );
 }
 
 void SettingsTabController::initStage2( OverlayController* var_parent )
@@ -20,7 +18,7 @@ void SettingsTabController::initStage2( OverlayController* var_parent )
 
 void SettingsTabController::dashboardLoopTick()
 {
-    if ( settingsUpdateCounter >= m_k_settingsTabSettingsUpdateCounter )
+    if ( settingsUpdateCounter >= k_settingsTabSettingsUpdateCounter )
     {
         setAutoStartEnabled( vr::VRApplications()->GetApplicationAutoLaunch(
             application_strings::applicationKey ) );

--- a/src/tabcontrollers/SettingsTabController.h
+++ b/src/tabcontrollers/SettingsTabController.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <QObject>
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -23,8 +22,6 @@ private:
     unsigned settingsUpdateCounter = 0;
 
     bool m_autoStartEnabled = false;
-
-    unsigned int m_k_settingsTabSettingsUpdateCounter = 157;
 
 public:
     void initStage1();

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -7,8 +7,6 @@ namespace advsettings
 {
 void SteamVRTabController::initStage1()
 {
-    m_k_steamVrSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_steamVrSettingsUpdateCounter );
     dashboardLoopTick();
 }
 
@@ -19,7 +17,7 @@ void SteamVRTabController::initStage2( OverlayController* var_parent )
 
 void SteamVRTabController::dashboardLoopTick()
 {
-    if ( settingsUpdateCounter >= m_k_steamVrSettingsUpdateCounter )
+    if ( settingsUpdateCounter >= k_steamVrSettingsUpdateCounter )
     {
         vr::EVRSettingsError vrSettingsError;
 

--- a/src/tabcontrollers/SteamVRTabController.h
+++ b/src/tabcontrollers/SteamVRTabController.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <QObject>
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -50,8 +49,6 @@ private:
     bool m_cameraDashboard = false;
 
     unsigned settingsUpdateCounter = 0;
-
-    unsigned int m_k_steamVrSettingsUpdateCounter = 97;
 
 public:
     void initStage1();

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -18,9 +18,6 @@ void UtilitiesTabController::initStage1()
         = settings::getSetting( settings::IntSetting::UTILITY_alarmMinute );
 
     m_alarmTime = QTime( qAlarmHour, qAlarmMinute );
-
-    m_k_utilitiesSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_utilitiesSettingsUpdateCounter );
 }
 
 void UtilitiesTabController::initStage2( OverlayController* var_parent )
@@ -429,7 +426,7 @@ vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index )
 
 void UtilitiesTabController::eventLoopTick()
 {
-    if ( settingsUpdateCounter >= m_k_utilitiesSettingsUpdateCounter )
+    if ( settingsUpdateCounter >= k_utilitiesSettingsUpdateCounter )
     {
         if ( alarmEnabled() && m_alarmTime.isValid() )
         {

--- a/src/tabcontrollers/UtilitiesTabController.h
+++ b/src/tabcontrollers/UtilitiesTabController.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include "src/keyboard_input/keyboard_input.h"
 #include "src/media_keys/media_keys.h"
-#include "../utils/FrameRateUtils.h"
 
 class QQuickWindow;
 // application namespace
@@ -42,8 +41,6 @@ private:
         = { 0 };
     int m_batteryState[vr::k_unMaxTrackedDeviceCount];
     bool m_batteryVisible[vr::k_unMaxTrackedDeviceCount];
-
-    unsigned int m_k_utilitiesSettingsUpdateCounter = 19;
 
 public:
     void initStage1();


### PR DESCRIPTION
fixes #313 

Simply refactors keys for update rates so that we don't have `m_k_` and reduces memory consumed by said variables.