### PR TITLE
Move profile structs to settings object API, change header name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,12 +40,6 @@ int main( int argc, char* argv[] )
 
     try
     {
-        QSettings appSettings( QSettings::IniFormat,
-                               QSettings::UserScope,
-                               mainEventLoop.organizationName(),
-                               mainEventLoop.applicationName() );
-        advsettings::OverlayController::setAppSettings( &appSettings );
-
         QQmlEngine qmlEngine;
 
         advsettings::OverlayController controller( commandLineArgs.desktopMode,

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -26,8 +26,6 @@
 // application namespace
 namespace advsettings
 {
-QSettings* OverlayController::_appSettings = nullptr;
-
 int verifyCustomTickRate( const int tickRate )
 {
     if ( tickRate < 1 )

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -11,7 +11,6 @@
 #include <QVector2D>
 #include <QVector3D>
 #include <QObject>
-#include <QSettings>
 #include <QQmlEngine>
 #include <QtGui/QOpenGLContext>
 #include <QtWidgets/QGraphicsScene>
@@ -279,20 +278,6 @@ signals:
     void vsyncDisabledChanged( bool value );
     void customTickRateMsChanged( int value );
     void debugStateChanged( int value );
-
-private:
-    static QSettings* _appSettings;
-
-public:
-    static QSettings* appSettings()
-    {
-        return _appSettings;
-    }
-
-    static void setAppSettings( QSettings* settings )
-    {
-        _appSettings = settings;
-    }
 };
 
 } // namespace advsettings

--- a/src/res/qml/RootPage.qml
+++ b/src/res/qml/RootPage.qml
@@ -12,7 +12,7 @@ MyStackViewPage {
     id: rootPage
     width: 1200
     height: 800
-    headerText: "OpenVR Advanced Settings"
+    headerText: "OVR Advanced Settings"
     headerShowBackButton: false
     stackView: mainView
     content: Item {

--- a/src/settings/internal/settings_object_data.h
+++ b/src/settings/internal/settings_object_data.h
@@ -9,30 +9,35 @@ class SettingsObjectData
 public:
     template <typename Value> void addValue( const Value value )
     {
-        std::list<Value>& list = getListObject<Value>();
+        auto& list = getListObject<Value>();
 
         list.push_back( value );
     }
 
     template <typename Value>
-    Value getNextValueOrDefault( const Value defaultValue )
+    auto getNextValueOrDefault( const Value defaultValue )
     {
-        Value returnedValue = defaultValue;
-
-        std::list<Value>& list = getListObject<Value>();
+        auto& list = getListObject<Value>();
 
         if ( hasValuesOfType<Value>() )
         {
-            returnedValue = list.front();
+            auto returnedValue = list.front();
             list.pop_front();
+            return returnedValue;
         }
-
-        return returnedValue;
+        if constexpr ( std::is_same<const char*, Value>::value )
+        {
+            return std::string( defaultValue );
+        }
+        else
+        {
+            return defaultValue;
+        }
     }
 
     template <typename Value> bool hasValuesOfType()
     {
-        std::list<Value>& list = getListObject<Value>();
+        auto& list = getListObject<Value>();
 
         return !list.empty();
     }
@@ -48,13 +53,14 @@ public:
     }
 
 private:
-    template <typename Value> std::list<Value>& getListObject()
+    template <typename Value> auto& getListObject()
     {
         using std::is_same;
         const auto isBool = is_same<bool, Value>::value;
         const auto isInt = is_same<int, Value>::value;
         const auto isDouble = is_same<double, Value>::value;
-        const auto isString = is_same<std::string, Value>::value;
+        const auto isString = is_same<std::string, Value>::value
+                              || is_same<const char*, Value>::value;
 
         static_assert( isBool || isInt || isDouble || isString,
                        "Type is not supported for the settings object." );

--- a/src/settings/internal/settings_object_data.h
+++ b/src/settings/internal/settings_object_data.h
@@ -59,8 +59,12 @@ private:
         const auto isBool = is_same<bool, Value>::value;
         const auto isInt = is_same<int, Value>::value;
         const auto isDouble = is_same<double, Value>::value;
+        const auto isFloat = is_same<float, Value>::value;
         const auto isString = is_same<std::string, Value>::value
                               || is_same<const char*, Value>::value;
+
+        static_assert( !isFloat,
+                       "'float' is not supported. Use 'double' instead." );
 
         static_assert( isBool || isInt || isDouble || isString,
                        "Type is not supported for the settings object." );

--- a/src/settings/settings_object.cpp
+++ b/src/settings/settings_object.cpp
@@ -65,7 +65,11 @@ std::list<Value> loadListFromDisk( const std::string structName,
     const auto isBool = is_same<bool, Value>::value;
     const auto isInt = is_same<int, Value>::value;
     const auto isDouble = is_same<double, Value>::value;
+    const auto isFloat = is_same<float, Value>::value;
     const auto isString = is_same<std::string, Value>::value;
+
+    static_assert( !isFloat,
+                   "'float' is not supported. Use 'double' instead." );
 
     static_assert( isBool || isInt || isDouble || isString,
                    "Type is not supported for the settings object." );

--- a/src/settings/settings_object.h
+++ b/src/settings/settings_object.h
@@ -92,6 +92,54 @@ void loadObject( ISettingsObject& obj );
 void saveNumberedObject( const ISettingsObject& obj, const int slot );
 
 /*!
+   \brief Saves \a vec of \c ISettingsObject.
+   \param vec Vector of \c ISettingsObject derived objects.
+
+   Saves the objects starting from \c slot 1 to \c slot \c{1 + vec.size()}.
+*/
+template <class T> void saveAllObjects( const std::vector<T> vec )
+{
+    static_assert(
+        std::is_base_of<ISettingsObject, T>::value,
+        "Only objects that inherit from ISettingsObject can be saved." );
+
+    auto i = 1;
+    for ( auto& p : vec )
+    {
+        saveNumberedObject( p, i );
+        ++i;
+    }
+}
+
+/*!
+   \brief Loads \a vec of \c ISettingsObject.
+   \param vec Vector of \c ISettingsObject derived objects.
+
+   Loads the objects starting from \c slot 1 to the last contiguous object.
+*/
+template <class T> void loadAllObjects( std::vector<T>& vec )
+{
+    static_assert(
+        std::is_base_of<ISettingsObject, T>::value,
+        "Only objects that inherit from ISettingsObject can be loaded." );
+
+    vec.clear();
+
+    // We'll need to know which name the object is saved under.
+    // We could check vec.at(0), but it's not guaranteed to exist.
+    auto o = T{};
+    auto profileCount = getAmountOfSavedObjects( o );
+    for ( int profileNumber = 1; profileNumber < profileCount; ++profileNumber )
+    {
+        vec.emplace_back();
+
+        const auto index = static_cast<size_t>( profileNumber - 1 );
+
+        loadNumberedObject( vec.at( index ), profileNumber );
+    }
+}
+
+/*!
    \brief Loads \a obj from permanent storage in a numbered \a slot.
    \param obj Object to load.
    \param slot Specific object to load.

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include "../overlaycontroller.h"
 #include "../settings/settings.h"
+#include "../settings/settings_object.h"
 #ifdef _WIN32
 #    include "audiomanager/AudioManagerWindows.h"
 #else
@@ -672,111 +673,14 @@ void AudioTabController::findMicDeviceIndex( std::string id, bool notify )
     }
 }
 
-/*AUDIO PROFILE FUNCTIONS
-The following section includes the code required to save and load Audio
-Profiles.
-
-Saved Settings Include:
-Playback Device
-Mirror Device
-Mirror Vol
-Microphone
-Microphone Volume
-Profile Name
-
-*/
-
-/*
-    Name:  reloadAudioProfiles
-
-    Inputs: args: none
-            other: Reads audioProfiles setting from file
-
-
-    Output: return:none
-            other:none
-
-    Description: Clears working copy, and reloads from Settings file.
-
-*/
 void AudioTabController::reloadAudioProfiles()
 {
-    audioProfiles.clear();
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( getSettingsName() );
-    auto profileCount = settings->beginReadArray( "audioProfiles" );
-    for ( int i = 0; i < profileCount; i++ )
-    {
-        settings->setArrayIndex( i );
-        audioProfiles.emplace_back();
-        auto& entry = audioProfiles[static_cast<size_t>( i )];
-        entry.profileName
-            = settings->value( "profileName" ).toString().toStdString();
-        entry.playbackName
-            = settings->value( "playbackName" ).toString().toStdString();
-        entry.micName = settings->value( "micName" ).toString().toStdString();
-        entry.mirrorName
-            = settings->value( "mirrorName" ).toString().toStdString();
-        entry.micMute = settings->value( "micMute", false ).toBool();
-        entry.mirrorMute = settings->value( "mirrorMute", false ).toBool();
-        entry.mirrorVol = settings->value( "mirrorVol", 0.0 ).toFloat();
-        entry.micVol = settings->value( "micVol", 1.0 ).toFloat();
-        entry.defaultProfile
-            = settings->value( "defaultProfile", false ).toBool();
-        entry.mirrorID = settings->value( "mirrorID" ).toString().toStdString();
-        entry.recordingID
-            = settings->value( "recordingID" ).toString().toStdString();
-        entry.playbackID
-            = settings->value( "playbackID" ).toString().toStdString();
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::loadAllObjects( audioProfiles );
 }
 
-/*
-Name: saveAudioProfile
-
-Inputs: args: none
-other: none
-
-
-Output: return: none
-other: Writes audioProfiles setting to file
-
-Description: saves a copy of the audio profiles from working to Settings file.
-
-*/
 void AudioTabController::saveAudioProfiles()
 {
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( getSettingsName() );
-    settings->beginWriteArray( "audioProfiles" );
-    int i = 0;
-    for ( auto& p : audioProfiles )
-    {
-        settings->setArrayIndex( i );
-        settings->setValue( "profileName",
-                            QString::fromStdString( p.profileName ) );
-        settings->setValue( "playbackName",
-                            QString::fromStdString( p.playbackName ) );
-        settings->setValue( "micName", QString::fromStdString( p.micName ) );
-        settings->setValue( "mirrorName",
-                            QString::fromStdString( p.mirrorName ) );
-        settings->setValue( "micMute", p.micMute );
-        settings->setValue( "mirrorMute", p.mirrorMute );
-        settings->setValue( "micVol", p.micVol );
-        settings->setValue( "mirrorVol", p.mirrorVol );
-        settings->setValue( "defaultProfile", p.defaultProfile );
-
-        settings->setValue( "playbackID",
-                            QString::fromStdString( p.playbackID ) );
-        settings->setValue( "mirrorID", QString::fromStdString( p.mirrorID ) );
-        settings->setValue( "recordingID",
-                            QString::fromStdString( p.recordingID ) );
-        i++;
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::saveAllObjects( audioProfiles );
 }
 
 /*
@@ -838,7 +742,6 @@ void AudioTabController::addAudioProfile( QString name )
         setAudioProfileDefault( false );
     }
     saveAudioProfiles();
-    OverlayController::appSettings()->sync();
     emit audioProfilesUpdated();
     emit audioProfileAdded();
 }
@@ -949,7 +852,6 @@ void AudioTabController::deleteAudioProfile( unsigned index )
         }
         audioProfiles.erase( pos );
         saveAudioProfiles();
-        OverlayController::appSettings()->sync();
         emit audioProfilesUpdated();
     }
 }

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -6,6 +6,7 @@
 #include "audiomanager/AudioManager.h"
 #include <memory>
 #include "../utils/FrameRateUtils.h"
+#include "../settings/settings_object.h"
 
 class QQuickWindow;
 // application namespace
@@ -14,7 +15,7 @@ namespace advsettings
 // forward declaration
 class OverlayController;
 
-struct AudioProfile
+struct AudioProfile : settings::ISettingsObject
 {
     std::string profileName;
     std::string playbackName;
@@ -24,10 +25,54 @@ struct AudioProfile
     std::string playbackID;
     std::string mirrorID;
     float mirrorVol = 0.0;
-    float micVol = 0.0;
+    float micVol = 1.0;
     bool micMute = false;
     bool mirrorMute = false;
     bool defaultProfile = false;
+
+    virtual settings::SettingsObjectData saveSettings() const
+    {
+        settings::SettingsObjectData o;
+
+        o.addValue( profileName );
+        o.addValue( playbackName );
+        o.addValue( mirrorName );
+        o.addValue( micName );
+        o.addValue( recordingID );
+        o.addValue( playbackID );
+        o.addValue( mirrorID );
+
+        o.addValue( static_cast<double>( mirrorVol ) );
+        o.addValue( static_cast<double>( micVol ) );
+
+        o.addValue( micMute );
+        o.addValue( mirrorMute );
+        o.addValue( defaultProfile );
+
+        return o;
+    }
+
+    virtual void loadSettings( settings::SettingsObjectData& obj )
+    {
+        profileName = obj.getNextValueOrDefault( "" );
+        playbackName = obj.getNextValueOrDefault( "" );
+        mirrorName = obj.getNextValueOrDefault( "" );
+        micName = obj.getNextValueOrDefault( "" );
+        recordingID = obj.getNextValueOrDefault( "" );
+        playbackID = obj.getNextValueOrDefault( "" );
+        mirrorID = obj.getNextValueOrDefault( "" );
+
+        mirrorVol = static_cast<float>( obj.getNextValueOrDefault( 0.0 ) );
+        micVol = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+        micMute = obj.getNextValueOrDefault( false );
+        mirrorMute = obj.getNextValueOrDefault( false );
+        defaultProfile = obj.getNextValueOrDefault( false );
+    }
+
+    virtual std::string settingsName() const
+    {
+        return "AudioTabController::AudioProfile";
+    }
 };
 
 class AudioTabController : public QObject
@@ -97,10 +142,6 @@ private:
 
     std::recursive_mutex eventLoopMutex;
 
-    QString getSettingsName()
-    {
-        return "audioSettings";
-    }
     void onPttStart();
     void onPttStop();
     void onPttEnabled();

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -36,285 +36,12 @@ ChaperoneTabController::~ChaperoneTabController()
 
 void ChaperoneTabController::reloadChaperoneProfiles()
 {
-    chaperoneProfiles.clear();
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "chaperoneSettings" );
-    auto profileCount = settings->beginReadArray( "chaperoneProfiles" );
-    for ( int i = 0; i < profileCount; i++ )
-    {
-        settings->setArrayIndex( i );
-        chaperoneProfiles.emplace_back();
-        auto& entry = chaperoneProfiles[static_cast<size_t>( i )];
-        entry.profileName
-            = settings->value( "profileName" ).toString().toStdString();
-        entry.includesChaperoneGeometry
-            = settings->value( "includesChaperoneGeometry", false ).toBool();
-        if ( entry.includesChaperoneGeometry )
-        {
-            entry.chaperoneGeometryQuadCount
-                = settings->value( "chaperoneGeometryQuadCount", 0 ).toUInt();
-            entry.chaperoneGeometryQuads.reset(
-                new vr::HmdQuad_t[entry.chaperoneGeometryQuadCount] );
-            unsigned qi = 0;
-            for ( auto q :
-                  settings->value( "chaperoneGeometryQuads" ).toList() )
-            {
-                unsigned ci = 0;
-                for ( auto c : q.toList() )
-                {
-                    unsigned cci = 0;
-                    for ( auto cc : c.toList() )
-                    {
-                        entry.chaperoneGeometryQuads.get()[qi]
-                            .vCorners[ci]
-                            .v[cci]
-                            = cc.toFloat();
-                        cci++;
-                    }
-                    ci++;
-                }
-                qi++;
-            }
-            unsigned i1 = 0;
-            for ( auto l1 : settings->value( "standingCenter" ).toList() )
-            {
-                unsigned i2 = 0;
-                for ( auto l2 : l1.toList() )
-                {
-                    entry.standingCenter.m[i1][i2] = l2.toFloat();
-                    i2++;
-                }
-                i1++;
-            }
-            entry.playSpaceAreaX
-                = settings->value( "playSpaceAreaX", 0.0f ).toFloat();
-            entry.playSpaceAreaZ
-                = settings->value( "playSpaceAreaZ", 0.0f ).toFloat();
-        }
-        entry.includesVisibility
-            = settings->value( "includesVisibility", false ).toBool();
-        if ( entry.includesVisibility )
-        {
-            entry.visibility = settings->value( "visibility", 0.6 ).toFloat();
-        }
-        entry.includesFadeDistance
-            = settings->value( "includesFadeDistance", false ).toBool();
-        if ( entry.includesFadeDistance )
-        {
-            entry.fadeDistance
-                = settings->value( "fadeDistance", 0.7 ).toFloat();
-        }
-        entry.includesCenterMarker
-            = settings->value( "includesCenterMarker", false ).toBool();
-        if ( entry.includesCenterMarker )
-        {
-            entry.centerMarker
-                = settings->value( "centerMarker", false ).toBool();
-        }
-        entry.includesPlaySpaceMarker
-            = settings->value( "includesPlaySpaceMarker", false ).toBool();
-        if ( entry.includesPlaySpaceMarker )
-        {
-            entry.playSpaceMarker
-                = settings->value( "playSpaceMarker", false ).toBool();
-        }
-        entry.includesFloorBoundsMarker
-            = settings->value( "includesFloorBoundsMarker", false ).toBool();
-        if ( entry.includesFloorBoundsMarker )
-        {
-            entry.floorBoundsMarker
-                = settings->value( "floorBoundsMarker", false ).toBool();
-        }
-        entry.includesBoundsColor
-            = settings->value( "includesBoundsColor", false ).toBool();
-        if ( entry.includesBoundsColor )
-        {
-            auto color = settings->value( "boundsColor" ).toList();
-            entry.boundsColor[0] = color[0].toInt();
-            entry.boundsColor[1] = color[1].toInt();
-            entry.boundsColor[2] = color[2].toInt();
-        }
-        entry.includesChaperoneStyle
-            = settings->value( "includesChaperoneStyle", false ).toBool();
-        if ( entry.includesChaperoneStyle )
-        {
-            entry.chaperoneStyle
-                = settings->value( "chaperoneStyle", 0 ).toInt();
-        }
-        entry.includesForceBounds
-            = settings->value( "includesForceBounds", false ).toBool();
-        if ( entry.includesForceBounds )
-        {
-            entry.forceBounds
-                = settings->value( "forceBounds", false ).toBool();
-        }
-        entry.includesProximityWarningSettings
-            = settings->value( "includesProximityWarningSettings", false )
-                  .toBool();
-        if ( entry.includesProximityWarningSettings )
-        {
-            entry.enableChaperoneSwitchToBeginner
-                = settings->value( "chaperoneSwitchToBeginnerEnabled", false )
-                      .toBool();
-            entry.chaperoneSwitchToBeginnerDistance
-                = settings->value( "chaperoneSwitchToBeginnerDistance", 0.5f )
-                      .toFloat();
-            entry.enableChaperoneHapticFeedback
-                = settings->value( "chaperoneHapticFeedbackEnabled", false )
-                      .toBool();
-            entry.chaperoneHapticFeedbackDistance
-                = settings->value( "chaperoneHapticFeedbackDistance", 0.5f )
-                      .toFloat();
-            entry.enableChaperoneAlarmSound
-                = settings->value( "chaperoneAlarmSoundEnabled", false )
-                      .toBool();
-            entry.chaperoneAlarmSoundLooping
-                = settings->value( "chaperoneAlarmSoundLooping", true )
-                      .toBool();
-            entry.chaperoneAlarmSoundAdjustVolume
-                = settings->value( "chaperoneAlarmSoundAdjustVolume", false )
-                      .toBool();
-            entry.chaperoneAlarmSoundDistance
-                = settings->value( "chaperoneAlarmSoundDistance", 0.5f )
-                      .toFloat();
-            entry.enableChaperoneShowDashboard
-                = settings->value( "chaperoneShowDashboardEnabled", false )
-                      .toBool();
-            entry.chaperoneShowDashboardDistance
-                = settings->value( "chaperoneShowDashboardDistance", 0.5f )
-                      .toFloat();
-        }
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::loadAllObjects( chaperoneProfiles );
 }
 
 void ChaperoneTabController::saveChaperoneProfiles()
 {
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "chaperoneSettings" );
-    settings->beginWriteArray( "chaperoneProfiles" );
-    unsigned i = 0;
-    for ( auto& p : chaperoneProfiles )
-    {
-        settings->setArrayIndex( static_cast<int>( i ) );
-        settings->setValue( "profileName",
-                            QString::fromStdString( p.profileName ) );
-        settings->setValue( "includesChaperoneGeometry",
-                            p.includesChaperoneGeometry );
-        if ( p.includesChaperoneGeometry )
-        {
-            settings->setValue( "chaperoneGeometryQuadCount",
-                                p.chaperoneGeometryQuadCount );
-            QVariantList quadList;
-            for ( unsigned qi = 0; qi < p.chaperoneGeometryQuadCount; qi++ )
-            {
-                QVariantList cornerList;
-                for ( unsigned ci = 0; ci < 4; ci++ )
-                {
-                    QVariantList coordVector;
-                    for ( unsigned cci = 0; cci < 3; cci++ )
-                    {
-                        coordVector.push_back(
-                            p.chaperoneGeometryQuads.get()[qi]
-                                .vCorners[ci]
-                                .v[cci] );
-                    }
-                    cornerList.push_back( coordVector );
-                }
-                quadList.push_back( cornerList );
-            }
-            settings->setValue( "chaperoneGeometryQuads", quadList );
-            QVariantList l1;
-            for ( unsigned i1 = 0; i1 < 3; i1++ )
-            {
-                QVariantList l2;
-                for ( unsigned i2 = 0; i2 < 4; i2++ )
-                {
-                    l2.push_back( p.standingCenter.m[i1][i2] );
-                }
-                l1.push_back( l2 );
-            }
-            settings->setValue( "standingCenter", l1 );
-            settings->setValue( "playSpaceAreaX", p.playSpaceAreaX );
-            settings->setValue( "playSpaceAreaZ", p.playSpaceAreaZ );
-        }
-        settings->setValue( "includesVisibility", p.includesVisibility );
-        if ( p.includesVisibility )
-        {
-            settings->setValue( "visibility", p.visibility );
-        }
-        settings->setValue( "includesFadeDistance", p.includesFadeDistance );
-        if ( p.includesFadeDistance )
-        {
-            settings->setValue( "fadeDistance", p.fadeDistance );
-        }
-        settings->setValue( "includesCenterMarker", p.includesCenterMarker );
-        if ( p.includesCenterMarker )
-        {
-            settings->setValue( "centerMarker", p.centerMarker );
-        }
-        settings->setValue( "includesPlaySpaceMarker",
-                            p.includesPlaySpaceMarker );
-        if ( p.includesPlaySpaceMarker )
-        {
-            settings->setValue( "playSpaceMarker", p.playSpaceMarker );
-        }
-        settings->setValue( "includesFloorBoundsMarker",
-                            p.includesFloorBoundsMarker );
-        if ( p.includesFloorBoundsMarker )
-        {
-            settings->setValue( "floorBoundsMarker", p.floorBoundsMarker );
-        }
-        settings->setValue( "includesBoundsColor", p.includesBoundsColor );
-        if ( p.includesBoundsColor )
-        {
-            QVariantList color;
-            color.push_back( p.boundsColor[0] );
-            color.push_back( p.boundsColor[1] );
-            color.push_back( p.boundsColor[2] );
-            settings->setValue( "boundsColor", color );
-        }
-        settings->setValue( "includesChaperoneStyle",
-                            p.includesChaperoneStyle );
-        if ( p.includesChaperoneStyle )
-        {
-            settings->setValue( "chaperoneStyle", p.chaperoneStyle );
-        }
-        settings->setValue( "includesForceBounds", p.includesForceBounds );
-        if ( p.includesForceBounds )
-        {
-            settings->setValue( "forceBounds", p.forceBounds );
-        }
-        settings->setValue( "includesProximityWarningSettings",
-                            p.includesProximityWarningSettings );
-        if ( p.includesProximityWarningSettings )
-        {
-            settings->setValue( "chaperoneSwitchToBeginnerEnabled",
-                                p.enableChaperoneSwitchToBeginner );
-            settings->setValue( "chaperoneSwitchToBeginnerDistance",
-                                p.chaperoneSwitchToBeginnerDistance );
-            settings->setValue( "chaperoneHapticFeedbackEnabled",
-                                p.enableChaperoneHapticFeedback );
-            settings->setValue( "chaperoneHapticFeedbackDistance",
-                                p.chaperoneHapticFeedbackDistance );
-            settings->setValue( "chaperoneAlarmSoundEnabled",
-                                p.enableChaperoneAlarmSound );
-            settings->setValue( "chaperoneAlarmSoundLooping",
-                                p.chaperoneAlarmSoundLooping );
-            settings->setValue( "chaperoneAlarmSoundAdjustVolume",
-                                p.chaperoneAlarmSoundAdjustVolume );
-            settings->setValue( "chaperoneAlarmSoundDistance",
-                                p.chaperoneAlarmSoundDistance );
-            settings->setValue( "chaperoneShowDashboardEnabled",
-                                p.enableChaperoneShowDashboard );
-            settings->setValue( "chaperoneShowDashboardDistance",
-                                p.chaperoneShowDashboardDistance );
-        }
-        i++;
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::saveAllObjects( chaperoneProfiles );
 }
 
 void ChaperoneTabController::handleChaperoneWarnings( float distance )
@@ -1204,9 +931,13 @@ void ChaperoneTabController::addChaperoneProfile(
         vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo( nullptr,
                                                             &quadCount );
         profile->chaperoneGeometryQuadCount = quadCount;
-        profile->chaperoneGeometryQuads.reset( new vr::HmdQuad_t[quadCount] );
+        for ( int i = 0; i < static_cast<int>( quadCount ); ++i )
+        {
+            profile->chaperoneGeometryQuads.emplace_back();
+        }
+
         vr::VRChaperoneSetup()->GetLiveCollisionBoundsInfo(
-            profile->chaperoneGeometryQuads.get(), &quadCount );
+            profile->chaperoneGeometryQuads.data(), &quadCount );
         vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
             &profile->standingCenter );
         vr::VRChaperoneSetup()->GetWorkingPlayAreaSize(
@@ -1332,7 +1063,6 @@ void ChaperoneTabController::addChaperoneProfile(
             = chaperoneShowDashboardDistance();
     }
     saveChaperoneProfiles();
-    OverlayController::appSettings()->sync();
     emit chaperoneProfilesUpdated();
 }
 
@@ -1347,7 +1077,7 @@ void ChaperoneTabController::applyChaperoneProfile( unsigned index )
             vr::VRChaperoneSetup()->HideWorkingSetPreview();
             vr::VRChaperoneSetup()->RevertWorkingCopy();
             vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(
-                profile.chaperoneGeometryQuads.get(),
+                profile.chaperoneGeometryQuads.data(),
                 profile.chaperoneGeometryQuadCount );
             vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
                 &profile.standingCenter );
@@ -1436,7 +1166,6 @@ void ChaperoneTabController::deleteChaperoneProfile( unsigned index )
         auto pos = chaperoneProfiles.begin() + index;
         chaperoneProfiles.erase( pos );
         saveChaperoneProfiles();
-        OverlayController::appSettings()->sync();
         emit chaperoneProfilesUpdated();
     }
 }
@@ -1485,7 +1214,6 @@ void ChaperoneTabController::createNewAutosaveProfile()
         chaperoneProfiles[currentAutosaveIndexLookup.second].profileName
             = "«Autosaved Profile (previous)»";
         saveChaperoneProfiles();
-        OverlayController::appSettings()->sync();
         emit chaperoneProfilesUpdated();
     }
     else

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -54,45 +54,12 @@ void MoveCenterTabController::initStage2( OverlayController* var_parent )
 
 void MoveCenterTabController::reloadOffsetProfiles()
 {
-    m_offsetProfiles.clear();
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "playspaceSettings" );
-    auto profileCount = settings->beginReadArray( "offsetProfiles" );
-    for ( int i = 0; i < profileCount; i++ )
-    {
-        settings->setArrayIndex( i );
-        m_offsetProfiles.emplace_back();
-        auto& entry = m_offsetProfiles[static_cast<size_t>( i )];
-        entry.profileName
-            = settings->value( "profileName" ).toString().toStdString();
-        entry.offsetX = settings->value( "offsetX", 0.0f ).toFloat();
-        entry.offsetY = settings->value( "offsetY", 0.0f ).toFloat();
-        entry.offsetZ = settings->value( "offsetZ", 0.0f ).toFloat();
-        entry.rotation = settings->value( "rotation", 0 ).toInt();
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::loadAllObjects( m_offsetProfiles );
 }
 
 void MoveCenterTabController::saveOffsetProfiles()
 {
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "playspaceSettings" );
-    settings->beginWriteArray( "offsetProfiles" );
-    unsigned i = 0;
-    for ( auto& p : m_offsetProfiles )
-    {
-        settings->setArrayIndex( static_cast<int>( i ) );
-        settings->setValue( "profileName",
-                            QString::fromStdString( p.profileName ) );
-        settings->setValue( "offsetX", p.offsetX );
-        settings->setValue( "offsetY", p.offsetY );
-        settings->setValue( "offsetZ", p.offsetZ );
-        settings->setValue( "rotation", p.rotation );
-        i++;
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::saveAllObjects( m_offsetProfiles );
 }
 
 Q_INVOKABLE unsigned MoveCenterTabController::getOffsetProfileCount()
@@ -136,7 +103,6 @@ void MoveCenterTabController::addOffsetProfile( QString name )
     profile->offsetZ = m_offsetZ;
     profile->rotation = m_rotation;
     saveOffsetProfiles();
-    OverlayController::appSettings()->sync();
     emit offsetProfilesUpdated();
 }
 
@@ -167,7 +133,6 @@ void MoveCenterTabController::deleteOffsetProfile( unsigned index )
         auto pos = m_offsetProfiles.begin() + index;
         m_offsetProfiles.erase( pos );
         saveOffsetProfiles();
-        OverlayController::appSettings()->sync();
         emit offsetProfilesUpdated();
     }
 }

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <qmath.h>
 #include "../utils/FrameRateUtils.h"
+#include "../settings/settings_object.h"
 
 class QQuickWindow;
 // application namespace
@@ -28,13 +29,40 @@ constexpr double k_maxOvrasUniverseCenteredTurningOffset = 25000.0;
 
 class OverlayController;
 
-struct OffsetProfile
+struct OffsetProfile : settings::ISettingsObject
 {
     std::string profileName;
     float offsetX = 0.0f;
     float offsetY = 0.0f;
     float offsetZ = 0.0f;
     int rotation = 0;
+
+    virtual std::string settingsName() const override
+    {
+        return "MoveCenterTabController::OffsetProfile";
+    }
+
+    virtual settings::SettingsObjectData saveSettings() const override
+    {
+        settings::SettingsObjectData o;
+
+        o.addValue( static_cast<double>( offsetX ) );
+        o.addValue( static_cast<double>( offsetY ) );
+        o.addValue( static_cast<double>( offsetZ ) );
+
+        o.addValue( rotation );
+
+        return o;
+    }
+
+    virtual void loadSettings( settings::SettingsObjectData& obj ) override
+    {
+        offsetX = static_cast<float>( obj.getNextValueOrDefault( 0.0 ) );
+        offsetY = static_cast<float>( obj.getNextValueOrDefault( 0.0 ) );
+        offsetZ = static_cast<float>( obj.getNextValueOrDefault( 0.0 ) );
+
+        rotation = obj.getNextValueOrDefault( 0 );
+    }
 };
 
 class MoveCenterTabController : public QObject

--- a/src/tabcontrollers/VideoTabController.cpp
+++ b/src/tabcontrollers/VideoTabController.cpp
@@ -239,8 +239,6 @@ void VideoTabController::dashboardLoopTick()
 
 void VideoTabController::reloadVideoConfig()
 {
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( getSettingsName() );
     setBrightnessEnabled( brightnessEnabled(), true );
     setColorOverlayEnabled( colorOverlayEnabled(), true );
     setIsOverlayMethodActive( isOverlayMethodActive(), true );
@@ -248,7 +246,6 @@ void VideoTabController::reloadVideoConfig()
     setColorGreen( colorGreen() );
     setColorBlue( colorBlue() );
 
-    settings->endGroup();
     vr::VROverlayError overlayError = vr::VROverlay()->SetOverlayAlpha(
         m_brightnessOverlayHandle, brightnessOpacityValue() );
     if ( overlayError != vr::VROverlayError_None )
@@ -258,7 +255,6 @@ void VideoTabController::reloadVideoConfig()
                             overlayError );
     }
     loadColorOverlay();
-    settings->sync();
 }
 
 float VideoTabController::brightnessOpacityValue() const

--- a/src/tabcontrollers/VideoTabController.cpp
+++ b/src/tabcontrollers/VideoTabController.cpp
@@ -932,7 +932,6 @@ void VideoTabController::addVideoProfile( const QString name )
     profile->overlayMethodState = isOverlayMethodActive();
 
     saveVideoProfiles();
-    OverlayController::appSettings()->sync();
     emit videoProfilesUpdated();
     emit videoProfileAdded();
 }
@@ -964,81 +963,18 @@ void VideoTabController::deleteVideoProfile( const unsigned index )
         auto pos = videoProfiles.begin() + index;
         videoProfiles.erase( pos );
         saveVideoProfiles();
-        OverlayController::appSettings()->sync();
         emit videoProfilesUpdated();
     }
 }
 
 void VideoTabController::reloadVideoProfiles()
 {
-    videoProfiles.clear();
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "VideoSettings" );
-    auto profileCount = settings->beginReadArray( "videoProfiles" );
-    for ( int i = 0; i < profileCount; i++ )
-    {
-        settings->setArrayIndex( i );
-        videoProfiles.emplace_back();
-        auto& entry = videoProfiles[static_cast<size_t>( i )];
-        entry.profileName
-            = settings->value( "profileName" ).toString().toStdString();
-
-        entry.supersampleOverride
-            = settings->value( "supersamplingOverride", false ).toBool();
-        entry.supersampling
-            = settings->value( "supersampling", 1.0f ).toFloat();
-        entry.anisotropicFiltering
-            = settings->value( "anisotropicFiltering", true ).toBool();
-        entry.motionSmooth = settings->value( "motionSmooth", true ).toBool();
-
-        entry.colorRed = settings->value( "colorRedNew", 1.0f ).toFloat();
-        entry.colorBlue = settings->value( "colorBlueNew", 1.0f ).toFloat();
-        entry.colorGreen = settings->value( "colorGreenNew", 1.0f ).toFloat();
-
-        entry.brightnessToggle
-            = settings->value( "brightnessToggle", false ).toBool();
-        entry.brightnessOpacityValue
-            = settings->value( "brightnessOpacityValue", 1.0f ).toFloat();
-        entry.opacity = settings->value( "opacity", 0.0f ).toFloat();
-        entry.overlayMethodState
-            = settings->value( "overlayMethodState", false ).toBool();
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::loadAllObjects( videoProfiles );
 }
 
 void VideoTabController::saveVideoProfiles()
 {
-    auto settings = OverlayController::appSettings();
-    settings->beginGroup( "VideoSettings" );
-    settings->beginWriteArray( "videoProfiles" );
-    unsigned i = 0;
-    for ( auto& p : videoProfiles )
-    {
-        settings->setArrayIndex( static_cast<int>( i ) );
-        settings->setValue( "profileName",
-                            QString::fromStdString( p.profileName ) );
-
-        settings->setValue( "supersamplingOverride", p.supersampleOverride );
-        settings->setValue( "supersampling", p.supersampling );
-        settings->setValue( "anisotropicFiltering", p.anisotropicFiltering );
-        settings->setValue( "motionSmooth", p.motionSmooth );
-
-        settings->setValue( "colorRedNew", p.colorRed );
-        settings->setValue( "colorBlueNew", p.colorBlue );
-        settings->setValue( "colorGreenNew", p.colorGreen );
-
-        settings->setValue( "brightnessToggle", p.brightnessToggle );
-        settings->setValue( "brightnessOpacityValue",
-                            p.brightnessOpacityValue );
-
-        settings->setValue( "opacity", p.opacity );
-        settings->setValue( "overlayMethodState", p.overlayMethodState );
-
-        i++;
-    }
-    settings->endArray();
-    settings->endGroup();
+    settings::saveAllObjects( videoProfiles );
 }
 
 int VideoTabController::getVideoProfileCount()

--- a/src/tabcontrollers/VideoTabController.h
+++ b/src/tabcontrollers/VideoTabController.h
@@ -5,6 +5,7 @@
 #include <QVariant>
 #include <openvr.h>
 #include "../utils/FrameRateUtils.h"
+#include "../settings/settings_object.h"
 
 class QQuickWindow;
 
@@ -20,7 +21,7 @@ namespace advsettings
 // forward declaration
 class OverlayController;
 
-struct VideoProfile
+struct VideoProfile : settings::ISettingsObject
 {
     std::string profileName;
 
@@ -35,6 +36,58 @@ struct VideoProfile
     float brightnessOpacityValue = 1.0f;
     bool overlayMethodState = false;
     float opacity = 0.0f; // TODO check
+
+    virtual settings::SettingsObjectData saveSettings() const override
+    {
+        settings::SettingsObjectData o;
+
+        o.addValue( static_cast<double>( supersampling ) );
+
+        o.addValue( anisotropicFiltering );
+        o.addValue( motionSmooth );
+        o.addValue( supersampleOverride );
+
+        o.addValue( static_cast<double>( colorRed ) );
+        o.addValue( static_cast<double>( colorGreen ) );
+        o.addValue( static_cast<double>( colorBlue ) );
+
+        o.addValue( brightnessToggle );
+
+        o.addValue( static_cast<double>( brightnessOpacityValue ) );
+
+        o.addValue( overlayMethodState );
+
+        o.addValue( static_cast<double>( opacity ) );
+
+        return o;
+    }
+
+    virtual void loadSettings( settings::SettingsObjectData& obj ) override
+    {
+        supersampling = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+
+        anisotropicFiltering = obj.getNextValueOrDefault( false );
+        motionSmooth = obj.getNextValueOrDefault( false );
+        supersampleOverride = obj.getNextValueOrDefault( false );
+
+        colorRed = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+        colorGreen = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+        colorBlue = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+
+        brightnessToggle = obj.getNextValueOrDefault( false );
+
+        brightnessOpacityValue
+            = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+
+        overlayMethodState = obj.getNextValueOrDefault( false );
+
+        opacity = static_cast<float>( obj.getNextValueOrDefault( 1.0 ) );
+    }
+
+    virtual std::string settingsName() const override
+    {
+        return "VideoTabController::VideoProfile";
+    }
 };
 
 class VideoTabController : public QObject

--- a/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
+++ b/src/tabcontrollers/audiomanager/AudioManagerWindows.cpp
@@ -485,6 +485,11 @@ std::string AudioManagerWindows::getDeviceName( IMMDevice* device )
     if ( device->OpenPropertyStore( STGM_READ, &pProps ) >= 0
          && pProps->GetValue( PKEY_Device_FriendlyName, &varString ) >= 0 )
     {
+        if ( varString.pwszVal == nullptr )
+        {
+            return "INVALID-NAME";
+        }
+
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         std::string name = converter.to_bytes( varString.pwszVal );
         return name;
@@ -497,6 +502,11 @@ std::string AudioManagerWindows::getDeviceId( IMMDevice* device )
     LPWSTR ppstrId;
     if ( device->GetId( &ppstrId ) >= 0 )
     {
+        if ( ppstrId == nullptr )
+        {
+            return "INVALID-ID";
+        }
+
         std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         return converter.to_bytes( ppstrId );
     }


### PR DESCRIPTION
## Change name from header title from OpenVR to OVR
* Required for screenshots.

## Settings object API upgrades
* `save/loadAllObjects` functions since the implementation can be a little tricky due to off by one errors.
* Automatic type deduction on more things, since strings in C++ in general are weird and annoying.

## Implement settings object API
* Defaults have been moved over as well as I could. I have never used the profile features for anything, so maybe someone with more knowledge of how they should work can spot some weird default values.
* I decided on the `TabController::StructName` syntax as a save name for no particular reason. `:` is not rendered in the settings file, so it might make more sense to use `-` instead or something.

## Fix SEGFAULT on Windows due to Audio Device name
* Fixes #357.
* Even arbitrary ASCII names of devices could lead to a nullptr returned by Windows.