### PR TITLE
fixed audio override key unset issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ update_and_install_prereqs: &update_and_install_prereqs
         name: Get wget and apt-key
         command: |
             apt-get install wget -y
-            apt-get install software-properties-common -y
+            apt-get install software-properties-common apt-transport-https -y
     - run:
         name: Set up LLVM-8 repo
         command: |
@@ -86,7 +86,7 @@ jobs:
                 name: Get apt-key
                 # Required for LLVM
                 command: |
-                    sudo apt-get install software-properties-common -y
+                    sudo apt-get install software-properties-common apt-transport-https -y
             - run:
                 name: Get LLVM repos
                 command: |

--- a/src/tabcontrollers/AudioTabController.cpp
+++ b/src/tabcontrollers/AudioTabController.cpp
@@ -967,6 +967,8 @@ void AudioTabController::initOverride()
         LOG( ERROR ) << "Could not get recording override setting: "
                      << vr::VRSettings()->GetSettingsErrorNameFromEnum(
                             vrSettingsError );
+        LOG( INFO ) << "Setting recording override to false";
+        setRecordingOverride( false );
     }
     else
     {
@@ -981,6 +983,8 @@ void AudioTabController::initOverride()
         LOG( ERROR ) << "Could not get playback override setting: "
                      << vr::VRSettings()->GetSettingsErrorNameFromEnum(
                             vrSettingsError );
+        LOG( INFO ) << "Setting playback override to false";
+        setPlaybackOverride( false );
     }
     else
     {


### PR DESCRIPTION
fixes #316 


Currently the new audio override keys are unset by default, and can cause some log spam, this change sets them to false, and maintains default behavior, but should prevent spam issues.