### PR TITLE
Add Publisher and Version to ARP entry

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -141,6 +141,8 @@ Section "Install" SecInstall
 	;Create uninstaller
 	WriteUninstaller "$INSTDIR\Uninstall.exe"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenVRAdvancedSettings" "DisplayName" "OpenVR Advanced Settings"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenVRAdvancedSettings" "DisplayVersion" "${VERSION_STRING}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenVRAdvancedSettings" "Publisher" "OVRAS Team"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenVRAdvancedSettings" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
 
 	; If SteamVR is already running, execute the dashboard as the user


### PR DESCRIPTION
The [Microsoft Windows Package Manager](/microsoft/winget-cli) relies on registry entries to determine the version of an installed package. This PR causes the Publisher and Version to be set in the ARP table when using the installer file