### PR TITLE
Refactor update rates of tab controllers

### DIFF
--- a/build_scripts/qt/sources.pri
+++ b/build_scripts/qt/sources.pri
@@ -23,6 +23,7 @@ SOURCES += src/main.cpp\
     src/settings/settings.cpp \
     src/settings/settings_object.cpp \
     src/alarm_clock/vr_alarm.cpp \
+    src/utils/update_rate.cpp \
 
 
 
@@ -64,6 +65,9 @@ HEADERS += src/overlaycontroller.h \
     src/settings/settings_object.h \
     src/settings/internal/settings_object_data.h \
     src/alarm_clock/vr_alarm.h \
+    src/settings/internal/settings_object_data.h \
+    src/settings/internal/settings_object_data.h \
+    src/utils/update_rate.h \
 
 
 win32 {

--- a/src/alarm_clock/vr_alarm.cpp
+++ b/src/alarm_clock/vr_alarm.cpp
@@ -2,6 +2,7 @@
 #include "../tabcontrollers/UtilitiesTabController.h"
 #include "vr_alarm.h"
 #include "../openvr/ovr_overlay_wrapper.h"
+#include "../utils/update_rate.h"
 
 namespace alarm_clock
 {
@@ -36,6 +37,12 @@ VrAlarm::VrAlarm()
 
 void VrAlarm::eventLoopTick()
 {
+    if ( updateRate.shouldSubjectNotRun(
+             UpdateSubject::UtilitiesTabController ) )
+    {
+        return;
+    }
+
     if ( alarmEnabled() && m_alarm.isValid() )
     {
         checkAlarmStatus();

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -150,7 +150,6 @@ OverlayController::OverlayController( bool desktopMode,
     m_moveCenterTabController.initStage1();
     m_audioTabController.initStage1();
     m_settingsTabController.initStage1();
-    m_utilitiesTabController.initStage1();
     m_videoTabController.initStage1();
     m_rotationTabController.initStage1();
 
@@ -958,6 +957,8 @@ void OverlayController::OnTimeoutPumpEvents()
             m_vsyncTooLateCounter++;
         }
     }
+
+    updateRate.incrementCounter();
 }
 
 void OverlayController::mainEventLoop()

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -44,6 +44,8 @@
 
 #include "alarm_clock/vr_alarm.h"
 
+#include "utils/update_rate.h"
+
 namespace application_strings
 {
 constexpr auto applicationOrganizationName = "AdvancedSettings-Team";
@@ -61,23 +63,6 @@ constexpr const char* applicationVersionString = APPLICATION_VERSION;
 // application namespace
 namespace advsettings
 {
-// These counters set timing for refreshing settings changes in tab ui
-// SettingsUpdateCounter values are set as prime numbers to reduce overlap
-// of simultaneous settings updates.
-// Actual rates of updates are counter * vsync (~11ms)
-// Values chosen based on update speed priority
-// Avoid setting values to the same numbers.
-constexpr int k_audioSettingsUpdateCounter = 89;
-constexpr int k_chaperoneSettingsUpdateCounter = 101;
-constexpr int k_moveCenterSettingsUpdateCounter = 83;
-constexpr int k_settingsTabSettingsUpdateCounter = 157;
-constexpr int k_steamVrSettingsUpdateCounter = 97;
-constexpr int k_utilitiesSettingsUpdateCounter = 19;
-
-// Dashboard Updates These can be faster as they should only be running while
-// Dashboard is active.
-constexpr int k_videoDashboardUpdateCounter = 47;
-
 // k_nonVsyncTickRate determines number of ms we wait to force the next event
 // loop tick when vsync is too late due to dropped frames.
 constexpr int k_nonVsyncTickRate = 20;

--- a/src/tabcontrollers/AudioTabController.h
+++ b/src/tabcontrollers/AudioTabController.h
@@ -131,8 +131,6 @@ private:
     bool m_isPlaybackOverride = false;
     bool m_isRecordingOverride = false;
 
-    unsigned int m_audioSettingsUpdateCounter = 90;
-
     int m_defaultProfileIndex = -1;
 
     unsigned settingsUpdateCounter = 0;

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -4,6 +4,7 @@
 #include "../settings/settings.h"
 #include "../utils/Matrix.h"
 #include "../quaternion/quaternion.h"
+#include "../utils/update_rate.h"
 #include <cmath>
 
 // application namespace
@@ -18,8 +19,6 @@ void ChaperoneTabController::initStage1()
     }
 
     reloadChaperoneProfiles();
-    m_chaperoneSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_chaperoneSettingsUpdateCounter );
     initCenterMarkerOverlay();
     eventLoopTick( m_trackingUniverse, nullptr );
 }
@@ -42,15 +41,13 @@ void ChaperoneTabController::initStage2( OverlayController* var_parent )
 
 void ChaperoneTabController::dashboardLoopTick()
 {
-    if ( settingsUpdateCounter >= m_chaperoneSettingsUpdateCounter )
+    if ( updateRate.shouldSubjectNotRun(
+             UpdateSubject::ChaperoneTabController ) )
     {
-        updateChaperoneSettings();
-        settingsUpdateCounter = 0;
+        return;
     }
-    else
-    {
-        settingsUpdateCounter++;
-    }
+
+    updateChaperoneSettings();
 }
 
 ChaperoneTabController::~ChaperoneTabController()

--- a/src/tabcontrollers/ChaperoneTabController.h
+++ b/src/tabcontrollers/ChaperoneTabController.h
@@ -363,8 +363,6 @@ private:
 
     int m_updateTicksChaperoneReload = 0;
 
-    unsigned int m_chaperoneSettingsUpdateCounter = 101;
-
     vr::VRActionHandle_t m_rightActionHandle;
     vr::VRActionHandle_t m_leftActionHandle;
     vr::VRInputValueHandle_t m_leftInputHandle;

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -39,8 +39,6 @@ namespace advsettings
 void MoveCenterTabController::initStage1()
 {
     reloadOffsetProfiles();
-    m_moveCenterSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_moveCenterSettingsUpdateCounter );
     m_lastDragUpdateTimePoint = std::chrono::steady_clock::now();
     m_lastGravityUpdateTimePoint = std::chrono::steady_clock::now();
 }

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -204,8 +204,6 @@ private:
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
 
-    unsigned int m_moveCenterSettingsUpdateCounter = 83;
-
     // Matrix used For Center Marker
     vr::HmdMatrix34_t m_offsetmatrix = utils::k_forwardUpMatrix;
 

--- a/src/tabcontrollers/SettingsTabController.cpp
+++ b/src/tabcontrollers/SettingsTabController.cpp
@@ -1,6 +1,7 @@
 #include "SettingsTabController.h"
 #include <QQuickWindow>
 #include "../overlaycontroller.h"
+#include "../utils/update_rate.h"
 
 // application namespace
 namespace advsettings
@@ -9,8 +10,6 @@ void SettingsTabController::initStage1()
 {
     m_autoStartEnabled = vr::VRApplications()->GetApplicationAutoLaunch(
         application_strings::applicationKey );
-    m_settingsTabSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_settingsTabSettingsUpdateCounter );
 }
 
 void SettingsTabController::initStage2( OverlayController* var_parent )
@@ -22,16 +21,14 @@ void SettingsTabController::initStage2( OverlayController* var_parent )
 
 void SettingsTabController::dashboardLoopTick()
 {
-    if ( settingsUpdateCounter >= m_settingsTabSettingsUpdateCounter )
+    if ( updateRate.shouldSubjectNotRun(
+             UpdateSubject::SettingsTabController ) )
     {
-        setAutoStartEnabled( vr::VRApplications()->GetApplicationAutoLaunch(
-            application_strings::applicationKey ) );
-        settingsUpdateCounter = 0;
+        return;
     }
-    else
-    {
-        settingsUpdateCounter++;
-    }
+
+    setAutoStartEnabled( vr::VRApplications()->GetApplicationAutoLaunch(
+        application_strings::applicationKey ) );
 }
 
 bool SettingsTabController::autoStartEnabled() const

--- a/src/tabcontrollers/SettingsTabController.h
+++ b/src/tabcontrollers/SettingsTabController.h
@@ -26,12 +26,8 @@ class SettingsTabController : public QObject
 private:
     OverlayController* parent;
 
-    unsigned settingsUpdateCounter = 0;
-
     bool m_autoStartEnabled = false;
     bool m_nativeChaperoneToggle = false;
-
-    unsigned int m_settingsTabSettingsUpdateCounter = 157;
 
 public:
     void initStage1();

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -1,14 +1,13 @@
 #include "SteamVRTabController.h"
 #include <QQuickWindow>
 #include "../overlaycontroller.h"
+#include "../utils/update_rate.h"
 
 // application namespace
 namespace advsettings
 {
 void SteamVRTabController::initStage1()
 {
-    m_steamVrSettingsUpdateCounter
-        = utils::adjustUpdateRate( k_steamVrSettingsUpdateCounter );
     dashboardLoopTick();
 }
 
@@ -19,149 +18,141 @@ void SteamVRTabController::initStage2( OverlayController* var_parent )
 
 void SteamVRTabController::dashboardLoopTick()
 {
-    if ( settingsUpdateCounter >= m_steamVrSettingsUpdateCounter )
+    if ( updateRate.shouldSubjectNotRun( UpdateSubject::SteamVrTabController ) )
     {
-        vr::EVRSettingsError vrSettingsError;
-
-        // Checks and synchs performance graph
-        auto pg = vr::VRSettings()->GetBool( vr::k_pch_Perf_Section,
-                                             vr::k_pch_Perf_PerfGraphInHMD_Bool,
-                                             &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_Perf_PerfGraphInHMD_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setPerformanceGraph( pg );
-
-        // synch systembutton
-        auto sb = vr::VRSettings()->GetBool(
-            vr::k_pch_SteamVR_Section,
-            vr::k_pch_SteamVR_SendSystemButtonToAllApps_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_SteamVR_SendSystemButtonToAllApps_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setSystemButton( sb );
-
-        // synch nofadetogrid
-        auto nf = vr::VRSettings()->GetBool( vr::k_pch_SteamVR_Section,
-                                             vr::k_pch_SteamVR_DoNotFadeToGrid,
-                                             &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_SteamVR_DoNotFadeToGrid
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setNoFadeToGrid( nf );
-
-        // synch multipleDriver
-        auto md = vr::VRSettings()->GetBool(
-            vr::k_pch_SteamVR_Section,
-            vr::k_pch_SteamVR_ActivateMultipleDrivers_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_SteamVR_ActivateMultipleDrivers_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setMultipleDriver( md );
-
-        // synch dnd
-        auto donotd = vr::VRSettings()->GetBool(
-            vr::k_pch_Notifications_Section,
-            vr::k_pch_Notifications_DoNotDisturb_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_Notifications_DoNotDisturb_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setDND( donotd );
-
-        // synch camera
-        auto ca = vr::VRSettings()->GetBool( vr::k_pch_Camera_Section,
-                                             vr::k_pch_Camera_EnableCamera_Bool,
-                                             &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_Camera_EnableCamera_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setCameraActive( ca );
-
-        // synch camera room
-        auto cr = vr::VRSettings()->GetBool(
-            vr::k_pch_Camera_Section,
-            vr::k_pch_Camera_EnableCameraForRoomView_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_Camera_EnableCameraForRoomView_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setCameraRoom( cr );
-
-        // synch camera dashboard
-        auto cd = vr::VRSettings()->GetBool(
-            vr::k_pch_Camera_Section,
-            vr::k_pch_Camera_EnableCameraInDashboard_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING ) << "Could not read \""
-                           << vr::k_pch_Camera_EnableCameraInDashboard_Bool
-                           << "\" setting: "
-                           << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                                  vrSettingsError );
-        }
-        setCameraDashboard( cd );
-
-        // synch camera bounds
-        auto cb = vr::VRSettings()->GetBool(
-            vr::k_pch_Camera_Section,
-            vr::k_pch_Camera_EnableCameraForCollisionBounds_Bool,
-            &vrSettingsError );
-        if ( vrSettingsError != vr::VRSettingsError_None )
-        {
-            LOG( WARNING )
-                << "Could not read \""
-                << vr::k_pch_Camera_EnableCameraForCollisionBounds_Bool
-                << "\" setting: "
-                << vr::VRSettings()->GetSettingsErrorNameFromEnum(
-                       vrSettingsError );
-        }
-        setCameraBounds( cb );
-
-        settingsUpdateCounter = 0;
+        return;
     }
-    else
+
+    vr::EVRSettingsError vrSettingsError;
+
+    // Checks and synchs performance graph
+    auto pg = vr::VRSettings()->GetBool( vr::k_pch_Perf_Section,
+                                         vr::k_pch_Perf_PerfGraphInHMD_Bool,
+                                         &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
     {
-        settingsUpdateCounter++;
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Perf_PerfGraphInHMD_Bool << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
     }
+    setPerformanceGraph( pg );
+
+    // synch systembutton
+    auto sb = vr::VRSettings()->GetBool(
+        vr::k_pch_SteamVR_Section,
+        vr::k_pch_SteamVR_SendSystemButtonToAllApps_Bool,
+        &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_SteamVR_SendSystemButtonToAllApps_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setSystemButton( sb );
+
+    // synch nofadetogrid
+    auto nf = vr::VRSettings()->GetBool( vr::k_pch_SteamVR_Section,
+                                         vr::k_pch_SteamVR_DoNotFadeToGrid,
+                                         &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_SteamVR_DoNotFadeToGrid << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setNoFadeToGrid( nf );
+
+    // synch multipleDriver
+    auto md = vr::VRSettings()->GetBool(
+        vr::k_pch_SteamVR_Section,
+        vr::k_pch_SteamVR_ActivateMultipleDrivers_Bool,
+        &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_SteamVR_ActivateMultipleDrivers_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setMultipleDriver( md );
+
+    // synch dnd
+    auto donotd
+        = vr::VRSettings()->GetBool( vr::k_pch_Notifications_Section,
+                                     vr::k_pch_Notifications_DoNotDisturb_Bool,
+                                     &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Notifications_DoNotDisturb_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setDND( donotd );
+
+    // synch camera
+    auto ca = vr::VRSettings()->GetBool( vr::k_pch_Camera_Section,
+                                         vr::k_pch_Camera_EnableCamera_Bool,
+                                         &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Camera_EnableCamera_Bool << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setCameraActive( ca );
+
+    // synch camera room
+    auto cr = vr::VRSettings()->GetBool(
+        vr::k_pch_Camera_Section,
+        vr::k_pch_Camera_EnableCameraForRoomView_Bool,
+        &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Camera_EnableCameraForRoomView_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setCameraRoom( cr );
+
+    // synch camera dashboard
+    auto cd = vr::VRSettings()->GetBool(
+        vr::k_pch_Camera_Section,
+        vr::k_pch_Camera_EnableCameraInDashboard_Bool,
+        &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Camera_EnableCameraInDashboard_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setCameraDashboard( cd );
+
+    // synch camera bounds
+    auto cb = vr::VRSettings()->GetBool(
+        vr::k_pch_Camera_Section,
+        vr::k_pch_Camera_EnableCameraForCollisionBounds_Bool,
+        &vrSettingsError );
+    if ( vrSettingsError != vr::VRSettingsError_None )
+    {
+        LOG( WARNING ) << "Could not read \""
+                       << vr::k_pch_Camera_EnableCameraForCollisionBounds_Bool
+                       << "\" setting: "
+                       << vr::VRSettings()->GetSettingsErrorNameFromEnum(
+                              vrSettingsError );
+    }
+    setCameraBounds( cb );
 }
 
 bool SteamVRTabController::performanceGraph() const

--- a/src/tabcontrollers/SteamVRTabController.h
+++ b/src/tabcontrollers/SteamVRTabController.h
@@ -49,10 +49,6 @@ private:
     bool m_cameraRoom = false;
     bool m_cameraDashboard = false;
 
-    unsigned settingsUpdateCounter = 0;
-
-    unsigned int m_steamVrSettingsUpdateCounter = 97;
-
 public:
     void initStage1();
     void initStage2( OverlayController* parent );

--- a/src/tabcontrollers/UtilitiesTabController.h
+++ b/src/tabcontrollers/UtilitiesTabController.h
@@ -32,10 +32,7 @@ private:
     int m_batteryState[vr::k_unMaxTrackedDeviceCount];
     bool m_batteryVisible[vr::k_unMaxTrackedDeviceCount];
 
-    unsigned int m_utilitiesSettingsUpdateCounter = 19;
-
 public:
-    void initStage1();
     void initStage2( OverlayController* var_parent );
 
     void eventLoopTick();

--- a/src/utils/update_rate.cpp
+++ b/src/utils/update_rate.cpp
@@ -1,0 +1,57 @@
+#include "update_rate.h"
+
+UpdateRate updateRate{};
+
+/**
+   @brief getSubjectRate returns the amount of frames before a subject is run
+   again.
+   @param Subject
+   @return Amount of frames before subject is run again.
+
+    So a return value of 19 would mean that every 19 frames, the subject is run.
+    Divide the expected framerate with the return value to get the amount of
+   times per second the subject is run.
+ */
+constexpr unsigned int getSubjectRate( const UpdateSubject subject )
+{
+    /*
+       Return values are primes in order to reduce the amount of times where
+       multiple subjects are run on the same frame.
+    */
+    switch ( subject )
+    {
+    case UpdateSubject::UtilitiesTabController:
+        return 19;
+    case UpdateSubject::VideoDashboard:
+        return 47;
+    case UpdateSubject::AudioTabController:
+        return 89;
+    case UpdateSubject::SteamVrTabController:
+        return 97;
+    case UpdateSubject::ChaperoneTabController:
+        return 101;
+    case UpdateSubject::SettingsTabController:
+        return 157;
+    }
+
+    return 0;
+}
+
+bool UpdateRate::shouldSubjectRun( const UpdateSubject subject ) noexcept
+{
+    const auto subjectTarget = getSubjectRate( subject );
+
+    const auto shouldRun = ( m_counter % subjectTarget ) == 0;
+
+    return shouldRun;
+}
+
+bool UpdateRate::shouldSubjectNotRun( const UpdateSubject subject ) noexcept
+{
+    return !shouldSubjectRun( subject );
+}
+
+void UpdateRate::incrementCounter() noexcept
+{
+    m_counter++;
+}

--- a/src/utils/update_rate.h
+++ b/src/utils/update_rate.h
@@ -1,0 +1,28 @@
+#pragma once
+
+enum class UpdateSubject
+{
+    AudioTabController,
+    ChaperoneTabController,
+    SettingsTabController,
+    SteamVrTabController,
+    UtilitiesTabController,
+    VideoDashboard,
+};
+
+class UpdateRate
+{
+public:
+    [[nodiscard]] bool shouldSubjectRun( const UpdateSubject subject ) noexcept;
+    [[nodiscard]] bool
+        shouldSubjectNotRun( const UpdateSubject subject ) noexcept;
+    void incrementCounter() noexcept;
+
+private:
+    // counter is deliberately set as unsigned so that the program can continue
+    // functioning if the counter should go above INT_MAX (or UINT_MAX in this
+    // case)
+    unsigned int m_counter;
+};
+
+extern UpdateRate updateRate;


### PR DESCRIPTION
Previous way of controlling when controllers were run was split among the different  controllers, meaning that third parties would require knowledge of internal state of  controllers in order to be on the same update schedule as them.

This refactor moves the logic into a seperate class.

Additionally, it also stops the use of the `adjustUpdateRate` function on all tab controllers, since it broke the prime-number-ability of less collisions.