### PR TITLE
(WIP) Autoalign

### DIFF
--- a/src/openvr/ivrinput.cpp
+++ b/src/openvr/ivrinput.cpp
@@ -132,6 +132,7 @@ SteamIVRInput::SteamIVRInput()
       m_smoothTurnLeft( action_keys::smoothTurnLeft ),
       m_smoothTurnRight( action_keys::smoothTurnRight ),
       m_autoTurnToggle( action_keys::autoTurnToggle ),
+      m_addAutoAlignPoint( action_keys::addAutoAlignPoint ),
       m_xAxisLockToggle( action_keys::xAxisLockToggle ),
       m_yAxisLockToggle( action_keys::yAxisLockToggle ),
       m_zAxisLockToggle( action_keys::zAxisLockToggle ),
@@ -299,6 +300,10 @@ bool SteamIVRInput::smoothTurnRight()
 bool SteamIVRInput::autoTurnToggle()
 {
     return isDigitalActionActivatedOnce( m_autoTurnToggle );
+}
+bool SteamIVRInput::addAutoAlignPoint()
+{
+    return isDigitalActionActivatedOnce( m_addAutoAlignPoint );
 }
 
 bool SteamIVRInput::xAxisLockToggle()

--- a/src/openvr/ivrinput.h
+++ b/src/openvr/ivrinput.h
@@ -47,6 +47,7 @@ namespace action_keys
     constexpr auto smoothTurnLeft = "/actions/motion/in/SmoothTurnLeft";
     constexpr auto smoothTurnRight = "/actions/motion/in/SmoothTurnRight";
     constexpr auto autoTurnToggle = "/actions/motion/in/AutoTurnToggle";
+    constexpr auto addAutoAlignPoint = "/actions/motion/in/AddAutoAlignPoint";
 
     constexpr auto xAxisLockToggle = "/actions/misc/in/XAxisLockToggle";
     constexpr auto yAxisLockToggle = "/actions/misc/in/YAxisLockToggle";
@@ -151,6 +152,7 @@ public:
     bool smoothTurnLeft();
     bool smoothTurnRight();
     bool autoTurnToggle();
+    bool addAutoAlignPoint();
     bool xAxisLockToggle();
     bool yAxisLockToggle();
     bool zAxisLockToggle();
@@ -233,6 +235,7 @@ private:
     DigitalAction m_smoothTurnLeft;
     DigitalAction m_smoothTurnRight;
     DigitalAction m_autoTurnToggle;
+    DigitalAction m_addAutoAlignPoint;
     DigitalAction m_xAxisLockToggle;
     DigitalAction m_yAxisLockToggle;
     DigitalAction m_zAxisLockToggle;

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -755,6 +755,10 @@ void OverlayController::processRotationBindings()
         m_rotationTabController.setAutoTurnEnabled(
             !( m_rotationTabController.autoTurnEnabled() ) );
     }
+    if ( m_actions.addAutoAlignPoint() )
+    {
+        m_rotationTabController.addAutoAlignPoint();
+    }
 }
 /*!
 Checks if an action has been activated and dispatches the related action if

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -163,7 +163,11 @@
       "requirement": "optional",
       "type": "boolean"
     },
-    
+    {
+      "name": "/actions/motion/in/AddAutoAlignPoint",
+      "requirement": "optional",
+      "type": "boolean"
+    },
     {
       "name": "/actions/misc/in/XAxisLockToggle",
       "requirement": "optional",
@@ -288,6 +292,7 @@
         "/actions/motion/in/SmoothTurnLeft" : "Smooth-Turn Left",
         "/actions/motion/in/SmoothTurnRight" : "Smooth-Turn Right",
 		"/actions/motion/in/AutoTurnToggle" : "Auto-Turn Toggle",
+        "/actions/motion/in/AddAutoAlignPoint" : "Add Auto Align Point",
         
         "/actions/misc/in/XAxisLockToggle" : "X-Axis Lock Toggle",
         "/actions/misc/in/YAxisLockToggle" : "Y-Axis Lock Toggle",

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -330,8 +330,6 @@ void MoveCenterTabController::setRotation( int value, bool notify )
             return;
         }
 
-        double angle = ( value - m_rotation ) * k_centidegreesToRadians;
-
         // Get hmd pose matrix.
         vr::TrackedDevicePose_t
             devicePosesForRot[vr::k_unMaxTrackedDeviceCount];
@@ -356,26 +354,35 @@ void MoveCenterTabController::setRotation( int value, bool notify )
 
         vr::HmdMatrix34_t oldHmdPos
             = devicePosesForRot[0].mDeviceToAbsoluteTracking;
+        
+        setRotationAroundPivot(value, notify, oldHmdPos);
+    }
+}
 
+void MoveCenterTabController::setRotationAroundPivot( int value, bool notify, const vr::HmdMatrix34_t& pivot )
+{
+    if ( m_rotation != value )
+    {
+        double angle = ( value - m_rotation ) * k_centidegreesToRadians;
         // Set up xyz coordinate values from pose matrix.
-        double oldHmdXyz[3] = { static_cast<double>( oldHmdPos.m[0][3] ),
-                                static_cast<double>( oldHmdPos.m[1][3] ),
-                                static_cast<double>( oldHmdPos.m[2][3] ) };
-        double newHmdXyz[3] = { static_cast<double>( oldHmdPos.m[0][3] ),
-                                static_cast<double>( oldHmdPos.m[1][3] ),
-                                static_cast<double>( oldHmdPos.m[2][3] ) };
+        double oldXyz[3] = { static_cast<double>( pivot.m[0][3] ),
+                                static_cast<double>( pivot.m[1][3] ),
+                                static_cast<double>( pivot.m[2][3] ) };
+        double newXyz[3] = { static_cast<double>( pivot.m[0][3] ),
+                                static_cast<double>( pivot.m[1][3] ),
+                                static_cast<double>( pivot.m[2][3] ) };
 
-        // Convert oldHmdXyz into un-rotated coordinates.
+        // Convert oldXyz into un-rotated coordinates.
         double oldAngle = -m_rotation * k_centidegreesToRadians;
-        rotateCoordinates( oldHmdXyz, oldAngle );
+        rotateCoordinates( oldXyz, oldAngle );
 
-        // Set newHmdXyz to have additional rotation from incoming angle change.
-        rotateCoordinates( newHmdXyz, oldAngle - angle );
+        // Set newXyz to have additional rotation from incoming angle change.
+        rotateCoordinates( newXyz, oldAngle - angle );
 
         // find difference in x,z offset due to incoming angle change
         // (coordinates are in un-rotated axis).
         double hmdRotDiff[3]
-            = { oldHmdXyz[0] - newHmdXyz[0], 0, oldHmdXyz[2] - newHmdXyz[2] };
+            = { oldXyz[0] - newXyz[0], 0, oldXyz[2] - newXyz[2] };
 
         m_rotation = value;
         if ( notify )
@@ -999,12 +1006,10 @@ void MoveCenterTabController::reset()
     m_offsetY = 0.0f;
     m_offsetZ = 0.0f;
     m_rotation = 0;
-    m_lastControllerPosition[0] = 0.0f;
-    m_lastControllerPosition[1] = 0.0f;
-    m_lastControllerPosition[2] = 0.0f;
     m_lastMoveHand = vr::TrackedControllerRole_Invalid;
     m_lastRotateHand = vr::TrackedControllerRole_Invalid;
     applyChaperoneResetData();
+    m_lastControllerPosition = {0.0f, 0.0f, 0.0f};
 
     // For Center Marker
     // Needs to happen after apply chaperone
@@ -2211,6 +2216,80 @@ void MoveCenterTabController::updateHmdRotationCounter(
     m_lastHmdQuaternion = m_hmdQuaternion;
 }
 
+// Displace the entire universe by some difference. Both 'from' and 'to' are in relative coordinates, which get converted to absolute.
+void MoveCenterTabController::displaceUniverseRelative(const vr::HmdVector3_t& from, const vr::HmdVector3_t& to, double angle)
+{
+    double relativeControllerPosition[] = {
+        static_cast<double>( to.v[0] ),
+        static_cast<double>( to.v[1] ),
+        static_cast<double>( to.v[2] )
+    };
+    rotateCoordinates( relativeControllerPosition, -angle );
+    float absoluteControllerPosition[] = {
+        static_cast<float>( relativeControllerPosition[0] ) + m_offsetX,
+        static_cast<float>( relativeControllerPosition[1] ) + m_offsetY,
+        static_cast<float>( relativeControllerPosition[2] ) + m_offsetZ,
+    };
+    double relativeFromPosition[] = {
+        static_cast<double>( from.v[0] ),
+        static_cast<double>( from.v[1] ),
+        static_cast<double>( from.v[2] )
+    };
+    rotateCoordinates( relativeFromPosition, -angle );
+    float absoluteFromPosition[] = {
+        static_cast<float>( relativeFromPosition[0] ) + m_offsetX,
+        static_cast<float>( relativeFromPosition[1] ) + m_offsetY,
+        static_cast<float>( relativeFromPosition[2] ) + m_offsetZ,
+    };
+
+    double diff[3] = {
+        static_cast<double>( absoluteControllerPosition[0]
+                - absoluteFromPosition[0] ),
+        static_cast<double>( absoluteControllerPosition[1]
+                - absoluteFromPosition[1] ),
+        static_cast<double>( absoluteControllerPosition[2]
+                - absoluteFromPosition[2] ),
+    };
+
+    // offset is un-rotated coordinates
+
+    // prevent positional glitches from exceeding max openvr offset clamps.
+    // We do this by detecting a drag larger than 100m in a single frame.
+    if ( abs( diff[0] ) > 100.0 || abs( diff[1] ) > 100.0
+            || abs( diff[2] ) > 100.0 )
+    {
+        reset();
+    }
+
+    // prevents updating if axis movement is locked
+    if ( !lockXToggle() )
+    {
+        m_offsetX += static_cast<float>( diff[0] );
+    }
+    if ( !lockYToggle() )
+    {
+        m_offsetY += static_cast<float>( diff[1] );
+    }
+    if ( !lockZToggle() )
+    {
+        m_offsetZ += static_cast<float>( diff[2] );
+    }
+
+    double secondsSinceLastDragUpdate
+        = std::chrono::duration<double>( std::chrono::steady_clock::now()
+                - m_lastDragUpdateTimePoint )
+        .count();
+
+    // TODO: Add 'effects fling' boolean? or simply return diff[] as a HmdVect3_t
+    m_velocity[0] = ( diff[0] / secondsSinceLastDragUpdate )
+        * static_cast<double>( flingStrength() );
+    m_velocity[1] = ( diff[1] / secondsSinceLastDragUpdate )
+        * static_cast<double>( flingStrength() );
+    m_velocity[2] = ( diff[2] / secondsSinceLastDragUpdate )
+        * static_cast<double>( flingStrength() );
+
+}
+
 void MoveCenterTabController::updateHandDrag(
     vr::TrackedDevicePose_t* devicePoses,
     double angle )
@@ -2261,69 +2340,18 @@ void MoveCenterTabController::updateHandDrag(
         return;
     }
 
-    double relativeControllerPosition[] = {
-        static_cast<double>( movePose->mDeviceToAbsoluteTracking.m[0][3] ),
-        static_cast<double>( movePose->mDeviceToAbsoluteTracking.m[1][3] ),
-        static_cast<double>( movePose->mDeviceToAbsoluteTracking.m[2][3] )
-    };
-
-    rotateCoordinates( relativeControllerPosition, -angle );
-    float absoluteControllerPosition[] = {
-        static_cast<float>( relativeControllerPosition[0] ) + m_offsetX,
-        static_cast<float>( relativeControllerPosition[1] ) + m_offsetY,
-        static_cast<float>( relativeControllerPosition[2] ) + m_offsetZ,
+    vr::HmdVector3_t relativeControllerPosition = {
+        movePose->mDeviceToAbsoluteTracking.m[0][3],
+        movePose->mDeviceToAbsoluteTracking.m[1][3],
+        movePose->mDeviceToAbsoluteTracking.m[2][3]
     };
 
     if ( m_lastMoveHand == m_activeDragHand )
     {
-        double diff[3] = {
-            static_cast<double>( absoluteControllerPosition[0]
-                                 - m_lastControllerPosition[0] ),
-            static_cast<double>( absoluteControllerPosition[1]
-                                 - m_lastControllerPosition[1] ),
-            static_cast<double>( absoluteControllerPosition[2]
-                                 - m_lastControllerPosition[2] ),
-        };
-
-        // offset is un-rotated coordinates
-
-        // prevent positional glitches from exceeding max openvr offset clamps.
-        // We do this by detecting a drag larger than 100m in a single frame.
-        if ( abs( diff[0] ) > 100.0 || abs( diff[1] ) > 100.0
-             || abs( diff[2] ) > 100.0 )
-        {
-            reset();
-        }
-
-        // prevents updating if axis movement is locked
-        if ( !lockXToggle() )
-        {
-            m_offsetX += static_cast<float>( diff[0] );
-        }
-        if ( !lockYToggle() )
-        {
-            m_offsetY += static_cast<float>( diff[1] );
-        }
-        if ( !lockZToggle() )
-        {
-            m_offsetZ += static_cast<float>( diff[2] );
-        }
-
-        double secondsSinceLastDragUpdate
-            = std::chrono::duration<double>( std::chrono::steady_clock::now()
-                                             - m_lastDragUpdateTimePoint )
-                  .count();
-
-        m_velocity[0] = ( diff[0] / secondsSinceLastDragUpdate )
-                        * static_cast<double>( flingStrength() );
-        m_velocity[1] = ( diff[1] / secondsSinceLastDragUpdate )
-                        * static_cast<double>( flingStrength() );
-        m_velocity[2] = ( diff[2] / secondsSinceLastDragUpdate )
-                        * static_cast<double>( flingStrength() );
+        // Displace from last controller position to current
+        displaceUniverseRelative(m_lastControllerPosition, relativeControllerPosition, angle);
     }
-    m_lastControllerPosition[0] = absoluteControllerPosition[0];
-    m_lastControllerPosition[1] = absoluteControllerPosition[1];
-    m_lastControllerPosition[2] = absoluteControllerPosition[2];
+    m_lastControllerPosition = relativeControllerPosition;
     m_lastMoveHand = m_activeDragHand;
 }
 

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -158,7 +158,7 @@ private:
     bool m_moveShortcutRightPressed = false;
     bool m_moveShortcutLeftPressed = false;
     vr::TrackedDeviceIndex_t m_activeMoveController;
-    float m_lastControllerPosition[3];
+    vr::HmdVector3_t m_lastControllerPosition;
     bool m_heightToggle = false;
     float m_gravityFloor = 0.0f;
     // Set lastHandQuaternion.w to -1000.0 when last hand is invalid.
@@ -283,6 +283,8 @@ public:
     void incomingSeatedReset();
     void setBoundsBasisHeight( float newHeight );
     float getBoundsBasisMaxY();
+    void setRotationAroundPivot( int value, bool notify, const vr::HmdMatrix34_t& pivot);
+    void displaceUniverseRelative( const vr::HmdVector3_t& from, const vr::HmdVector3_t& to, double angle);
 
     void updateChaperoneResetData();
 

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -227,7 +227,7 @@ private:
 
     void updateHmdRotationCounter( vr::TrackedDevicePose_t hmdPose,
                                    double angle );
-    void updateHandDrag( vr::TrackedDevicePose_t* devicePoses, double angle );
+    void updateHandDrag( vr::TrackedDevicePose_t* devicePoses );
     void updateHandTurn( vr::TrackedDevicePose_t* devicePoses, double angle );
     void updateGravity();
     void updateSpace( bool forceUpdate = false );
@@ -283,8 +283,11 @@ public:
     void incomingSeatedReset();
     void setBoundsBasisHeight( float newHeight );
     float getBoundsBasisMaxY();
-    void setRotationAroundPivot( int value, bool notify, const vr::HmdMatrix34_t& pivot);
-    void displaceUniverseRelative( const vr::HmdVector3_t& from, const vr::HmdVector3_t& to, double angle);
+    void setRotationAroundPivot( int value, bool notify, const vr::HmdVector3_t& pivot );
+    void displaceUniverse( const vr::HmdVector3_t& from, const vr::HmdVector3_t& to );
+
+	vr::HmdVector3_t relativeToAbsolute(const vr::HmdVector3_t& coordinates_in) const;
+	vr::HmdVector3_t absoluteToRelative(const vr::HmdVector3_t& absolute) const;
 
     void updateChaperoneResetData();
 

--- a/src/tabcontrollers/RotationTabController.cpp
+++ b/src/tabcontrollers/RotationTabController.cpp
@@ -584,45 +584,31 @@ void RotationTabController::doAutoTurn(
 
 void RotationTabController::addAutoAlignPoint()
 {
+	// TODO: State machine: if we have >2 align points, freeze vestibular motion/ratchetting/etc
+	// remain frozen until after we move away from the aligned area
+
     LOG(INFO) << "point added: " << autoAlignPoints.size();
     // get the location of right hand, push_back onto autoAlignPoints
-    autoAlignPoints.push_back(lastHandPose);
+	// TODO:
+	vr::HmdVector3_t new_point = {
+		lastHandPose.mDeviceToAbsoluteTracking.m[0][3],
+		lastHandPose.mDeviceToAbsoluteTracking.m[1][3],
+		lastHandPose.mDeviceToAbsoluteTracking.m[2][3]
+	};
+	// TODO: Probably smarter to actually just keep the virtual points as virtual until we use them.
+	// Then if they drift we don't care.
+	vr::HmdVector3_t absolute_point = parent->m_moveCenterTabController.relativeToAbsolute(new_point);
+    autoAlignPoints.push_back(absolute_point);
 
     // if we have exactly 4 points, go into main loop
     if(autoAlignPoints.size() == 4)
     {
-        vr::HmdVector3_t realFirstPoint = {
-            autoAlignPoints[0].mDeviceToAbsoluteTracking.m[0][3],
-            autoAlignPoints[0].mDeviceToAbsoluteTracking.m[1][3],
-            autoAlignPoints[0].mDeviceToAbsoluteTracking.m[2][3]
-        };
+        vr::HmdVector3_t realFirstPoint = autoAlignPoints[0];
+		vr::HmdVector3_t realSecondPoint = autoAlignPoints[1];
+        vr::HmdVector3_t virtualFirstPoint = autoAlignPoints[2];
+        vr::HmdVector3_t virtualSecondPoint = autoAlignPoints[3];
 
-        vr::HmdVector3_t realSecondPoint = {
-            autoAlignPoints[1].mDeviceToAbsoluteTracking.m[0][3],
-            autoAlignPoints[1].mDeviceToAbsoluteTracking.m[1][3],
-            autoAlignPoints[1].mDeviceToAbsoluteTracking.m[2][3]
-        };
-
-        vr::HmdVector3_t virtualFirstPoint = {
-            autoAlignPoints[2].mDeviceToAbsoluteTracking.m[0][3],
-            autoAlignPoints[2].mDeviceToAbsoluteTracking.m[1][3],
-            autoAlignPoints[2].mDeviceToAbsoluteTracking.m[2][3]
-        };
-
-        vr::HmdVector3_t virtualSecondPoint = {
-            autoAlignPoints[3].mDeviceToAbsoluteTracking.m[0][3],
-            autoAlignPoints[3].mDeviceToAbsoluteTracking.m[1][3],
-            autoAlignPoints[3].mDeviceToAbsoluteTracking.m[2][3]
-        };
-        
-
-        // Align the first of VR points (points[2]) with the first of the real points (points[0]) purely in position
-        parent->m_moveCenterTabController.displaceUniverseRelative(virtualFirstPoint, realFirstPoint, parent->m_moveCenterTabController.rotation());
-
-
-        // TODO: if centered, use the center of both points as the pivot
-        
-        // Then rotate the universe to align, pivoting around the real point 
+		// Rotate the universe to align, pivoting around the real point 
         double realEdgeAngle = static_cast<double>( std::atan2(
                     realFirstPoint.v[0] - realSecondPoint.v[0],
                     realFirstPoint.v[2] - realSecondPoint.v[2] ) );
@@ -634,15 +620,19 @@ void RotationTabController::addAutoAlignPoint()
                 parent->m_moveCenterTabController.rotation()
                 + delta_degrees );
 
-        // these need to be in the new, offset position. TODO: Doesn't currently work when already offset for some reason
-        vr::HmdMatrix34_t autoAlignPivot = autoAlignPoints[0].mDeviceToAbsoluteTracking;
-        autoAlignPivot.m[0][3] -= realFirstPoint.v[0] - virtualFirstPoint.v[0];
-        autoAlignPivot.m[1][3] -= realFirstPoint.v[1] - virtualFirstPoint.v[1];
-        autoAlignPivot.m[2][3] -= realFirstPoint.v[2] - virtualFirstPoint.v[2];
+        // these need to be in the new, offset position. TODO: needs to be converted into new relative position?
+        vr::HmdVector3_t autoAlignPivot = realFirstPoint;
+        autoAlignPivot.v[0] -= realFirstPoint.v[0] - virtualFirstPoint.v[0];
+        autoAlignPivot.v[1] -= realFirstPoint.v[1] - virtualFirstPoint.v[1];
+        autoAlignPivot.v[2] -= realFirstPoint.v[2] - virtualFirstPoint.v[2];
 
+        // TODO: if centered, use the center of both points as the pivot
         parent->m_moveCenterTabController.setRotationAroundPivot(
-                newRotationAngleDeg, true, autoAlignPivot);
+                newRotationAngleDeg, true, parent->m_moveCenterTabController.absoluteToRelative(virtualFirstPoint));
 
+
+        // Align the first of VR points (points[2]) with the first of the real points (points[0]) purely in position
+        parent->m_moveCenterTabController.displaceUniverse(virtualFirstPoint, realFirstPoint);
 
         // end of main loop, clear autoAlignPoints
         autoAlignPoints.clear();

--- a/src/tabcontrollers/RotationTabController.cpp
+++ b/src/tabcontrollers/RotationTabController.cpp
@@ -74,7 +74,6 @@ void RotationTabController::initStage2( OverlayController* var_parent )
     this->parent = var_parent;
 }
 
-static vr::TrackedDevicePose_t lastHandPose;
 void RotationTabController::eventLoopTick(
     vr::TrackedDevicePose_t* devicePoses )
 {
@@ -583,7 +582,6 @@ void RotationTabController::doAutoTurn(
     }
 }
 
-static std::vector<vr::TrackedDevicePose_t> autoAlignPoints;
 void RotationTabController::addAutoAlignPoint()
 {
     LOG(INFO) << "point added: " << autoAlignPoints.size();

--- a/src/tabcontrollers/RotationTabController.h
+++ b/src/tabcontrollers/RotationTabController.h
@@ -156,6 +156,7 @@ public:
     bool viewRatchettingEnabled() const;
     double viewRatchettingPercent() const;
 
+
 public slots:
     void setAutoTurnEnabled( bool value, bool notify = true );
     void setAutoTurnShowNotification( bool value, bool notify = true );
@@ -170,6 +171,9 @@ public slots:
     void setVestibularMotionRadius( double value, bool notify = true );
     void setViewRatchettingEnabled( bool value, bool notify = true );
     void setViewRatchettingPercent( double value, bool notify = true );
+    
+    // Experimental - auto-align
+    void addAutoAlignPoint();
 
 signals:
 

--- a/src/tabcontrollers/RotationTabController.h
+++ b/src/tabcontrollers/RotationTabController.h
@@ -121,7 +121,7 @@ private:
     std::optional<std::chrono::steady_clock::time_point>
         m_autoTurnNotificationTimestamp;
 
-    std::vector<vr::TrackedDevicePose_t> autoAlignPoints;
+    std::vector<vr::HmdVector3_t> autoAlignPoints;
     vr::TrackedDevicePose_t lastHandPose;
 
     bool m_isHMDActive = false;

--- a/src/tabcontrollers/RotationTabController.h
+++ b/src/tabcontrollers/RotationTabController.h
@@ -121,6 +121,9 @@ private:
     std::optional<std::chrono::steady_clock::time_point>
         m_autoTurnNotificationTimestamp;
 
+    std::vector<vr::TrackedDevicePose_t> autoAlignPoints;
+    vr::TrackedDevicePose_t lastHandPose;
+
     bool m_isHMDActive = false;
 
     void doAutoTurn(


### PR DESCRIPTION
Mostly opening this up now as a place to keep track of what's left to do.

Currently working:
- Somewhat abstracted MoveCenterTabController code to let you convert arbitrary points to/from absolute/relative coordinates, allow pivot around an arbitrary point, move universe 'from' 'to' two absolute points (from other classes)
- Auto-align (right-handed only): Adds an 'auto-align' bind. Press it on two points along the edge of a real object, followed by two points along the edge of a virtual object, and it'll snap them together (in X/Y/Z and yaw). Easily set up real analogs to your virtual environment (align a real->virtual chair to sit on it, align real->virtual table to rest your hands on it, align real->virtual wall to lean against it). Especially useful for full-body, since your avatar will appear to be physically interacting with the world.

TBD:
- Allow for left-handed bind
- Proximity activation: After auto-aligning something, it would be nice if it was an option to align it in every axis but Z (so the floor still matches as you walk over) until you get close, then snap the height into place, resetting the floor after you stand up and walk away from the area. This would also be good to freeze auto-turn/vestibular motion/(anything which rotates/moves the playspace) until you walk away, so the virtual object doesn't drift away from the real one.
- Some form of UI, probably an ephemeral popup like auto-turn's: currently there's no indicator of how many points you've put up, so you could accidentally activate it without knowing how many you've added so far.
- Some kind of timeout, so if you accidentally activate it you don't have to force it to activate later
- An option to just save the first two coordinates (possibly between resets), for if you only have one thing you want to align with (e.g. a chair) without peeking under your headset so much.
- Significant code cleanup. It's pretty ugly right now.