### PR TITLE
Add `qt5-quickcontrols` package to required for Arch

### DIFF
--- a/docs/building_for_linux.md
+++ b/docs/building_for_linux.md
@@ -128,7 +128,7 @@ If you choose the wrong Ubuntu version you will get an error from `apt` about th
 
 ### Arch/Manjaro
 
-The `qt5-declarative` and `qt5-multimedia` packages are required.
+The `qt5-declarative`, `qt5-quickcontrols` and `qt5-multimedia` packages are required.
 
 ## `qtchooser` and versions
 


### PR DESCRIPTION
Fixes partially https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings/issues/580. AUR package still needs to be updated.