### PR TITLE
Set a static DPI before rendering in-VR overlay

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@ int main( int argc, char* argv[] )
 
     LOG( INFO ) << settings::getSettingsAndValues();
 
+    QCoreApplication::setAttribute( Qt::AA_Use96Dpi );
     MyQApplication mainEventLoop( argc, argv );
     mainEventLoop.setOrganizationName(
         application_strings::applicationOrganizationName );


### PR DESCRIPTION
We expect a standard 96DPI display rendering when creating the overlay,
but system DPI can interfere with this. Setting
QCoreApplication::setAttribute(Qt::AA_Use96Dpi) resolves this.

https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/369