### PR TITLE
Reverb Bindings and 5.3.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -542,7 +542,7 @@ Allows users to temporarily move and rotate the center of the playspace. This al
 - **Disable Notification of Newer Version Availability**: This turns off the on start-up check for a new version. (You can refresh this to do a manual check.)
 - **Force Use SteamVR Chaperone**: This feature is currently experimental, when using third party headsets this will allow you to use SteamVR's chaperone, as if it was a native headset.
 - **Force Use SteamVR (Disable Oculus API)**: This feature is currently experimental, it should disable Oculus API preventing games with both SteamVR and Oculus API to only run as SteamVR
-- ** Exclusive Input Toggle: This feature Enables Exclusive Input Mode, while in this mode you will only send OVRAS keybinds or App keybinds [with the exception of OVRAS system keybinds always working]
+- **Exclusive Input Toggle**: This feature Enables Exclusive Input Mode, while in this mode you will only send OVRAS keybinds or App keybinds [with the exception of OVRAS system keybinds always working]
 - **Disable App Vsync:** Allows setting a custom base update rate for Advanced Settings. (Might be useful on HMDs with very high or very low refresh rates).
 - **Shutdown OVRAS** Shuts-Down Advanced Settings without closing out of VR.
 

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.3.0-release
+5.3.1-release

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -17,6 +17,10 @@
       "binding_url": "default_action_manifests/ovras-team.advancedsettings_default_touch.json"
    },
    {
+      "controller_type": "hpmotioncontroller",
+      "binding_url": "default_action_manifests/ovras-team.advancedsettings_default_hp_wmr.json"   
+   }
+   {
       "controller_type": "generic_hmd",
       "binding_url": "default_action_manifests/ovras-team.advancedsettings_default_hmd.json"
    }

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -19,7 +19,7 @@
    {
       "controller_type": "hpmotioncontroller",
       "binding_url": "default_action_manifests/ovras-team.advancedsettings_default_hp_wmr.json"   
-   }
+   },
    {
       "controller_type": "generic_hmd",
       "binding_url": "default_action_manifests/ovras-team.advancedsettings_default_hmd.json"

--- a/src/package_files/default_action_manifests/ovras-team.advancedsettings_default_hp_wmr.json
+++ b/src/package_files/default_action_manifests/ovras-team.advancedsettings_default_hp_wmr.json
@@ -1,0 +1,106 @@
+{
+   "alias_info" : {},
+   "app_key" : "steam.overlay.1009850",
+   "bindings" : {
+      "/actions/haptic" : {
+         "haptics" : [
+            {
+               "output" : "/actions/haptic/out/hapticsleft",
+               "path" : "/user/hand/left/output/haptic"
+            },
+            {
+               "output" : "/actions/haptic/out/hapticsright",
+               "path" : "/user/hand/right/output/haptic"
+            }
+         ],
+         "sources" : [
+            {
+               "inputs" : {},
+               "mode" : "none",
+               "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {},
+               "mode" : "none",
+               "path" : "/user/hand/right/input/b"
+            }
+         ]
+      },
+      "/actions/system" : {
+         "sources" : [
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/system/in/pushtotalk"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/trigger"
+            }
+         ]
+      },
+      "/actions/motion" : {
+         "sources" : [
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/motion/in/lefthandspaceturn"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {
+                  "double" : {
+                     "output" : "/actions/motion/in/optionaloverridelefthandspacedrag"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/motion/in/swapspacedragtolefthandoverride"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/motion/in/righthandspaceturn"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/b"
+            },
+            {
+               "inputs" : {
+                  "double" : {
+                     "output" : "/actions/motion/in/optionaloverriderighthandspacedrag"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/b"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/motion/in/swapspacedragtorighthandoverride"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/b"
+            }
+         ]
+      }
+   },
+   "controller_type" : "hpmotioncontroller",
+   "description" : "",
+   "name" : "OVRAS HP WMR Default",
+   "options" : {},
+   "simulated_actions" : []
+}

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 3, "patch": 0, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 3, "patch": 1, "updateMessage": "", "optionalMessage": "" }


### PR DESCRIPTION
**This Is a release PR**

fixes #518 


Adds default Controller Bindings for HP's new WMR controllers (probably)
fixes a formatting Issue in readme.