### PR TITLE
Refactor CI and add Linux compiler optimizations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,3 +37,10 @@ artifacts:
     name: portable
   - path: installer\AdvancedSettings*.exe
     name: installer
+
+branches:
+  except:
+    - /docs-*/
+    - /do-not-run-ci-*/
+    - /only-travis-ci-*/
+    - /only-circle-ci-*/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,8 @@
 image: Visual Studio 2017
 
+# Disable automatic build of Visual Studio files
+build: off
+
 environment:
   matrix:
   - QT_LOC: '"C:\Qt\5.12\msvc2017_64\bin\"'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,81 +1,13 @@
-workflows:
-    version: 2
-    gcc_1:
-        jobs:
-          - gcc
-    clang_1:
-        jobs:
-          - clang
-    clang_tidy:
-        jobs:
-          - clang-tidy
-
-update_and_install_prereqs: &update_and_install_prereqs
-    - checkout
-    - run: apt-get update &&  apt-get upgrade -y
-    - run:
-        name: Get wget and apt-key
-        command: |
-            apt-get install wget -y
-            apt-get install software-properties-common apt-transport-https -y
-    - run:
-        name: Set up LLVM-8 repo
-        command: |
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add -
-            add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-            apt update -qq
-    - run:
-        name: Install LLVM-8 binaries
-        command: |
-            apt install clang-format-8 -y
-            apt install clang-tidy-7 -y
-            apt install clang-8 -y
-            apt install clang -y
-    - run:
-        name: Run clang-format
-        command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
-    - run:
-        name: Install g++-7
-        command: |
-            add-apt-repository ppa:ubuntu-toolchain-r/test
-            apt update
-            apt install g++-7 -y
-    - run:
-        name: Add required QT repos
-        command: |
-            add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
-            apt-get update -qq
-    - run: apt-get install build-essential libgl1-mesa-dev -y
-    - run:
-        name: Install QT packages
-        command: |
-            apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2 qt512quickcontrols qt512tools qt512imageformats qt512svg qt512base qtchooser -y
-    - run:
-        name: Install X11 packages
-        command: apt-get install libx11-dev libxt-dev libxtst-dev -y
-    - run:
-        name: Install pulse packages
-        command: apt-get install libpulse-dev -y
-    - run:
-        name: Install bear/clang-tidy
-        command: apt-get install bear clang-tidy -y
-    - run:
-        name: Set up qtchooser
-        command: qtchooser -install opt-qt512 /opt/qt512/bin/qmake
-    - run:
-        name: Give build scripts +x
-        command: |
-            chmod +x ./build_scripts/linux/build_linux.sh
-            chmod +x ./build_scripts/linux/format.sh
-            chmod +x ./build_scripts/linux/run-clang-tidy.sh
-            chmod +x ./build_scripts/linux/verify_formatting.sh
-    - run:
-        name: Run build script
-        command: ./build_scripts/linux/build_linux.sh
+version: 2.0
 
 jobs:
-    gcc:
+    build:
+        branches:
+            ignore:
+                - /docs-*/
+                - /do-not-run-ci-*/
+                - /only-appveyor-ci-*/
+                - /only-travis-ci-*/
         environment:
             QMAKE_SPEC: linux-g++
             QT_SELECT: opt-qt512
@@ -168,22 +100,3 @@ jobs:
             - store_artifacts:
                 path: ./artifacts/
 
-    clang:
-        environment:
-            QMAKE_SPEC: linux-clang
-            QT_SELECT: opt-qt512
-            MAKE_JOBS: 2
-        docker:
-            - image: "ubuntu:xenial"
-        steps: *update_and_install_prereqs
-            
-    clang-tidy:
-        environment:
-            QMAKE_SPEC: linux-clang
-            QT_SELECT: opt-qt512
-            USE_TIDY: TRUE
-            CLANG_TIDY_EXECUTABLE: clang-tidy-7
-            MAKE_JOBS: 2
-        docker:
-            - image: "ubuntu:xenial"
-        steps: *update_and_install_prereqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: cpp
 dist: xenial
 
+branches:
+  except:
+    - /docs-*/
+    - /do-not-run-ci-*/
+    - /only-appveyor-ci-*/
+    - /only-circle-ci-*/
+
 matrix:
   include:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
   - sudo apt install clang-format-8
   - clang-format-8 --version
   - python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
+  - sed -i 's/QMAKE_CXXFLAGS += -flto//g' ./build_scripts/qt/compilers/clang-gcc-common-switches.pri # CI version of clang can't handle LTO
+  - sed -i 's/QMAKE_LFLAGS += -flto -fuse-ld=gold//g' ./build_scripts/qt/compilers/clang-gcc-common-switches.pri # CI version of clang can't handle LTO
 
 install:
   - sudo add-apt-repository ppa:beineri/opt-qt-5.12.7-bionic -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 
 branches:
   except:
@@ -11,36 +11,12 @@ branches:
 matrix:
   include:
   - os: linux
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
     env:
     - QMAKE_SPEC=linux-g++
     - QT_SELECT="opt-qt512"
     compiler: gcc
 
   - os: linux
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
-    env:
-    - QMAKE_SPEC=linux-clang
-    - QT_SELECT="opt-qt512"
-    compiler: clang
-
-  - os: linux
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
     env:
     - USE_TIDY=TRUE
     - QT_SELECT="opt-qt512"
@@ -51,18 +27,15 @@ before_install:
   - chmod +x ./build_scripts/linux/format.sh
   - chmod +x ./build_scripts/linux/run-clang-tidy.sh
   - chmod +x ./build_scripts/linux/verify_formatting.sh
-  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
   - sudo apt update -qq
   - sudo apt install clang-format-8
   - clang-format-8 --version
   - python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
 
 install:
-  - sudo add-apt-repository ppa:kubuntu-ppa/backports -y
-  - sudo add-apt-repository ppa:beineri/opt-qt-5.12.2-xenial -y
+  - sudo add-apt-repository ppa:beineri/opt-qt-5.12.7-bionic -y
   - sudo apt-get update -qq
-  - sudo apt-get install build-essential libgl1-mesa-dev
+  - sudo apt-get install gcc clang build-essential libgl1-mesa-dev
   - sudo apt-get install qt512-meta-minimal qt512multimedia qt512declarative qt512quickcontrols2  qt512tools  qt512base
   - sudo apt-get install libx11-dev libxt-dev libxtst-dev libpulse-dev
   - sudo apt-get install bear clang-tidy

--- a/advancedSettings.pro
+++ b/advancedSettings.pro
@@ -1,5 +1,5 @@
 QT       += core gui qml quick multimedia widgets
-CONFIG   += c++1z file_copies
+CONFIG   += c++1z file_copies optimize_full
 
 DEFINES += ELPP_THREAD_SAFE ELPP_QT_LOGGING ELPP_NO_DEFAULT_LOG_FILE
 

--- a/build_scripts/qt/compilers/clang-gcc-common-switches.pri
+++ b/build_scripts/qt/compilers/clang-gcc-common-switches.pri
@@ -9,3 +9,8 @@ QMAKE_CXXFLAGS += -Wnon-virtual-dtor
 QMAKE_CXXFLAGS += -Wcast-align -Wunused -Woverloaded-virtual -Wformat=2
 
 QMAKE_CXXFLAGS += -Wdouble-promotion
+
+# Enable Link Time Optimization
+QMAKE_CXXFLAGS += -flto
+# Clang LTO requires the gold linker instead of ld
+QMAKE_LFLAGS += -flto -fuse-ld=gold

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -38,6 +38,8 @@ else {
     }
 }
 
+system("$$QMAKE_CXX --version")
+
 include(clang-gcc-common-switches.pri)
 
 QMAKE_CXXFLAGS += -Wmost

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -1,5 +1,5 @@
 # comments are the value of CLANG_VERSION
-CLANG_VERSION = $$system("clang --version | grep 'clang version'")
+CLANG_VERSION = $$system("clang++ --version | grep 'clang version'")
 # clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final)
 CLANG_VERSION = $$split(CLANG_VERSION, ' ')
 # CLANG_VERSION is now a list, this is shown as spaces in QMAKE
@@ -12,29 +12,31 @@ CLANG_VERSION = $$member(CLANG_VERSION, 0)
 # 6
 
 greaterThan(CLANG_VERSION, 4) {
-    message('clang' version is above 4. Using regular clang.)
+    message('clang++' version is above 4. Using regular clang++.)
+    QMAKE_CXX = clang++
+    QMAKE_LINK = clang++
 }
 else {
-    message('clang' version is not above 4. Attempting to use highest specific version.)
-    system("clang-5 --version") {
-        QMAKE_CXX = clang-5
-        QMAKE_LINK = clang-5
-        message('clang-5' found.)
+    message('clang++' version is not above 4. Attempting to use highest specific version.)
+    system("clang++-5 --version") {
+        QMAKE_CXX = clang++-5
+        QMAKE_LINK = clang++-5
+        message('clang++-5' found.)
     }
-    system("clang-6 --version") {
-        QMAKE_CXX = clang-6
-        QMAKE_LINK = clang-6
-        message('clang-6' found.)
+    system("clang++-6 --version") {
+        QMAKE_CXX = clang++-6
+        QMAKE_LINK = clang++-6
+        message('clang++-6' found.)
     }
-    system("clang-7 --version") {
-        QMAKE_CXX = clang-7
-        QMAKE_LINK = clang-7
-        message('clang-7' found.)
+    system("clang++-7 --version") {
+        QMAKE_CXX = clang++-7
+        QMAKE_LINK = clang++-7
+        message('clang++-7' found.)
     }
-    system("clang-8 --version") {
-        QMAKE_CXX = clang-8
-        QMAKE_LINK = clang-8
-        message('clang-8' found.)
+    system("clang++-8 --version") {
+        QMAKE_CXX = clang++-8
+        QMAKE_LINK = clang++-8
+        message('clang++-8' found.)
     }
 }
 

--- a/build_scripts/qt/compilers/clang.pri
+++ b/build_scripts/qt/compilers/clang.pri
@@ -18,18 +18,22 @@ else {
     message('clang' version is not above 4. Attempting to use highest specific version.)
     system("clang-5 --version") {
         QMAKE_CXX = clang-5
+        QMAKE_LINK = clang-5
         message('clang-5' found.)
     }
     system("clang-6 --version") {
         QMAKE_CXX = clang-6
+        QMAKE_LINK = clang-6
         message('clang-6' found.)
     }
     system("clang-7 --version") {
         QMAKE_CXX = clang-7
+        QMAKE_LINK = clang-7
         message('clang-7' found.)
     }
     system("clang-8 --version") {
         QMAKE_CXX = clang-8
+        QMAKE_LINK = clang-8
         message('clang-8' found.)
     }
 }

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -39,3 +39,4 @@ QMAKE_CXXFLAGS += -Wzero-as-null-pointer-constant
 
 # Qmake will append this even though higher optimization levels are used.
 QMAKE_LFLAGS_RELEASE -= -Wl,-O1
+QMAKE_LFLAGS += -Wl,-O3

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -31,3 +31,6 @@ QMAKE_CXXFLAGS += -Wduplicated-branches -Wduplicated-cond -Wlogical-op -Wrestric
 QMAKE_CXXFLAGS += -Wconversion -Wno-sign-conversion
 
 QMAKE_CXXFLAGS += -Wzero-as-null-pointer-constant
+
+# Qmake will append this even though higher optimization levels are used.
+QMAKE_LFLAGS_RELEASE -= -Wl,-O1

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -21,6 +21,8 @@ else {
     }
 }
 
+system("$$QMAKE_CXX --version")
+
 include(clang-gcc-common-switches.pri)
 
 QMAKE_CXXFLAGS += -Wpedantic

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -39,4 +39,4 @@ QMAKE_CXXFLAGS += -Wzero-as-null-pointer-constant
 
 # Qmake will append this even though higher optimization levels are used.
 QMAKE_LFLAGS_RELEASE -= -Wl,-O1
-QMAKE_LFLAGS += -Wl,-O3
+QMAKE_LFLAGS += -Wl,-O3 -O3

--- a/build_scripts/qt/compilers/gcc.pri
+++ b/build_scripts/qt/compilers/gcc.pri
@@ -7,14 +7,17 @@ else {
     system(g++-7 --version) {
         message('g++-7' found.)
         QMAKE_CXX = g++-7
+        QMAKE_LINK = g++-7
     }
     system(g++-8 --version) {
         message('g++-8' found.)
         QMAKE_CXX = g++-8
+        QMAKE_LINK = g++-8
     }
     system(g++-9 --version) {
         message('g++-9' found.)
         QMAKE_CXX = g++-9
+        QMAKE_LINK = g++-9
     }
 }
 


### PR DESCRIPTION
## This PR:
* Fixes #398 
* Fixes a few of the points in #396.

The clang Travis server does not have the gold linker plugin installed, which means it can't compile with LTO on. The LTO lines are removed in the Travis build script, but regular Clang builds are still compiled with LTO on.