### PR TITLE
Fix visibility not being set, and off by one error when loading settings

### DIFF
--- a/src/settings/settings_object.h
+++ b/src/settings/settings_object.h
@@ -129,7 +129,8 @@ template <class T> void loadAllObjects( std::vector<T>& vec )
     // We could check vec.at(0), but it's not guaranteed to exist.
     auto o = T{};
     auto profileCount = getAmountOfSavedObjects( o );
-    for ( int profileNumber = 1; profileNumber < profileCount; ++profileNumber )
+    for ( int profileNumber = 1; profileNumber <= profileCount;
+          ++profileNumber )
     {
         vec.emplace_back();
 

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -417,7 +417,7 @@ float ChaperoneTabController::boundsVisibility() const
 
 void ChaperoneTabController::setBoundsVisibility( float value, bool notify )
 {
-    if ( fabs( static_cast<double>( m_visibility - m_visibility ) ) > 0.005 )
+    if ( fabs( static_cast<double>( m_visibility - value ) ) > 0.005 )
     {
         if ( value <= 0.3f )
         {


### PR DESCRIPTION
## Visibility

`m_visibility - m_visibility` is always zero, and so the if statement body is never executed.

## Settings

```cpp
// getAmountOfSavedObjects() gives the total amount of objects,
// so if we have 2 profiles it will return 2
auto profileCount = getAmountOfSavedObjects( o );
// Since we start at one, we'll need <= and not < to not miss the last item
for ( int profileNumber = 1; profileNumber <= profileCount; ++profileNumber )
```