### PR TITLE
Workaround RawAndUnclibrated tracking space reported by OpenXR apps.

### DIFF
--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1240,6 +1240,11 @@ void OverlayController::mainEventLoop()
             = std::sqrt( vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2] );
     }
     auto universe = vr::VRCompositor()->GetTrackingSpace();
+    if (universe == vr::TrackingUniverseRawAndUncalibrated && vr::VRApplications()->GetApplicationProcessId("openvr.tool.steamvr_room_setup") == 0) {
+        // OpenXR applications will appear as RawAndUncalibrated.
+        // Unless Room Setup is running, treat this case as Standing.
+        universe = vr::TrackingUniverseStanding;
+    }
 
     m_moveCenterTabController.eventLoopTick( universe, devicePoses );
     m_utilitiesTabController.eventLoopTick();


### PR DESCRIPTION
Fixes #556

This seems to allow space dragging while running an OpenXR application.

With regards to my choice to detect Room Setup as "openvr.tool.steamvr_room_setup" using VRApplications, I received this advice from someone at Valve.

 > if room setup detection is the only issue, VRApplications() or whatever it's called will tell you the current app, and room setup has a known/fixed string name

I tested Room Setup with my patch and space dragging is forbidden while it is running. See here:
![Room Setup with OVRAS](https://user-images.githubusercontent.com/39946030/153691108-041758e2-d0cb-4c33-80a5-e9083fbac244.png)

Here is an example of an OpenXR application, showing that the tracking universe now reports Standing in OVRAS (this is a lie, but it works):
![OpenXR example app](https://user-images.githubusercontent.com/39946030/153691131-eb594bef-86b8-4707-88c9-34955fe735a8.png)
