### PR TITLE
Add switch for debug symbols and logging, and add PKGBUILD for Arch/Manjaro

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ Adds an overlay to the OpenVR dashboard that allows access to advanced settings 
      * [Standalone](#standalone)
   * [Linux](#linux)
      * [AppImage](#appimage)
+     * [Arch/Manjaro](#archmanjaro)
      * [Building from Source](#building-from-source)
   * [Bindings](#bindings)
      * [Music](#music)
@@ -106,6 +107,11 @@ The AppImage can be found in the [release section](https://github.com/OpenVR-Adv
 Simply double click the AppImage once downloaded to run it. Depending on your distribution you may need to make it executable with `chmod +x OpenVR_Advanced_Settings*`.
 
 If the AppImage doesn't work for whatever reason, please create an issue [here](https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/new/choose) describing the problem and try compiling from source.
+
+### Arch/Manjaro
+
+OpenVR Advanced Settings is on the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) as `ovras`.
+Manjaro users can [enable](https://wiki.manjaro.org/index.php/Arch_User_Repository) the AUR and install this package using `pamac build ovras`.
 
 ### Building from Source
 

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -118,3 +118,8 @@ unix {
     INSTALLS += application
 }
 
+debugSymbolsAndLogs {
+    message(Debug symbols and logging enabled.)
+    CONFIG += force_debug_info
+    DEFINES += ENABLE_DEBUG_LOGGING
+}

--- a/build_scripts/linux/PKGBUILD
+++ b/build_scripts/linux/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Vitaly Utkin <vautkin AT teknik DOT io>
+pkgname=ovras
+pkgver=4.0.1
+pkgrel=2
+epoch=0
+pkgdesc="Advanced settings and custom behavior for SteamVR using OpenVR."
+arch=("x86_64")
+url="https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings"
+license=("GPL")
+depends=("qt5-declarative"
+         "qt5-multimedia"
+         "libudev0-shim"
+         "mesa")
+optdepends=("dbus: media player support"
+            "xorg-server: send keyboard keys")
+source=("https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/archive/v$pkgver.tar.gz")
+sha256sums=("371d5a3f81a986ec5b3446c62a36cbf5eb951c97ea2b4a64752c4709bb8e6c76")
+
+build() {
+    cd "OpenVR-AdvancedSettings-$pkgver"
+
+    _additionalOptions=
+
+    # Attempting to compile without package will result in compile error
+    pacman -Qi xorg-server >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        _additionalOptions="CONFIG+=noX11"
+        echo "X11 features disabled."
+    else
+        echo "X11 features enabled."
+    fi
+
+    # Attempting to compile without package will result in compile error
+    pacman -Qi dbus >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        _additionalOptions+=" CONFIG+=noDBUS"
+        echo "DBUS features disabled."
+    else
+        echo "DBUS features enabled."
+    fi
+
+    qmake PREFIX="$pkgdir/opt/" $_additionalOptions
+    make
+}
+
+package() {
+    cd "OpenVR-AdvancedSettings-$pkgver"
+
+    # Add .desktop file
+    mkdir -p "$pkgdir/usr/share/applications"
+    cp "src/package_files/linux/AdvancedSettings.desktop" "$pkgdir/usr/share/applications/"
+    sed -i 's/Exec=.*/Exec=\/opt\/AdvancedSettings\/AdvancedSettings/' "$pkgdir/usr/share/applications/AdvancedSettings.desktop"
+
+    # Add correct desktop icon to desktop file
+    sed -i 's/Icon=.*/Icon=\/opt\/AdvancedSettings\/AdvancedSettings.png/' "$pkgdir/usr/share/applications/AdvancedSettings.desktop"
+    # Dir doesn't exist before `make install`
+    mkdir -p "$pkgdir/opt/AdvancedSettings/"
+    cp "src/res/img/icons/thumbicon.png" "$pkgdir/opt/AdvancedSettings/AdvancedSettings.png"
+
+    # Make program use correct working dir
+    echo "Path=/opt/AdvancedSettings" >> "$pkgdir/usr/share/applications/AdvancedSettings.desktop"
+
+    # Enable command line usage
+    mkdir -p "$pkgdir/usr/bin/"
+    ln -s /opt/AdvancedSettings/AdvancedSettings "$pkgdir/usr/bin/ovras"
+
+    # Install
+    make install
+}

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -296,7 +296,7 @@ sudo pacman --noconfirm -S git
 git clone https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings --depth=1
 cd OpenVR-AdvancedSettings
 # Install build tools
-sudo pacman --noconfirm -S base-devel mesa
+sudo pacman --noconfirm -S base-devel mesa libudev0-shim
 # Install Qt
 sudo pacman --noconfirm -S qt5-declarative qt5-multimedia
 # Install additional features

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -306,6 +306,9 @@ qmake
 make -j2
 ```
 
+A stable version can also be found on the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) as `ovras`.
+It can be installed with `pamac build ovras`.
+
 # Building
 
 You will need the requirements above.

--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -334,6 +334,7 @@ The following values can be appended to the `CONFIG` internal variable in order 
 | ----- | ------- |
 | `noX11` | Disables X11 specific features (VR to keyboard input). |
 | `noDBUS` | Disables DBUS specific features (control media players). |
+| `debugSymbolsAndLogs` | Enables debug symbols and debug logging calls (while still having release optimizations). |
 
 The values are case sensitive.
 

--- a/src/utils/setup.cpp
+++ b/src/utils/setup.cpp
@@ -1,4 +1,9 @@
 #include "setup.h"
+#ifdef ENABLE_DEBUG_LOGGING
+constexpr auto debugLoggingEnabled = true;
+#else
+constexpr auto debugLoggingEnabled = false;
+#endif
 
 // The default Qt message handler prints to stdout on X11 and to the debugger on
 // Windows. That is borderline useless for us, therefore we create our own
@@ -317,7 +322,15 @@ void setUpLogging()
 
     constexpr auto confDisabled = "false";
     conf.set( Level::Trace, ConfigurationType::Enabled, confDisabled );
-    conf.set( Level::Debug, ConfigurationType::Enabled, confDisabled );
+
+    if constexpr ( debugLoggingEnabled )
+    {
+        conf.set( Level::Debug, ConfigurationType::Enabled, confEnabled );
+    }
+    else
+    {
+        conf.set( Level::Debug, ConfigurationType::Enabled, confDisabled );
+    }
 
     const auto appDataLocation
         = std::string( "/" ) + application_strings::applicationOrganizationName


### PR DESCRIPTION
## Debug Symbols and Logging:
Adds the switch `debugSymbolsAndLogs` which can be added to the `CONFIG` variable in order to enable debug symbols and debug logging to be enabled, while still using release optimizations. This is very useful for debugging issues that occur with release optimizations.
This also means we can use more explicit `LOG(DEBUG)` calls in our code, since it can actually be used. To enable this you simply add it to the `CONFIG` variable in `advancedSettings.pro` like `CONFIG   += c++1z file_copies debugSymbolsAndLogs`. 
Fixes #334.

## PKGBUILD
Adds a `PKGBUILD` file for easy building on Arch/Manjaro. This file is also hosted on the [Arch User Repository](https://aur.archlinux.org/packages/ovras/) and can now be installed from the command line (or GUI) on all Arch/Manjaro systems.
While the `PKGBUILD` file essentially just gets dependencies and then builds from source, it is significantly better since it integrates with the package manager and desktop environments.
The `PKGBUILD` file does not use the `master` branch from the repo, instead it downloads the `v4.0.1` repository from the release page.