### PR TITLE
fix PKGBUILD to include missing dependency (#606)

### DIFF
--- a/build_scripts/linux/PKGBUILD
+++ b/build_scripts/linux/PKGBUILD
@@ -9,6 +9,7 @@ url="https://github.com/OpenVR-Advanced-Settings/OpenVR-AdvancedSettings"
 license=("GPL")
 depends=("qt5-declarative"
          "qt5-multimedia"
+         "qt5-websockets"
          "libudev0-shim"
          "mesa")
 optdepends=("dbus: media player support"


### PR DESCRIPTION
It turns out qt5-websockets needs to be included for a successful build.