### PR TITLE
Add exclution of libxcb-randr.so.0 to AppImage

### DIFF
--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -43,4 +43,4 @@ qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0


### PR DESCRIPTION
This prevented the appimage from working on newer Manjaro versions.
It has also been tested on Debian Testing to still work there.

Apparently pushes the bottom of the screen out of the overlay on Manjaro, but it's better than having it immediately segfault.

AppVeyor fails due to storage limit.

Fixes #437.