### PR TITLE
Disallow AppImageLauncher integration

### DIFF
--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -39,12 +39,17 @@ cp $PROJECT_DIR/src/res/img/icons/thumbicon.png $EXE_DIR/usr/share/icons/hicolor
 
 cp $PROJECT_DIR/src/package_files/linux/AdvancedSettings.desktop $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
 
-if [ "$1" == "steam" ]; then
-  echo "X-AppImage-Integrate=false" >> $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
-fi
-
 qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run
 
-$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0,libxkbcommon-x11.so.0
+APPIMAGE_COMMAND="$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0,libxkbcommon-x11.so.0"
+
+$APPIMAGE_COMMAND
+
+# Disable AppImageLauncher integration for Steam versions
+echo "X-AppImage-Integrate=false" >> $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
+export VERSION="$(git rev-parse --short HEAD)-STEAM"
+
+$APPIMAGE_COMMAND
+

--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -39,6 +39,10 @@ cp $PROJECT_DIR/src/res/img/icons/thumbicon.png $EXE_DIR/usr/share/icons/hicolor
 
 cp $PROJECT_DIR/src/package_files/linux/AdvancedSettings.desktop $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
 
+if [ "$1" == "steam" ]; then
+  echo "X-AppImage-Integrate=false" >> $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
+fi
+
 qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run

--- a/src/package_files/linux/AdvancedSettings.desktop
+++ b/src/package_files/linux/AdvancedSettings.desktop
@@ -5,4 +5,3 @@ Comment=OVRAS
 Exec=AdvancedSettings
 Icon=AdvancedSettings
 Categories=Office;
-X-AppImage-Integrate=false

--- a/src/package_files/linux/AdvancedSettings.desktop
+++ b/src/package_files/linux/AdvancedSettings.desktop
@@ -5,3 +5,4 @@ Comment=OVRAS
 Exec=AdvancedSettings
 Icon=AdvancedSettings
 Categories=Office;
+X-AppImage-Integrate=false


### PR DESCRIPTION
This PR disables the AppImageLauncher integration. The problem right now is that whenever OVR-AS is started on Steam, AppImageLauncher will ask about starting it once or integrating it into the system.

Related issue and note by the developer of AppImageLauncher:
https://github.com/TheAssassin/AppImageLauncher/issues/338#issuecomment-649001773