### PR TITLE
Enable LTO and optimization level O3 for Linux

### DIFF
--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -1,5 +1,5 @@
 QT       += core gui qml quick multimedia widgets
-CONFIG   += c++1z file_copies
+CONFIG   += c++1z file_copies optimize_full
 
 DEFINES += ELPP_THREAD_SAFE ELPP_QT_LOGGING ELPP_NO_DEFAULT_LOG_FILE
 

--- a/build_scripts/qt/compilers/clang-gcc-common-switches.pri
+++ b/build_scripts/qt/compilers/clang-gcc-common-switches.pri
@@ -9,3 +9,8 @@ QMAKE_CXXFLAGS += -Wnon-virtual-dtor
 QMAKE_CXXFLAGS += -Wcast-align -Wunused -Woverloaded-virtual -Wformat=2
 
 QMAKE_CXXFLAGS += -Wdouble-promotion
+
+# Enable Link Time Optimization
+QMAKE_CXXFLAGS += -flto
+# Clang LTO requires the gold linker instead of ld
+QMAKE_LFLAGS += -flto -fuse-ld=gold

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -18,18 +18,22 @@ else {
     message('clang' version is not above 4. Attempting to use highest specific version.)
     system("clang-5 --version") {
         QMAKE_CXX = clang-5
+        QMAKE_LINK = clang-5
         message('clang-5' found.)
     }
     system("clang-6 --version") {
         QMAKE_CXX = clang-6
+        QMAKE_LINK = clang-6
         message('clang-6' found.)
     }
     system("clang-7 --version") {
         QMAKE_CXX = clang-7
+        QMAKE_LINK = clang-7
         message('clang-7' found.)
     }
     system("clang-8 --version") {
         QMAKE_CXX = clang-8
+        QMAKE_LINK = clang-8
         message('clang-8' found.)
     }
 }

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -31,3 +31,6 @@ QMAKE_CXXFLAGS += -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Wrestric
 QMAKE_CXXFLAGS += -Wconversion -Wno-sign-conversion
 
 QMAKE_CXXFLAGS += -Wzero-as-null-pointer-constant
+
+# Qmake will append this even though higher optimization levels are used.
+QMAKE_LFLAGS_RELEASE -= -Wl,-O1

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -7,14 +7,17 @@ else {
     system(g++-7 --version) {
         message('g++-7' found.)
         QMAKE_CXX = g++-7
+        QMAKE_LINK = g++-7
     }
     system(g++-8 --version) {
         message('g++-8' found.)
         QMAKE_CXX = g++-8
+        QMAKE_LINK = g++-8
     }
     system(g++-9 --version) {
         message('g++-9' found.)
         QMAKE_CXX = g++-9
+        QMAKE_LINK = g++-9
     }
 }
 


### PR DESCRIPTION
Partially solves https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/396.

Link Time Optimization and max optimization settings has been used on MSVC for a while now.

SSE2 is activated by default on all 3 compilers as detailed in the issue.