### PR TITLE
Refactor keyboard input sender

### DIFF
--- a/src/keyboard_input/input_sender.h
+++ b/src/keyboard_input/input_sender.h
@@ -8,7 +8,72 @@ enum class KeyStatus
     Down,
 };
 
-void sendTokensAsInput( const std::vector<Token> tokens );
+void initOsSystems();
+void shutdownOsSystems();
+
+void sendKeyPress( const Token token, const KeyStatus status );
+
+inline void sendTokensAsInput( const std::vector<Token> tokens )
+{
+    initOsSystems();
+
+    std::vector<Token> heldInputs = {};
+    bool noKeyUp = false;
+    for ( const auto& token : tokens )
+    {
+        if ( token == Token::TOKEN_NO_KEYUP_NEXT )
+        {
+            noKeyUp = true;
+            continue;
+        }
+
+        if ( isModifier( token ) )
+        {
+            sendKeyPress( token, KeyStatus::Down );
+            if ( !noKeyUp )
+            {
+                heldInputs.push_back( token );
+            }
+            continue;
+        }
+
+        if ( token == Token::TOKEN_NEW_SEQUENCE )
+        {
+            for ( const auto& h : heldInputs )
+            {
+                sendKeyPress( h, KeyStatus::Up );
+            }
+            heldInputs.clear();
+            continue;
+        }
+
+        if ( isLiteral( token ) )
+        {
+            sendKeyPress( token, KeyStatus::Down );
+            if ( !noKeyUp )
+            {
+                sendKeyPress( token, KeyStatus::Up );
+            }
+            continue;
+        }
+
+        if ( token != Token::TOKEN_NO_KEYUP_NEXT )
+        {
+            noKeyUp = false;
+            continue;
+        }
+    }
+
+    if ( !heldInputs.empty() )
+    {
+        for ( const auto& h : heldInputs )
+        {
+            sendKeyPress( h, KeyStatus::Up );
+        }
+    }
+
+    shutdownOsSystems();
+}
 
 inline void sendStringAsInput( const std::string input )
 {

--- a/src/keyboard_input/input_sender_win.cpp
+++ b/src/keyboard_input/input_sender_win.cpp
@@ -93,6 +93,15 @@ WORD convertToVirtualKeycode( const Token token )
         return 0;
     }
 }
+void initOsSystems()
+{
+    // Intentionally blank, no setup needed on Windows
+}
+
+void shutdownOsSystems()
+{
+    // Intentionally blank, no shutdown needed on Windows
+}
 
 INPUT createInputStruct( const WORD virtualKeyCode,
                          const KeyStatus keyStatus ) noexcept
@@ -163,68 +172,9 @@ void sendKeyboardInputRaw( std::vector<INPUT> inputs )
     }
 }
 
-void sendTokensAsInput( const std::vector<Token> tokens )
+void sendKeyPress( const Token token, const KeyStatus status )
 {
-    std::vector<INPUT> inputs = {};
-    std::vector<Token> heldInputs = {};
-    bool noKeyUp = false;
-    for ( const auto& token : tokens )
-    {
-        if ( token == Token::TOKEN_NO_KEYUP_NEXT )
-        {
-            noKeyUp = true;
-            continue;
-        }
-
-        if ( isModifier( token ) )
-        {
-            inputs.push_back( createInputStruct(
-                convertToVirtualKeycode( token ), KeyStatus::Down ) );
-            if ( !noKeyUp )
-            {
-                heldInputs.push_back( token );
-            }
-            continue;
-        }
-
-        if ( token == Token::TOKEN_NEW_SEQUENCE )
-        {
-            for ( const auto& h : heldInputs )
-            {
-                inputs.push_back( createInputStruct(
-                    convertToVirtualKeycode( h ), KeyStatus::Up ) );
-            }
-            heldInputs.clear();
-            continue;
-        }
-
-        if ( isLiteral( token ) )
-        {
-            inputs.push_back( createInputStruct(
-                convertToVirtualKeycode( token ), KeyStatus::Down ) );
-            if ( !noKeyUp )
-            {
-                inputs.push_back( createInputStruct(
-                    convertToVirtualKeycode( token ), KeyStatus::Up ) );
-            }
-            continue;
-        }
-        if ( token != Token::TOKEN_NO_KEYUP_NEXT )
-        {
-            noKeyUp = false;
-            continue;
-        }
-    }
-
-    if ( !heldInputs.empty() )
-    {
-        for ( const auto& h : heldInputs )
-        {
-            inputs.push_back( createInputStruct( convertToVirtualKeycode( h ),
-                                                 KeyStatus::Up ) );
-        }
-    }
-
-    sendKeyboardInputRaw( inputs );
-    // send inputs
+    std::vector<INPUT> v
+        = { createInputStruct( convertToVirtualKeycode( token ), status ) };
+    sendKeyboardInputRaw( v );
 }

--- a/src/keyboard_input/keyboard_input.cpp
+++ b/src/keyboard_input/keyboard_input.cpp
@@ -26,32 +26,36 @@ void sendKeyboardBackspace( const int count )
 
 void sendKeyboardAltTab()
 {
-    const auto tokens
-        = std::vector<Token>{ Token::MODIFIER_ALT, Token::KEY_TAB };
+    const auto tokens = std::vector<Token>{ Token::TOKEN_NO_KEYUP_NEXT,
+                                            Token::MODIFIER_ALT,
+                                            Token::KEY_TAB };
 
     sendTokensAsInput( tokens );
 }
 
 void sendKeyboardAltEnter()
 {
-    const auto tokens
-        = std::vector<Token>{ Token::MODIFIER_ALT, Token::KEY_ENTER };
+    const auto tokens = std::vector<Token>{ Token::TOKEN_NO_KEYUP_NEXT,
+                                            Token::MODIFIER_ALT,
+                                            Token::KEY_ENTER };
 
     sendTokensAsInput( tokens );
 }
 
 void sendKeyboardCtrlC()
 {
-    const auto tokens
-        = std::vector<Token>{ Token::MODIFIER_CTRL, Token::KEY_c };
+    const auto tokens = std::vector<Token>{ Token::TOKEN_NO_KEYUP_NEXT,
+                                            Token::MODIFIER_CTRL,
+                                            Token::KEY_c };
 
     sendTokensAsInput( tokens );
 }
 
 void sendKeyboardCtrlV()
 {
-    const auto tokens
-        = std::vector<Token>{ Token::MODIFIER_CTRL, Token::KEY_v };
+    const auto tokens = std::vector<Token>{ Token::TOKEN_NO_KEYUP_NEXT,
+                                            Token::MODIFIER_CTRL,
+                                            Token::KEY_v };
 
     sendTokensAsInput( tokens );
 }


### PR DESCRIPTION
## This PR:
* Moves the main logic of `keyboard_input/input_sender` to a cross platform file, in order to reduce duplication.
* Fixes a Linux bug where keys would not be released due to `TOKEN_NO_KEYUP_NEXT`
* Fixes a bug where premade key combinations that required holding one key did not work correctly (Alt+Tab, Alt+Enter, Ctrl+c, Ctrl+v).