### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ installer/*.exe
 build_scripts/win/__pycache__
 build_scripts/win/current_build.bat
 AdvancedSettings_resource.rc
+.qtc_clangd/

--- a/src/openvr/openvr_init.cpp
+++ b/src/openvr/openvr_init.cpp
@@ -26,15 +26,25 @@ void initializeProperly( const OpenVrInitializationType initType )
         if ( initError == vr::VRInitError_Init_HmdNotFound
              || initError == vr::VRInitError_Init_HmdNotFoundPresenceFailed )
         {
-            QMessageBox::critical( nullptr,
-                                   "OpenVR Advanced Settings Overlay",
-                                   "Could not find HMD!" );
+            // In particular in some setups these errors are thrown while
+            // nothing is wrong with their setup presumably this is some sort of
+            // race condition
+            LOG( WARNING ) << "HMD not Found During Startup";
+            LOG( WARNING ) << "steamvr error: "
+                                  + std::string(
+                                      vr::VR_GetVRInitErrorAsEnglishDescription(
+                                          initError ) );
+            return;
         }
         LOG( ERROR ) << "Failed to initialize OpenVR: "
                             + std::string(
                                 vr::VR_GetVRInitErrorAsEnglishDescription(
                                     initError ) );
-        exit( EXIT_FAILURE );
+        // Going to stop Exiting App, This may lead to crashes if OpenVR
+        // actually fails to start, HOWEVER based on the HMD errors we are
+        // probably pre-maturely killing ourselves from some sort of OpenVR race
+        // condition
+        // exit( EXIT_FAILURE );
     }
     else
     {

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -69,6 +69,7 @@ OverlayController::OverlayController( bool desktopMode,
     m_runtimePathUrl = QUrl::fromLocalFile( tempRuntimePath );
     LOG( INFO ) << "VR Runtime Path: " << m_runtimePathUrl.toLocalFile();
 
+    const double initVol = soundVolume();
     constexpr auto clickSoundURL = "res/sounds/click.wav";
     const auto activationSoundFile
         = paths::binaryDirectoryFindFile( clickSoundURL );
@@ -77,7 +78,7 @@ OverlayController::OverlayController( bool desktopMode,
     {
         m_activationSoundEffect.setSource( QUrl::fromLocalFile(
             QString::fromStdString( ( *activationSoundFile ) ) ) );
-        m_activationSoundEffect.setVolume( 0.7 );
+        m_activationSoundEffect.setVolume( initVol );
     }
     else
     {
@@ -92,7 +93,7 @@ OverlayController::OverlayController( bool desktopMode,
     {
         m_focusChangedSoundEffect.setSource( QUrl::fromLocalFile(
             QString::fromStdString( ( *focusChangedSoundFile ) ) ) );
-        m_focusChangedSoundEffect.setVolume( 0.7 );
+        m_focusChangedSoundEffect.setVolume( initVol );
     }
     else
     {
@@ -1646,6 +1647,26 @@ void OverlayController::setKeyboardPos()
     empty.vTopLeft = emptyvec;
     empty.vBottomRight = emptyvec;
     vr::VROverlay()->SetKeyboardPositionForOverlay( m_ulOverlayHandle, empty );
+}
+
+void OverlayController::setSoundVolume( double value, bool notify )
+{
+    m_activationSoundEffect.setVolume( value );
+    m_focusChangedSoundEffect.setVolume( value );
+    // leaving alarm sound alone for now as chaperone warning setting effects it
+    // m_alarm01SoundEffect.setVolume( value);
+    settings::setSetting( settings::DoubleSetting::APPLICATION_appVolume,
+                          value );
+    if ( notify )
+    {
+        emit soundVolumeChanged( value );
+    }
+}
+
+double OverlayController::soundVolume() const
+{
+    return settings::getSetting(
+        settings::DoubleSetting::APPLICATION_appVolume );
 }
 
 void OverlayController::playActivationSound()

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -295,7 +295,7 @@ signals:
     void customTickRateMsChanged( int value );
     void debugStateChanged( int value );
     void autoApplyChaperoneEnabledChanged( bool value );
-    void soundVolumeChanged( float value );
+    void soundVolumeChanged( double value );
 };
 
 } // namespace advsettings

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -96,6 +96,8 @@ class OverlayController : public QObject
     Q_PROPERTY( bool autoApplyChaperoneEnabled READ autoApplyChaperoneEnabled
                     WRITE setAutoApplyChaperoneEnabled NOTIFY
                         autoApplyChaperoneEnabledChanged )
+    Q_PROPERTY( double soundVolume READ soundVolume WRITE setSoundVolume NOTIFY
+                    soundVolumeChanged )
 
 private:
     vr::VROverlayHandle_t m_ulOverlayHandle = vr::k_ulOverlayHandleInvalid;
@@ -252,6 +254,8 @@ public:
     int debugState() const;
     std::string autoApplyChaperoneName();
 
+    double soundVolume() const;
+
 public slots:
     void renderOverlay();
     void OnRenderRequest();
@@ -277,6 +281,7 @@ public slots:
     void setCustomTickRateMs( int value, bool notify = true );
     void setDebugState( int value, bool notify = true );
     void setAutoApplyChaperoneEnabled( bool value, bool notify = true );
+    void setSoundVolume( double value, bool notify = true );
 
 signals:
     void keyBoardInputSignal( QString input, unsigned long userValue = 0 );
@@ -290,6 +295,7 @@ signals:
     void customTickRateMsChanged( int value );
     void debugStateChanged( int value );
     void autoApplyChaperoneEnabledChanged( bool value );
+    void soundVolumeChanged( float value );
 };
 
 } // namespace advsettings

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -246,6 +246,72 @@ MyStackViewPage {
                         }
                     }
             }
+            RowLayout{
+                MyText {
+                    text: "AppVolume:"
+                    Layout.rightMargin: 12
+                }
+
+                MyPushButton2 {
+                    text: "-"
+                    Layout.preferredWidth: 40
+                    onClicked: {
+                        volumeSlider.value -= 0.05
+                    }
+                }
+
+                MySlider {
+                    id: volumeSlider
+                    from: 0.0
+                    to: 1.0
+                    stepSize: 0.01
+                    value: 0.7
+                    Layout.fillWidth: true
+                    onPositionChanged: {
+                        var val = (this.value * 100)
+                        volumeText.text = Math.round(val) + "%"
+                    }
+                    onValueChanged: {
+                        OverlayController.setSoundVolume(value, false)
+                    }
+                }
+
+                MyPushButton2 {
+                    text: "+"
+                    Layout.preferredWidth: 40
+                    onClicked: {
+                        volumeSlider.value += 0.05
+                    }
+                }
+
+
+                MyTextField {
+                    id: volumeText
+                    text: "70%"
+                    keyBoardUID: 503
+                    Layout.preferredWidth: 100
+                    Layout.leftMargin: 10
+                    horizontalAlignment: Text.AlignHCenter
+                    function onInputEvent(input) {
+                        var val = parseFloat(input)
+                        if (!isNaN(val)) {
+                            if (val < 0) {
+                                val = 0
+                            } else if (val > 100.0) {
+                                val = 100.0
+                            }
+
+                            var v = (val/100).toFixed(0)
+                            if (v <= volumeSlider.to) {
+                                chaperoneVisibilitySlider.value = v
+                            } else {
+                                ChaperoneTabController.setBoundsVisibility(v, false)
+                            }
+                        }
+                        text = Math.round(ChaperoneTabController.boundsVisibility * 100) + "%"
+                    }
+                }
+            }
 
             Item {
                 Layout.fillHeight: true
@@ -295,6 +361,7 @@ MyStackViewPage {
 
                 seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
                 reloadChaperoneProfiles()
+                volumeSlider.value = OverlayController.soundVolume
             }
 
         Connections {
@@ -356,6 +423,9 @@ MyStackViewPage {
             }
             onAutoApplyChaperoneEnabledChanged: {
                autoApplyChaperoneToggleButton.checked = OverlayController.autoApplyChaperoneEnabled
+            }
+            onSoundVolumeChanged:{
+                volumeSlider.value = OverlayController.soundVolume
             }
         }
         Connections{

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -18,6 +18,73 @@ MyStackViewPage {
             ColumnLayout {
             spacing: 18
 
+            RowLayout{
+                MyText {
+                    text: "Application Volume:"
+                    Layout.rightMargin: 12
+                }
+
+                MyPushButton2 {
+                    text: "-"
+                    Layout.preferredWidth: 40
+                    onClicked: {
+                        volumeSlider.value -= 0.05
+                    }
+                }
+
+                MySlider {
+                    id: volumeSlider
+                    from: 0.0
+                    to: 1.0
+                    stepSize: 0.01
+                    value: 0.7
+                    Layout.fillWidth: true
+                    onPositionChanged: {
+                        var val = (this.value * 100)
+                        volumeText.text = Math.round(val) + "%"
+                    }
+                    onValueChanged: {
+                        OverlayController.setSoundVolume(value, false)
+                    }
+                }
+
+                MyPushButton2 {
+                    text: "+"
+                    Layout.preferredWidth: 40
+                    onClicked: {
+                        volumeSlider.value += 0.05
+                    }
+                }
+
+
+                MyTextField {
+                    id: volumeText
+                    text: "70%"
+                    keyBoardUID: 503
+                    Layout.preferredWidth: 100
+                    Layout.leftMargin: 10
+                    horizontalAlignment: Text.AlignHCenter
+                    function onInputEvent(input) {
+                        var val = parseFloat(input)
+                        if (!isNaN(val)) {
+                            if (val < 0) {
+                                val = 0
+                            } else if (val > 100.0) {
+                                val = 100.0
+                            }
+
+                            var v = (val/100).toFixed(0)
+                            if (v <= volumeSlider.to) {
+                                chaperoneVisibilitySlider.value = v
+                            } else {
+                                ChaperoneTabController.setBoundsVisibility(v, false)
+                            }
+                        }
+                        text = Math.round(ChaperoneTabController.boundsVisibility * 100) + "%"
+                    }
+                }
+            }
+
             MyToggleButton {
                 id: settingsAutoStartToggle
                 text: "Autostart"
@@ -245,72 +312,6 @@ MyStackViewPage {
                         OverlayController.exitApp()
                         }
                     }
-            }
-            RowLayout{
-                MyText {
-                    text: "AppVolume:"
-                    Layout.rightMargin: 12
-                }
-
-                MyPushButton2 {
-                    text: "-"
-                    Layout.preferredWidth: 40
-                    onClicked: {
-                        volumeSlider.value -= 0.05
-                    }
-                }
-
-                MySlider {
-                    id: volumeSlider
-                    from: 0.0
-                    to: 1.0
-                    stepSize: 0.01
-                    value: 0.7
-                    Layout.fillWidth: true
-                    onPositionChanged: {
-                        var val = (this.value * 100)
-                        volumeText.text = Math.round(val) + "%"
-                    }
-                    onValueChanged: {
-                        OverlayController.setSoundVolume(value, false)
-                    }
-                }
-
-                MyPushButton2 {
-                    text: "+"
-                    Layout.preferredWidth: 40
-                    onClicked: {
-                        volumeSlider.value += 0.05
-                    }
-                }
-
-
-                MyTextField {
-                    id: volumeText
-                    text: "70%"
-                    keyBoardUID: 503
-                    Layout.preferredWidth: 100
-                    Layout.leftMargin: 10
-                    horizontalAlignment: Text.AlignHCenter
-                    function onInputEvent(input) {
-                        var val = parseFloat(input)
-                        if (!isNaN(val)) {
-                            if (val < 0) {
-                                val = 0
-                            } else if (val > 100.0) {
-                                val = 100.0
-                            }
-
-                            var v = (val/100).toFixed(0)
-                            if (v <= volumeSlider.to) {
-                                chaperoneVisibilitySlider.value = v
-                            } else {
-                                ChaperoneTabController.setBoundsVisibility(v, false)
-                            }
-                        }
-                        text = Math.round(ChaperoneTabController.boundsVisibility * 100) + "%"
-                    }
-                }
             }
 
             Item {

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -446,6 +446,11 @@ private:
                             QtInfo{ "dragMult" },
                             1.0 },
 
+        DoubleSettingValue{ DoubleSetting::APPLICATION_appVolume,
+                            SettingCategory::Application,
+                            QtInfo{ "appVolume" },
+                            0.7 },
+
         DoubleSettingValue{ DoubleSetting::VIDEO_brightnessOpacityValue,
                             SettingCategory::Video,
                             QtInfo{ "brightnessOpacityValue" },

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -74,6 +74,8 @@ enum class DoubleSetting
     PLAYSPACE_flingStrength,
     PLAYSPACE_dragMult,
 
+    APPLICATION_appVolume,
+
     VIDEO_brightnessOpacityValue,
     VIDEO_colorOverlayOpacity,
     VIDEO_colorRed,


### PR DESCRIPTION
Add App Volume Adjustment To settings.

Add a build file to ignore.

Change Error Behavior around SteamVR errors on initialization.

- HMD not found errors caused us to exit out immediately in some situations, and possibly in more situations we are closing out when steamvr just has a race condition and errors are being improperly served.
- We know log the errors, but otherwise do nothing with them, the hope is that this will solve some of the instant crashing on launch.