### PR TITLE
Bump up autoturn smooth turn speed default, adjust Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -407,7 +407,7 @@ Allows users to temporarily move and rotate the center of the playspace. This al
   - **DeActivation Distance**:  The minimum distance (activation + deactivation) you must be from the wall before autoturn will activate again.
   - **Use Corner Angle**: When already against a wall and reaching a corner, turn the angle of that corner rather than the angle of your headset to the wall (reccomended)
   - **Use Smooth Turn**: Toggles between a smooth turn and a snap turn.
-  - **Turn Speed**: How fast you rotate in Degrees per second.
+  - **Turn Speed**: How fast you rotate in Degrees per second. Use more for a more comfortable experience, less for natural movement in social/physical VR games.
   - **Detangle Angle**: Settings attempting to keep your cord untangled while using the Auto-Turn feature.
     - **Min Rotations(deg)**: The amount of rotation before Auto-Turn starts to try and un-tangle your cord.
     - **Max Wall Angle(deg)**: When the angle of your headset to the wall is less than Max Wall Angle, it will turn you whichever way will start to untangle your cord. Otherwise it will turn you whichever way is closest. Set to '0' if you have a cordless setup 

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -484,7 +484,7 @@ private:
             DoubleSetting::ROTATION_autoturnVestibularMotionRadius,
             SettingCategory::Rotation,
             QtInfo{ "autoturnVestibularMotionRadius" },
-            11.0 },
+            22.0 },
 
     };
 

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -563,7 +563,7 @@ private:
         IntSettingValue{ IntSetting::ROTATION_autoturnLinearTurnSpeed,
                          SettingCategory::Rotation,
                          QtInfo{ "autoturnLinearTurnSpeed" },
-                         9000 },
+                         45000 },
         IntSettingValue{ IntSetting::ROTATION_autoturnMode,
                          SettingCategory::Rotation,
                          QtInfo{ "autoturnMode" },


### PR DESCRIPTION
Something I've been wanting to do for a while... with Autoturn, snap-turn is the most comfortable option but is super disorienting. Smooth-turn generally gives you a better sense of direction, but the default of 90 deg/s is a bit slow and uncomfortable, some people have mentioned turning it way up so you can see where you've turned but still spending as little time 'in the turn' as possible.