### PR TITLE
Exclude libxkbcommon.so.0, causes segfaults

### DIFF
--- a/build_scripts/linux/appimage.sh
+++ b/build_scripts/linux/appimage.sh
@@ -43,7 +43,7 @@ qmake --version
 
 $PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage -version --appimage-extract-and-run
 
-APPIMAGE_COMMAND="$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0,libxkbcommon-x11.so.0"
+APPIMAGE_COMMAND="$PROJECT_DIR/linuxdeployqt-continuous-x86_64.AppImage $EXE_DIR/usr/share/applications/AdvancedSettings.desktop --appimage-extract-and-run -appimage -verbose=2 -always-overwrite -qmldir=$PROJECT_DIR/src/res/qml -exclude-libs=libxcb-randr.so.0,libxkbcommon-x11.so.0,libxkbcommon.so.0"
 
 $APPIMAGE_COMMAND
 


### PR DESCRIPTION
On more recent distributions (Debian Testing, Arch, Manjaro), libxkbcommon.so.0 causes segfaults at launch.