### PR TITLE
Add X-AppImage-Integrate=false to second .desktop file

### DIFF
--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -49,6 +49,7 @@ $APPIMAGE_COMMAND
 
 # Disable AppImageLauncher integration for Steam versions
 echo "X-AppImage-Integrate=false" >> $EXE_DIR/usr/share/applications/AdvancedSettings.desktop
+echo "X-AppImage-Integrate=false" >> $EXE_DIR/AdvancedSettings.desktop
 export VERSION="$(git rev-parse --short HEAD)-STEAM"
 
 $APPIMAGE_COMMAND


### PR DESCRIPTION
`qtdeploylinux` apparently caches the .desktop file, so we need to change both of them.

Issue discovered by @DASPRiD in PR #484, see discussion there for more.