### PR TITLE
Fix default Brightness value/behavior adds shutdown button

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1023,6 +1023,9 @@ void OverlayController::mainEventLoop()
                                                        // time just in case
 
             exitApp();
+            // Won't fallthrough, but also exitApp() wont, but QT won't
+            // acknowledge
+            exit( EXIT_SUCCESS );
         }
 
         case vr::VREvent_DashboardActivated:

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -327,6 +327,24 @@ OverlayController::~OverlayController()
     Shutdown();
 }
 
+void OverlayController::exitApp()
+{
+    settings::saveAllSettings();
+
+    m_moveCenterTabController.shutdown();
+    // Un-mute mic before Exiting VR, as it is set at system level Not
+    // Vr level.
+    // m_audioTabController.setMicMuted( false, false );
+    m_audioTabController.shutdown();
+    m_chaperoneTabController.shutdown();
+    Shutdown();
+    QApplication::exit();
+
+    LOG( INFO ) << "All systems exited.";
+    exit( EXIT_SUCCESS );
+    // Does not fallthrough
+}
+
 void OverlayController::Shutdown()
 {
     disconnect( &m_pumpEventsTimer,
@@ -1004,20 +1022,7 @@ void OverlayController::mainEventLoop()
             vr::VRSystem()->AcknowledgeQuit_Exiting(); // Let us buy some
                                                        // time just in case
 
-            settings::saveAllSettings();
-
-            m_moveCenterTabController.shutdown();
-            // Un-mute mic before Exiting VR, as it is set at system level Not
-            // Vr level.
-            // m_audioTabController.setMicMuted( false, false );
-            m_audioTabController.shutdown();
-            m_chaperoneTabController.shutdown();
-            Shutdown();
-            QApplication::exit();
-
-            LOG( INFO ) << "All systems exited.";
-            exit( EXIT_SUCCESS );
-            // Does not fallthrough
+            exitApp();
         }
 
         case vr::VREvent_DashboardActivated:

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -184,7 +184,7 @@ public:
     virtual ~OverlayController();
 
     void Shutdown();
-    Q_INVOKABLE [[noreturn]] void exitApp();
+    Q_INVOKABLE void exitApp();
 
     bool isDashboardVisible()
     {

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -184,6 +184,7 @@ public:
     virtual ~OverlayController();
 
     void Shutdown();
+    Q_INVOKABLE [[noreturn]] void exitApp();
 
     bool isDashboardVisible()
     {

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -156,17 +156,32 @@ MyStackViewPage {
                 Layout.fillWidth: true
             }
         }
+        RowLayout{
 
-        MyText {
-            id: seatedOldExternalWarning
-            wrapMode: Text.WordWrap
-            font.pointSize: 20
-            color: "#FFA500"
-            text: "WARNING: 'Allow External App Chaperone Edits' + 'Old-Style Motion' + 'Enable Motion Features When in Seated Mode' active together may cause space center misalignment. Load the «Autosaved Profile» in the 'Chaperone' tab to fix."
-            horizontalAlignment: Text.AlignHCenter
-            Layout.leftMargin: 20
-            Layout.rightMargin: 20
-            Layout.fillWidth: true
+            MyText {
+                id: seatedOldExternalWarning
+                wrapMode: Text.WordWrap
+                font.pointSize: 20
+                color: "#FFA500"
+                text: "WARNING: 'Allow External App Chaperone Edits' + 'Old-Style Motion' + 'Enable Motion Features When in Seated Mode' active together may cause space center misalignment. Load the «Autosaved Profile» in the 'Chaperone' tab to fix."
+                horizontalAlignment: Text.AlignHCenter
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+                Layout.fillWidth: true
+            }
+        }
+        RowLayout{
+            Item {
+                Layout.fillWidth: true
+            }
+            MyPushButton {
+                id: shutdownButton
+                Layout.preferredWidth: 250
+                text: "Shutdown OVRAS"
+                onClicked: {
+                    OverlayController.exitApp()
+                    }
+                }
         }
 
         Item {
@@ -188,13 +203,6 @@ MyStackViewPage {
                 text: "Debug"
                 onCheckedChanged: {
                     OverlayController.setEnableDebug(checked, true)
-                }
-            }
-            MyToggleButton {
-                id: btnShutdown
-                text: "OVRAS shutdown"
-                onCheckedChanged: {
-                    OverlayController.exitApp()
                 }
             }
 

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -175,14 +175,15 @@ MyStackViewPage {
 
         RowLayout {
             Layout.fillWidth: true
-            // set visible to true here in builds when we need a debug toggle checkbox, otherwise false when on master branch.
-            visible: false
+
 
             Item {
                 Layout.fillWidth: true
             }
 
             MyToggleButton {
+                // set visible to true here in builds when we need a debug toggle checkbox, otherwise false when on master branch.
+                visible: false
                 id: debugToggle
                 text: "Debug"
                 onCheckedChanged: {

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -189,6 +189,13 @@ MyStackViewPage {
                     OverlayController.setEnableDebug(checked, true)
                 }
             }
+            MyToggleButton {
+                id: btnShutdown
+                text: "OVRAS shutdown"
+                onCheckedChanged: {
+                    OverlayController.exitApp()
+                }
+            }
 
         }
 

--- a/src/res/qml/video_page/brightness/BrightnessGroupBox.qml
+++ b/src/res/qml/video_page/brightness/BrightnessGroupBox.qml
@@ -51,7 +51,7 @@ GroupBox {
 
             MySlider {
                 id: brightnessSlider
-                from: 0.01
+                from: 0.10
                 to: 1.0
                 stepSize: 0.01
                 value: 1.0


### PR DESCRIPTION
fixes #410 

fixes default value of brightness caused by initialization issues w/ overlay.

Adds a  "shutdown" button to settings.... that shuts down OVRAS, and not SteamVR