### PR TITLE
Fix chaperone profiles not loading correctly and SEGFAULT with Linux appimage

### DIFF
--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -43,4 +43,4 @@ qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0
+$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0,libxkbcommon-x11.so.0

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -80,7 +80,10 @@ struct ChaperoneProfile : settings::ISettingsObject
         o.addValue( includesChaperoneGeometry );
         o.addValue( static_cast<int>( chaperoneGeometryQuadCount ) );
 
-        if ( chaperoneGeometryQuadCount > 0 )
+        const auto chaperoneGeometryQuadsValid = chaperoneGeometryQuadCount > 0;
+        o.addValue( chaperoneGeometryQuadsValid );
+
+        if ( chaperoneGeometryQuadsValid )
         {
             for ( auto& arrayMember : chaperoneGeometryQuads )
             {
@@ -157,7 +160,6 @@ struct ChaperoneProfile : settings::ISettingsObject
         chaperoneGeometryQuadCount
             = static_cast<unsigned>( obj.getNextValueOrDefault( 0 ) );
 
-        // chaperoneGeometryQuads = nullptr;
         const auto chaperoneGeometryQuadsValid
             = obj.getNextValueOrDefault( false );
         if ( chaperoneGeometryQuadsValid )


### PR DESCRIPTION
* Fixes #455 
* Fixes #456.

The problems in #450 _could_ be related to the chaperone profiles being out of whack.

More information for either issue in the commit text.

This also highlights how tedious and unnecessarily complex debugging the settings object API is.