### PR TITLE
Smoother (autoturn) smooth turn: estimate frame rate when beginning turn

### DIFF
--- a/src/tabcontrollers/RotationTabController.cpp
+++ b/src/tabcontrollers/RotationTabController.cpp
@@ -368,52 +368,46 @@ void RotationTabController::doAutoTurn(
                      < ( FrameRates::RATE_144HZ + FrameRates::RATE_120HZ ) / 2 )
                 {
                     m_estimatedFrameRate = FrameRates::RATE_144HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 144Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
                 else if ( ( delta >= ( FrameRates::RATE_144HZ
                                        + FrameRates::RATE_120HZ )
                                          / 2 )
                           && ( delta < ( FrameRates::RATE_120HZ
-                                          + FrameRates::RATE_90HZ )
-                                            / 2 ) )
+                                         + FrameRates::RATE_90HZ )
+                                           / 2 ) )
                 {
                     m_estimatedFrameRate = FrameRates::RATE_120HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 120Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
                 else if ( ( delta >= ( FrameRates::RATE_120HZ
                                        + FrameRates::RATE_90HZ )
                                          / 2 )
                           && ( delta < ( FrameRates::RATE_90HZ
-                                          + FrameRates::RATE_72HZ )
-                                            / 2 ) )
+                                         + FrameRates::RATE_72HZ )
+                                           / 2 ) )
                 {
                     m_estimatedFrameRate = FrameRates::RATE_90HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 90Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
                 else if ( ( delta
                             >= ( FrameRates::RATE_90HZ + FrameRates::RATE_72HZ )
                                    / 2 )
                           && ( delta < ( FrameRates::RATE_72HZ
-                                          + FrameRates::RATE_60HZ )
-                                            / 2 ) )
+                                         + FrameRates::RATE_60HZ )
+                                           / 2 ) )
                 {
                     m_estimatedFrameRate = FrameRates::RATE_72HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 72Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
                 else if ( ( delta
                             >= ( FrameRates::RATE_72HZ + FrameRates::RATE_60HZ )
                                    / 2 )
                           && ( delta < ( FrameRates::RATE_60HZ
-                                          + FrameRates::RATE_45HZ )
-                                            / 2 ) )
+                                         + FrameRates::RATE_45HZ )
+                                           / 2 ) )
                 {
                     m_estimatedFrameRate = FrameRates::RATE_60HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 60Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
                 else
                 {
                     m_estimatedFrameRate = FrameRates::RATE_45HZ;
-                    LOG (INFO) << "Estimate Frame Rate: 45Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
                 }
             }
             else if ( ( chaperoneQuad.distance

--- a/src/tabcontrollers/RotationTabController.cpp
+++ b/src/tabcontrollers/RotationTabController.cpp
@@ -196,14 +196,11 @@ void RotationTabController::doAutoTurn(
              && m_autoTurnLinearSmoothTurnRemaining != 0 )
         {
             // TODO: implement angular acceleration max?
-            auto deltaMillis
-                = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      currentTime - m_autoTurnLastUpdate )
-                      .count();
+            double deltaSeconds
+                = FrameRates::toDoubleSeconds( m_estimatedFrameRate );
             auto miniDeltaAngle = static_cast<int>(
                 std::abs(
-                    ( deltaMillis * RotationTabController::autoTurnSpeed() )
-                    / 1000 )
+                    ( deltaSeconds * RotationTabController::autoTurnSpeed() ) )
                 * ( m_autoTurnLinearSmoothTurnRemaining < 0 ? -1 : 1 ) );
             if ( std::abs( m_autoTurnLinearSmoothTurnRemaining )
                  < std::abs( miniDeltaAngle ) )
@@ -366,6 +363,58 @@ void RotationTabController::doAutoTurn(
                 } while ( false );
 
                 m_autoTurnWallActive[i] = true;
+                auto delta = currentTime - m_autoTurnLastUpdate;
+                if ( delta
+                     < ( FrameRates::RATE_144HZ + FrameRates::RATE_120HZ ) / 2 )
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_144HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 144Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
+                else if ( ( delta >= ( FrameRates::RATE_144HZ
+                                       + FrameRates::RATE_120HZ )
+                                         / 2 )
+                          && ( delta < ( FrameRates::RATE_120HZ
+                                          + FrameRates::RATE_90HZ )
+                                            / 2 ) )
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_120HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 120Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
+                else if ( ( delta >= ( FrameRates::RATE_120HZ
+                                       + FrameRates::RATE_90HZ )
+                                         / 2 )
+                          && ( delta < ( FrameRates::RATE_90HZ
+                                          + FrameRates::RATE_72HZ )
+                                            / 2 ) )
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_90HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 90Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
+                else if ( ( delta
+                            >= ( FrameRates::RATE_90HZ + FrameRates::RATE_72HZ )
+                                   / 2 )
+                          && ( delta < ( FrameRates::RATE_72HZ
+                                          + FrameRates::RATE_60HZ )
+                                            / 2 ) )
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_72HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 72Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
+                else if ( ( delta
+                            >= ( FrameRates::RATE_72HZ + FrameRates::RATE_60HZ )
+                                   / 2 )
+                          && ( delta < ( FrameRates::RATE_60HZ
+                                          + FrameRates::RATE_45HZ )
+                                            / 2 ) )
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_60HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 60Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
+                else
+                {
+                    m_estimatedFrameRate = FrameRates::RATE_45HZ;
+                    LOG (INFO) << "Estimate Frame Rate: 45Hz. Exact: " << (1.0 / FrameRates::toDoubleSeconds(delta));
+                }
             }
             else if ( ( chaperoneQuad.distance
                         > ( RotationTabController::autoTurnActivationDistance()

--- a/src/tabcontrollers/RotationTabController.h
+++ b/src/tabcontrollers/RotationTabController.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <QObject>
@@ -24,6 +23,35 @@ enum class AutoTurnModes
     SNAP,
     LINEAR_SMOOTH_TURN
 };
+
+namespace FrameRates
+{
+    // Each of type std::chrono::time_point::duration
+    constexpr auto RATE_45HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 45>>( 1 ) );
+    constexpr auto RATE_60HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 60>>( 1 ) );
+    constexpr auto RATE_72HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 72>>( 1 ) );
+    constexpr auto RATE_90HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 90>>( 1 ) );
+    constexpr auto RATE_120HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 120>>( 1 ) );
+    constexpr auto RATE_144HZ = std::chrono::duration_cast<
+        std::chrono::steady_clock::time_point::duration>(
+        std::chrono::duration<int, std::ratio<1, 144>>( 1 ) );
+
+    template <typename T> double toDoubleSeconds( T duration )
+    {
+        return ( static_cast<double>( duration.count() ) * T::period::num )
+               / T::period::den;
+    }
+} // namespace FrameRates
 
 class RotationTabController : public QObject
 {
@@ -65,6 +93,7 @@ private:
     vr::HmdMatrix34_t m_autoTurnLastHmdUpdate;
     std::vector<utils::ChaperoneQuadData> m_autoTurnChaperoneDistancesLast;
     double m_autoTurnRoundingError = 0.0;
+    std::chrono::steady_clock::time_point::duration m_estimatedFrameRate;
 
     bool m_isHMDActive = false;
 


### PR DESCRIPTION
Like the title says: when beginning an auto-turn, estimate the frame rate using the last frametime, then apply it (times our turn rate) each frame instead of checking the time delta every frame. Results in somewhat smoother turns, though the chaperone still jitters as it does when using space drag/turn.