### PR TITLE
Add apply offsets steamvr input

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -187,6 +187,7 @@ Override actions will take priority over non-override actions during simultaneou
 | Gravity Toggle | Binary/Button |  Toggles Gravity state when pressed. |
 | Gravity Reverse | Binary/Button |  Temporarily Reverses Gravity while held. |
 | Reset Offsets | Binary/Button |  Resets your offset and rotation to 0. |
+| Apply Offsets | Binary/Button | Recalibrates center/rotation from offsets |
 | Height Toggle | Binary/Button |  Shifts the gravity floor level by offset configured in motion tab. If gravity is inactive: also shifts the user's current y-axis position by offset configured in motion tab. |
 | Snap-Turn Left | Binary/Button |  Rotates a set value to the left based on settings in motion tab. |
 | Snap-Turn Right | Binary/Button |  Rotates a set value to the right based on settings in motion tab. |

--- a/src/openvr/ivrinput.cpp
+++ b/src/openvr/ivrinput.cpp
@@ -127,6 +127,7 @@ SteamIVRInput::SteamIVRInput()
       m_gravityReverse( action_keys::gravityReverse ),
       m_heightToggle( action_keys::heightToggle ),
       m_resetOffsets( action_keys::resetOffsets ),
+      m_applyOffsets( action_keys::applyOffsets ),
       m_snapTurnLeft( action_keys::snapTurnLeft ),
       m_snapTurnRight( action_keys::snapTurnRight ),
       m_smoothTurnLeft( action_keys::smoothTurnLeft ),
@@ -275,6 +276,11 @@ bool SteamIVRInput::heightToggle()
 bool SteamIVRInput::resetOffsets()
 {
     return isDigitalActionActivatedOnce( m_resetOffsets );
+}
+
+bool SteamIVRInput::applyOffsets()
+{
+    return isDigitalActionActivatedOnce( m_applyOffsets );
 }
 
 bool SteamIVRInput::snapTurnLeft()

--- a/src/openvr/ivrinput.h
+++ b/src/openvr/ivrinput.h
@@ -41,6 +41,7 @@ namespace action_keys
     constexpr auto gravityToggle = "/actions/motion/in/GravityToggle";
     constexpr auto gravityReverse = "/actions/motion/in/GravityReverse";
     constexpr auto resetOffsets = "/actions/motion/in/ResetOffsets";
+    constexpr auto applyOffsets = "/actions/motion/in/ApplyOffsets";
     constexpr auto heightToggle = "/actions/motion/in/HeightToggle";
     constexpr auto snapTurnLeft = "/actions/motion/in/SnapTurnLeft";
     constexpr auto snapTurnRight = "/actions/motion/in/SnapTurnRight";
@@ -146,6 +147,7 @@ public:
     bool gravityReverse();
     bool heightToggle();
     bool resetOffsets();
+    bool applyOffsets();
     bool snapTurnLeft();
     bool snapTurnRight();
     bool smoothTurnLeft();
@@ -228,6 +230,7 @@ private:
     DigitalAction m_gravityReverse;
     DigitalAction m_heightToggle;
     DigitalAction m_resetOffsets;
+    DigitalAction m_applyOffsets;
     DigitalAction m_snapTurnLeft;
     DigitalAction m_snapTurnRight;
     DigitalAction m_smoothTurnLeft;

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -602,6 +602,7 @@ void OverlayController::processMotionBindings()
         m_actions.gravityReverse() );
     m_moveCenterTabController.heightToggleAction( m_actions.heightToggle() );
     m_moveCenterTabController.resetOffsets( m_actions.resetOffsets() );
+    m_moveCenterTabController.applyOffsets( m_actions.applyOffsets() );
     m_moveCenterTabController.snapTurnLeft( m_actions.snapTurnLeft() );
     m_moveCenterTabController.snapTurnRight( m_actions.snapTurnRight() );
     m_moveCenterTabController.smoothTurnLeft( m_actions.smoothTurnLeft() );

--- a/src/package_files/action_manifest.json
+++ b/src/package_files/action_manifest.json
@@ -131,7 +131,12 @@
       "requirement": "optional",
       "type": "boolean"
     },
-    
+    {
+      "name": "/actions/motion/in/ApplyOffsets",
+      "requirement": "optional",
+      "type": "boolean"
+    },
+
     {
 
       "name": "/actions/motion/in/HeightToggle",
@@ -282,6 +287,7 @@
         "/actions/motion/in/GravityToggle" : "Gravity Toggle",
         "/actions/motion/in/GravityReverse" : "Gravity Reverse",
         "/actions/motion/in/ResetOffsets" : "Reset Offsets",
+        "/actions/motion/in/ApplyOffsets" : "Apply Offsets",
         "/actions/motion/in/HeightToggle" : "Height Toggle",
         "/actions/motion/in/SnapTurnLeft" : "Snap-Turn Left",
         "/actions/motion/in/SnapTurnRight" : "Snap-Turn Right",

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1962,6 +1962,14 @@ void MoveCenterTabController::resetOffsets( bool resetOffsetsJustPressed )
     }
 }
 
+void MoveCenterTabController::applyOffsets( bool applyOffsetsJustPressed )
+{
+    if ( applyOffsetsJustPressed )
+    {
+        zeroOffsets();
+    }
+}
+
 void MoveCenterTabController::snapTurnLeft( bool snapTurnLeftJustPressed )
 {
     if ( !snapTurnLeftJustPressed )

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -306,6 +306,7 @@ public:
     void gravityReverseAction( bool gravityReverseHeld );
     void heightToggleAction( bool heightToggleJustPressed );
     void resetOffsets( bool resetOffsetsJustPressed );
+    void applyOffsets( bool applyOffsetsJustPressed );
     void snapTurnLeft( bool snapTurnLeftJustPressed );
     void snapTurnRight( bool snapTurnRightJustPressed );
     void smoothTurnLeft( bool smoothTurnLeftActive );


### PR DESCRIPTION
Adds a binding in SteamVR for doing the "Apply Space Settings Offsets as Center" action. 