### PR TITLE
Add friction feature to motion tab

### DIFF
--- a/src/res/qml/motion_page/gravity/GravityGroupBox.qml
+++ b/src/res/qml/motion_page/gravity/GravityGroupBox.qml
@@ -114,6 +114,43 @@ GroupBox {
             }
 
             Item {
+                Layout.preferredWidth: 40
+            }
+
+            MyText {
+                text: "Friction:"
+                horizontalAlignment: Text.AlignRight
+                Layout.rightMargin: 2
+            }
+
+            MyTextField {
+                id: frictionPercentText
+                text: "0%"
+                keyBoardUID: 156
+                Layout.preferredWidth: 130
+                Layout.leftMargin: 5
+                horizontalAlignment: Text.AlignHCenter
+                function onInputEvent(input) {
+                    var val = parseInt(input)
+                    if (!isNaN(val)) {
+                        if ( val > 999 )
+                        {
+                            val = 999
+                        }
+                        if ( val < 0 )
+                        {
+                            val = 0
+                        }
+
+                        MoveCenterTabController.frictionPercent = val
+                        text = MoveCenterTabController.frictionPercent + "%"
+                    } else {
+                        text = MoveCenterTabController.frictionPercent + "%"
+                    }
+                }
+            }
+
+            Item {
                 Layout.fillWidth: true
             }
 
@@ -166,14 +203,6 @@ GroupBox {
                 }
             }
 
-            MyPushButton2 {
-                Layout.preferredWidth: 50
-                text: "4x"
-                onClicked: {
-                    MoveCenterTabController.flingStrength = 4.0
-                }
-            }
-
 
         }
     }
@@ -183,6 +212,7 @@ GroupBox {
         gravityStrengthText.text = MoveCenterTabController.gravityStrength.toFixed(2)
         momentumToggleButton.checked = MoveCenterTabController.momentumSave
         flingStrengthText.text = MoveCenterTabController.flingStrength.toFixed(2)
+        frictionPercentText.text = MoveCenterTabController.frictionPercent + "%"
     }
 
     Connections {
@@ -199,6 +229,9 @@ GroupBox {
         }
         onFlingStrengthChanged: {
             flingStrengthText.text = MoveCenterTabController.flingStrength.toFixed(2)
+        }
+        onFrictionPercentChanged: {
+            frictionPercentText.text = MoveCenterTabController.frictionPercent + "%"
         }
     }
 }

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -455,6 +455,10 @@ private:
                          SettingCategory::Playspace,
                          QtInfo{ "turnComfortFactor" },
                          0 },
+        IntSettingValue{ IntSetting::PLAYSPACE_frictionPercent,
+                         SettingCategory::Playspace,
+                         QtInfo{ "frictionPercent" },
+                         0 },
 
         IntSettingValue{ IntSetting::APPLICATION_debugState,
                          SettingCategory::Application,

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -90,6 +90,7 @@ enum class IntSetting
     PLAYSPACE_smoothTurnRate,
     PLAYSPACE_dragComfortFactor,
     PLAYSPACE_turnComfortFactor,
+    PLAYSPACE_frictionPercent,
 
     APPLICATION_debugState,
     APPLICATION_customTickRateMs,

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -17,6 +17,9 @@ constexpr double k_radiansToCentidegrees = 18000.0 / M_PI;
 constexpr double k_quaternionInvalidValue = -1000.0;
 constexpr double k_quaternionUnderIsInvalidValueThreshold = -900.0;
 constexpr double k_terminalVelocity_mps = 50.0;
+// k_frictionHalt_mps must be sufficiently small to allow a single tick of
+// gravity through
+constexpr double k_frictionHalt_mps = 0.0000001;
 // give the max offset a buffer to avoid crossing when traveling at astronomical
 // velocities
 constexpr double k_maxOpenvrWorkingSetOffest = 39900.0;
@@ -53,6 +56,8 @@ class MoveCenterTabController : public QObject
                     NOTIFY snapTurnAngleChanged )
     Q_PROPERTY( int smoothTurnRate READ smoothTurnRate WRITE setSmoothTurnRate
                     NOTIFY smoothTurnRateChanged )
+    Q_PROPERTY( int frictionPercent READ frictionPercent WRITE
+                    setFrictionPercent NOTIFY frictionPercentChanged )
     Q_PROPERTY( bool adjustChaperone READ adjustChaperone WRITE
                     setAdjustChaperone NOTIFY adjustChaperoneChanged )
     Q_PROPERTY( bool moveShortcutRight READ moveShortcutRight WRITE
@@ -214,6 +219,7 @@ public:
     int tempRotation() const;
     int snapTurnAngle() const;
     int smoothTurnRate() const;
+    int frictionPercent() const;
     bool adjustChaperone() const;
     bool moveShortcutRight() const;
     bool moveShortcutLeft() const;
@@ -285,6 +291,7 @@ public slots:
     void setTempRotation( int value, bool notify = true );
     void setSnapTurnAngle( int value, bool notify = true );
     void setSmoothTurnRate( int value, bool notify = true );
+    void setFrictionPercent( int value, bool notify = true );
 
     void setAdjustChaperone( bool value, bool notify = true );
     void setMoveShortcutRight( bool value, bool notify = true );
@@ -336,6 +343,7 @@ signals:
     void tempRotationChanged( int value );
     void snapTurnAngleChanged( int value );
     void smoothTurnRateChanged( int value );
+    void frictionPercentChanged( int value );
     void adjustChaperoneChanged( bool value );
     void moveShortcutRightChanged( bool value );
     void moveShortcutLeftChanged( bool value );


### PR DESCRIPTION
This adds a "friction" feature to the motion tab as per issue #344

When set to "0%" (default) it does nothing, but when larger percentages are used it degrades current velocity depending on the percentage. Degradation is relative to velocity so that it will feel something like wind resistance. When motion is very very small it instead halts velocity.

A value of 100% will bring the user to a full stop within roughly 1 second. The max value is 999% and min is 0%. Most useful values should be found within the range of 20%~80%.

Additionally this PR prevents the new settings api from saving reversed gravity caused by the binding to settings. It instead checks the reversed gravity bind on gravity processing and reverses the strength value within the gravity update function without touching the gravity strength setting itself.