### PR TITLE
Adjust tracker battery overlay position for Vive Tracker 3.0

### DIFF
--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -238,11 +238,11 @@ vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index )
         {
             vr::VROverlay()->SetOverlayFromFile(
                 handle, batteryIconPath.toStdString().c_str() );
-            vr::VROverlay()->SetOverlayWidthInMeters( handle, 0.05f );
+            vr::VROverlay()->SetOverlayWidthInMeters( handle, 0.045f );
             vr::HmdMatrix34_t notificationTransform
                 = { { { 1.0f, 0.0f, 0.0f, 0.00f },
-                      { 0.0f, -1.0f, 0.0f, 0.01f },
-                      { 0.0f, 0.0f, -1.0f, -0.013f } } };
+                      { 0.0f, -1.0f, 0.0f, 0.0081f },
+                      { 0.0f, 0.0f, -1.0f, -0.0178f } } };
             vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(
                 handle, index, &notificationTransform );
             LOG( INFO ) << "Created battery overlay for device " << index;


### PR DESCRIPTION
This is a slight adjustment to the tracker battery overlay position to prevent clipping with the new Vive Tracker 3.0 higher face and closer prongs. These changes shouldn't degrade functionality on other trackers.

Old position:
![tracker3-before](https://user-images.githubusercontent.com/38249782/111909223-c71e0a80-8a9f-11eb-904b-3b6d978b0e97.png)

![tracker3-vr-before](https://user-images.githubusercontent.com/38249782/111909275-03ea0180-8aa0-11eb-86bf-ba18aa4730b0.png)

New position:
![tracker3-after](https://user-images.githubusercontent.com/38249782/111909281-0c423c80-8aa0-11eb-8236-4c636a350594.png)

![tracker3-vr-after](https://user-images.githubusercontent.com/38249782/111909293-1106f080-8aa0-11eb-8a38-030c7f979549.png)


