### PR TITLE
5.8.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ init:
 
 build_script:
   - python ./build_scripts/append_to_version_file.py %APPVEYOR_REPO_COMMIT:~0,8%
-  - python ./build_scripts/run-clang-format.py ./src -r --clang-format-executable "C:\Program Files\LLVM\bin\clang-format.exe" --color always
+#  - python ./build_scripts/run-clang-format.py ./src -r --clang-format-executable "C:\Program Files\LLVM\bin\clang-format.exe" --color always
   - call "build_windows.cmd"
 
 artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,18 +29,18 @@ jobs:
                     sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
                     sudo add-apt-repository 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
                     sudo apt-get update -qq
-            - run:
-                name: Install LLVM-8 binaries
-                # clang is required due to a check by Qmake.
-                # clang-tidy-8 has new errors compared to clang-tidy-7, so we haven't upgraded.
-                command: |
-                    sudo apt-get install clang-format-8 -y
-                    sudo apt-get install clang-tidy-7 -y
-                    sudo apt-get install clang-8 -y
-                    sudo apt-get install clang -y
-            - run:
-                name: Run clang-format
-                command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
+            #- run:
+            #    name: Install LLVM-8 binaries
+            #    # clang is required due to a check by Qmake.
+            #    # clang-tidy-8 has new errors compared to clang-tidy-7, so we haven't upgraded.
+            #    command: |
+            #        sudo apt-get install clang-format-8 -y
+            #        sudo apt-get install clang-tidy-7 -y
+            #        sudo apt-get install clang-8 -y
+            #        sudo apt-get install clang -y
+            #- run:
+            #    name: Run clang-format
+            #    command: python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
             - run:
                 name: Install g++
                 command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - sudo apt update -qq
   - sudo apt install clang-format-8
   - clang-format-8 --version
-  - python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
+#  - python ./build_scripts/run-clang-format.py ./src -r --color always --clang-format-executable clang-format-8
   - sed -i 's/QMAKE_CXXFLAGS += -flto//g' ./build_scripts/qt/compilers/clang-gcc-common-switches.pri # CI version of clang can't handle LTO
   - sed -i 's/QMAKE_LFLAGS += -flto -fuse-ld=gold//g' ./build_scripts/qt/compilers/clang-gcc-common-switches.pri # CI version of clang can't handle LTO
 

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.8.1-release
+5.8.2-release

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.7.4-release
+5.8.0-release

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.8.0-release
+5.8.1-release

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.8.2-release
+5.8.3-release

--- a/build_scripts/qt/resources.pri
+++ b/build_scripts/qt/resources.pri
@@ -45,6 +45,7 @@ DISTFILES += \
     src/res/qml/utilities_page/media_keys/* \
     src/res/qml/utilities_page/keyboard_utils/* \
     src/res/qml/utilities_page/alarm_clock/* \
+    src/res/qml/utilities_page/misc/* \
     src/res/qml/audio_page/dialog_boxes/* \
     src/res/qml/audio_page/device_selector/* \
     src/res/qml/audio_page/proximity/* \

--- a/src/keyboard_input/input_parser.cpp
+++ b/src/keyboard_input/input_parser.cpp
@@ -65,8 +65,20 @@ std::optional<Token> getFunctionNumberExtended( const char& character ) noexcept
         return Token::KEY_F11;
     case '2':
         return Token::KEY_F12;
-    // Theoretically we could extende out to f19, but as F12 is the only
-    // function key on Standard Keyboard.
+    case '3':
+        return Token::KEY_F13;
+    case '4':
+        return Token::KEY_F14;
+    case '5':
+        return Token::KEY_F15;
+    case '6':
+        return Token::KEY_F16;
+    case '7':
+        return Token::KEY_F17;
+    case '8':
+        return Token::KEY_F18;
+    case '9':
+        return Token::KEY_F19;
     default:
         LOG( INFO ) << "Unknown function key number: " << character;
         return std::nullopt;

--- a/src/keyboard_input/input_parser.cpp
+++ b/src/keyboard_input/input_parser.cpp
@@ -489,6 +489,20 @@ bool isLiteral( const Token token ) noexcept
         return true;
     case Token::KEY_F12:
         return true;
+    case Token::KEY_F13:
+        return true;
+    case Token::KEY_F14:
+        return true;
+    case Token::KEY_F15:
+        return true;
+    case Token::KEY_F16:
+        return true;
+    case Token::KEY_F17:
+        return true;
+    case Token::KEY_F18:
+        return true;
+    case Token::KEY_F19:
+        return true;
 
     case Token::KEY_BACKSPACE:
         return true;

--- a/src/keyboard_input/input_parser.h
+++ b/src/keyboard_input/input_parser.h
@@ -28,7 +28,7 @@ enum class Token
     KEY_F18,
     KEY_F19,
 
-    KEY_BACKSPACE,
+    KEY_BACKSPACE = 150,
     KEY_SPACE,
     KEY_TAB,
     KEY_ESC,

--- a/src/keyboard_input/input_parser.h
+++ b/src/keyboard_input/input_parser.h
@@ -20,6 +20,13 @@ enum class Token
     KEY_F10,
     KEY_F11,
     KEY_F12,
+    KEY_F13,
+    KEY_F14,
+    KEY_F15,
+    KEY_F16,
+    KEY_F17,
+    KEY_F18,
+    KEY_F19,
 
     KEY_BACKSPACE,
     KEY_SPACE,

--- a/src/keyboard_input/input_sender_X11.cpp
+++ b/src/keyboard_input/input_sender_X11.cpp
@@ -105,6 +105,20 @@ unsigned int tokenToKeySym( const Token token )
         return XK_F11;
     case Token::KEY_F12:
         return XK_F12;
+    case Token::KEY_F13:
+        return XK_F13;
+    case Token::KEY_F14:
+        return XK_F14;
+    case Token::KEY_F15:
+        return XK_F15;
+    case Token::KEY_F16:
+        return XK_F16;
+    case Token::KEY_F17:
+        return XK_F17;
+    case Token::KEY_F18:
+        return XK_F18;
+    case Token::KEY_F19:
+        return XK_F19;
 
     case Token::KEY_BACKSPACE:
         return XK_BackSpace;

--- a/src/keyboard_input/input_sender_win.cpp
+++ b/src/keyboard_input/input_sender_win.cpp
@@ -36,6 +36,20 @@ WORD convertToVirtualKeycode( const Token token )
         return VK_F11;
     case Token::KEY_F12:
         return VK_F12;
+    case Token::KEY_F13:
+        return VK_F13;
+    case Token::KEY_F14:
+        return VK_F14;
+    case Token::KEY_F15:
+        return VK_F15;
+    case Token::KEY_F16:
+        return VK_F16;
+    case Token::KEY_F17:
+        return VK_F17;
+    case Token::KEY_F18:
+        return VK_F18;
+    case Token::KEY_F19:
+        return VK_F19;
 
     case Token::KEY_BACKSPACE:
         return VK_BACK;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,8 @@
 #ifdef _WIN64
 #    include <windows.h>
 extern "C" __declspec( dllexport ) DWORD NvOptimusEnablement = 0x00000001;
-extern "C" __declspec( dllexport ) DWORD
-    AmdPowerXpressRequestHighPerformance = 0x00000001;
+extern "C" __declspec( dllexport ) DWORD AmdPowerXpressRequestHighPerformance
+    = 0x00000001;
 #endif
 
 INITIALIZE_EASYLOGGINGPP
@@ -81,7 +81,7 @@ int main( int argc, char* argv[] )
                               application_strings::applicationKey );
 
         // Attempts to install the application manifest on all "regular" starts.
-        if ( !commandLineArgs.desktopMode && !commandLineArgs.forceNoManifest )
+        if ( !commandLineArgs.forceNoManifest )
         {
             try
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,9 @@ int main( int argc, char* argv[] )
             }
         }
 
-        if ( commandLineArgs.desktopMode )
+        if ( commandLineArgs.desktopMode
+             || settings::getSetting(
+                 settings::BoolSetting::APPLICATION_desktopModeToggle ) )
         {
             auto m_pWindow = new QQuickWindow();
             qobject_cast<QQuickItem*>( quickObj )

--- a/src/openvr/openvr_init.cpp
+++ b/src/openvr/openvr_init.cpp
@@ -59,23 +59,15 @@ void initializeOpenVR( const OpenVrInitializationType initType, int count )
     // The function call and error message was the same for all version checks.
     // Specific error messages are unlikely to be necessary since both the type
     // and version are in the string and will be output.
-    auto reportVersionError = []( const char* const interfaceAndVersion ) {
-        // 5.7.1
-        // Stop behavior from exiting out, again seems to be related to some
-        // sort of race condition in non-native Headsets (i.e. not lighthouse)
-
-        //        QMessageBox::critical(
-        //            nullptr,
-        //            "OpenVR Advanced Settings Overlay",
-        //            "OpenVR version is too outdated. Please update OpenVR." );
-
+    auto reportVersionError
+        = []( const char* const interfaceAndVersion, const int trynumber )
+    {
+        // as of 5.8.1 Based on some information on valve, if ANY interface
+        // fails to load we should have issues. we will re-initialize a few
+        // times if that is the case and hope that fixes things
         LOG( WARNING ) << "OpenVR version is invalid: Interface version "
-                       << interfaceAndVersion << " not found.";
-        //        throw std::runtime_error(
-        //            std::string( "OpenVR version is too outdated: Interface
-        //            version " )
-        //            + std::string( interfaceAndVersion )
-        //            + std::string( " not found." ) );
+                       << interfaceAndVersion << " not found. attempt number: "
+                       << std::to_string( trynumber );
     };
 
     // Check whether OpenVR is too outdated
@@ -84,47 +76,47 @@ void initializeOpenVR( const OpenVrInitializationType initType, int count )
     // condition in steamvr
     if ( !vr::VR_IsInterfaceVersionValid( vr::IVRSystem_Version ) )
     {
-        reportVersionError( vr::IVRSystem_Version );
+        reportVersionError( vr::IVRSystem_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRSettings_Version ) )
     {
-        reportVersionError( vr::IVRSettings_Version );
+        reportVersionError( vr::IVRSettings_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVROverlay_Version ) )
     {
-        reportVersionError( vr::IVROverlay_Version );
+        reportVersionError( vr::IVROverlay_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRApplications_Version ) )
     {
-        reportVersionError( vr::IVRApplications_Version );
+        reportVersionError( vr::IVRApplications_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRChaperone_Version ) )
     {
-        reportVersionError( vr::IVRChaperone_Version );
+        reportVersionError( vr::IVRChaperone_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRChaperoneSetup_Version ) )
     {
-        reportVersionError( vr::IVRChaperoneSetup_Version );
+        reportVersionError( vr::IVRChaperoneSetup_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRCompositor_Version ) )
     {
-        reportVersionError( vr::IVRCompositor_Version );
+        reportVersionError( vr::IVRCompositor_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRNotifications_Version ) )
     {
-        reportVersionError( vr::IVRNotifications_Version );
+        reportVersionError( vr::IVRNotifications_Version, count );
         success = false;
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRInput_Version ) )
     {
-        reportVersionError( vr::IVRInput_Version );
+        reportVersionError( vr::IVRInput_Version, count );
         success = false;
     }
     if ( !success && count < 3 )
@@ -133,6 +125,7 @@ void initializeOpenVR( const OpenVrInitializationType initType, int count )
                           "openvr/steamvr attempting again "
                        << std::to_string( count + 1 ) << " of 3 Attempts";
         std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
+        // 5.8.1 Unknown if VR shutdown needs to be callled if vr init fails
         initializeOpenVR( initType, ( count + 1 ) );
     }
     if ( count >= 3 )

--- a/src/openvr/openvr_init.cpp
+++ b/src/openvr/openvr_init.cpp
@@ -62,7 +62,7 @@ void initializeOpenVR( const OpenVrInitializationType initType, int count )
     auto reportVersionError
         = []( const char* const interfaceAndVersion, const int trynumber )
     {
-        // as of 5.8.1 Based on some information on valve, if ANY interface
+        // as of 5.8.1 Based on some information from valve, if ANY interface
         // fails to load we should have issues. we will re-initialize a few
         // times if that is the case and hope that fixes things
         LOG( WARNING ) << "OpenVR version is invalid: Interface version "

--- a/src/openvr/openvr_init.cpp
+++ b/src/openvr/openvr_init.cpp
@@ -79,41 +79,54 @@ void initializeOpenVR( const OpenVrInitializationType initType )
     };
 
     // Check whether OpenVR is too outdated
+
+    // Sleep duration is an attempt to hopefully alleviate a possible race
+    // condition in steamvr
+    std::chrono::seconds dur( 5 );
     if ( !vr::VR_IsInterfaceVersionValid( vr::IVRSystem_Version ) )
     {
         reportVersionError( vr::IVRSystem_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRSettings_Version ) )
     {
         reportVersionError( vr::IVRSettings_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVROverlay_Version ) )
     {
         reportVersionError( vr::IVROverlay_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRApplications_Version ) )
     {
         reportVersionError( vr::IVRApplications_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRChaperone_Version ) )
     {
         reportVersionError( vr::IVRChaperone_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRChaperoneSetup_Version ) )
     {
         reportVersionError( vr::IVRChaperoneSetup_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRCompositor_Version ) )
     {
         reportVersionError( vr::IVRCompositor_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRNotifications_Version ) )
     {
         reportVersionError( vr::IVRNotifications_Version );
+        std::this_thread::sleep_for( dur );
     }
     else if ( !vr::VR_IsInterfaceVersionValid( vr::IVRInput_Version ) )
     {
         reportVersionError( vr::IVRInput_Version );
+        std::this_thread::sleep_for( dur );
     }
 }
 

--- a/src/openvr/openvr_init.h
+++ b/src/openvr/openvr_init.h
@@ -8,6 +8,6 @@ enum class OpenVrInitializationType
     Utility,
 };
 
-void initializeOpenVR( const OpenVrInitializationType initType );
+void initializeOpenVR( const OpenVrInitializationType initType, int count = 0 );
 
 } // namespace openvr_init

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -527,8 +527,11 @@ void OverlayController::SetWidget( QQuickItem* quickItem,
         if ( chapindex.first )
         {
             m_chaperoneTabController.applyChaperoneProfile( chapindex.second );
-            vr::VRApplications()->CancelApplicationLaunch(
+            bool success = vr::VRApplications()->CancelApplicationLaunch(
                 "openvr.tool.steamvr_room_setup" );
+            auto successsstr = success ? "true" : "false";
+
+            LOG( INFO ) << "Attempted to stop roomsetup: " << successsstr;
             if ( vr::VRApplications()->GetApplicationProcessId(
                      "openvr.tool.steamvr_room_setup" )
                  != 0 )

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1271,15 +1271,7 @@ void OverlayController::mainEventLoop()
 
             if ( !chaperoneDataAlreadyUpdated )
             {
-                // LOG(INFO) << "Re-loading chaperone data ...";
                 m_chaperoneUtils.loadChaperoneData();
-                // LOG(INFO) << "Found " << m_chaperoneUtils.quadsCount() <<
-                // " chaperone quads."; if
-                // (m_chaperoneUtils.isChaperoneWellFormed()) { LOG(INFO) <<
-                // "Chaperone data seems to be well-formed.";
-                //} else {
-                // LOG(INFO) << "Chaperone data is NOT well-formed.";
-                //}
                 chaperoneDataAlreadyUpdated = true;
             }
         }
@@ -1289,15 +1281,7 @@ void OverlayController::mainEventLoop()
         {
             if ( !chaperoneDataAlreadyUpdated )
             {
-                // LOG(INFO) << "Re-loading chaperone data ...";
                 m_chaperoneUtils.loadChaperoneData();
-                // LOG(INFO) << "Found " << m_chaperoneUtils.quadsCount() <<
-                // " chaperone quads."; if
-                // (m_chaperoneUtils.isChaperoneWellFormed()) { LOG(INFO) <<
-                // "Chaperone data seems to be well-formed.";
-                //} else {
-                // LOG(INFO) << "Chaperone data is NOT well-formed.";
-                //}
                 chaperoneDataAlreadyUpdated = true;
             }
         }
@@ -1349,20 +1333,6 @@ void OverlayController::mainEventLoop()
             = std::sqrt( vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2] );
     }
     auto universe = vr::VRCompositor()->GetTrackingSpace();
-    // This Fix is hopefully temporary as OpenVR doesn't appear to have a way to
-    // tell if an application is OpenXR outside of VR_init which we don't have
-    // control over
-    /*
-    if ( vr::VRApplications()->GetApplicationProcessId(
-             "openvr.tool.steamvr_room_setup" )
-             == 0
-         && openXRFixEnabled() )
-    {
-        // OpenXR applications will appear as RawAndUncalibrated.
-        // Unless Room Setup is running, treat this case as Standing.
-        universe = vr::TrackingUniverseStanding;
-    }
-    */
     m_moveCenterTabController.eventLoopTick( universe, devicePoses );
     m_utilitiesTabController.eventLoopTick();
     m_statisticsTabController.eventLoopTick(

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -116,6 +116,13 @@ OverlayController::OverlayController( bool desktopMode,
         LOG( ERROR ) << "Could not find alarm01 sound file " << alarmFileName;
     }
 
+    // If we have desktop mode flag ignore waht toggle says otherwise we use
+    // toggle
+    if ( !m_desktopMode )
+    {
+        m_desktopMode = desktopModeToggle();
+    }
+
     QSurfaceFormat format;
     // Qt's QOpenGLPaintDevice is not compatible with OpenGL versions >= 3.0
     // NVIDIA does not care, but unfortunately AMD does
@@ -1683,6 +1690,22 @@ double OverlayController::soundVolume() const
 {
     return settings::getSetting(
         settings::DoubleSetting::APPLICATION_appVolume );
+}
+
+void OverlayController::setDesktopModeToggle( bool value, bool notify )
+{
+    settings::setSetting( settings::BoolSetting::APPLICATION_desktopModeToggle,
+                          value );
+    if ( notify )
+    {
+        emit desktopModeToggleChanged( value );
+    }
+    settings::saveAllSettings();
+}
+bool OverlayController::desktopModeToggle() const
+{
+    return settings::getSetting(
+        settings::BoolSetting::APPLICATION_desktopModeToggle );
 }
 
 void OverlayController::playActivationSound()

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -183,7 +183,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "OverlayController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = objectAddress;
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -197,7 +198,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "SteamVRTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_steamVRTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -207,7 +209,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "ChaperoneTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_chaperoneTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -217,7 +220,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "MoveCenterTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_moveCenterTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -227,7 +231,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "FixFloorTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_fixFloorTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -237,7 +242,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "AudioTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_audioTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -247,7 +253,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "StatisticsTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_statisticsTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -257,7 +264,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "SettingsTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_settingsTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -267,7 +275,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "UtilitiesTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_utilitiesTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -277,7 +286,8 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "VideoTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_videoTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
@@ -287,13 +297,19 @@ OverlayController::OverlayController( bool desktopMode,
         1,
         0,
         "RotationTabController",
-        []( QQmlEngine*, QJSEngine* ) {
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_rotationTabController );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;
         } );
     qmlRegisterSingletonType<alarm_clock::VrAlarm>(
-        qmlSingletonImportName, 1, 0, "VrAlarm", []( QQmlEngine*, QJSEngine* ) {
+        qmlSingletonImportName,
+        1,
+        0,
+        "VrAlarm",
+        []( QQmlEngine*, QJSEngine* )
+        {
             QObject* obj = &( objectAddress->m_alarm );
             QQmlEngine::setObjectOwnership( obj, QQmlEngine::CppOwnership );
             return obj;

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1363,7 +1363,7 @@ void OverlayController::mainEventLoop()
 
     m_alarm.eventLoopTick();
 
-    if ( vr::VROverlay()->IsDashboardVisible() )
+    if ( vr::VROverlay()->IsDashboardVisible() || m_desktopMode )
     {
         m_settingsTabController.dashboardLoopTick();
         m_steamVRTabController.dashboardLoopTick();

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -98,6 +98,8 @@ class OverlayController : public QObject
                         autoApplyChaperoneEnabledChanged )
     Q_PROPERTY( double soundVolume READ soundVolume WRITE setSoundVolume NOTIFY
                     soundVolumeChanged )
+    Q_PROPERTY( bool desktopModeToggle READ desktopModeToggle WRITE
+                    setDesktopModeToggle NOTIFY desktopModeToggleChanged )
 
 private:
     vr::VROverlayHandle_t m_ulOverlayHandle = vr::k_ulOverlayHandleInvalid;
@@ -255,6 +257,7 @@ public:
     std::string autoApplyChaperoneName();
 
     double soundVolume() const;
+    bool desktopModeToggle() const;
 
 public slots:
     void renderOverlay();
@@ -282,6 +285,7 @@ public slots:
     void setDebugState( int value, bool notify = true );
     void setAutoApplyChaperoneEnabled( bool value, bool notify = true );
     void setSoundVolume( double value, bool notify = true );
+    void setDesktopModeToggle( bool value, bool notify = true );
 
 signals:
     void keyBoardInputSignal( QString input, unsigned long userValue = 0 );
@@ -296,6 +300,7 @@ signals:
     void debugStateChanged( int value );
     void autoApplyChaperoneEnabledChanged( bool value );
     void soundVolumeChanged( double value );
+    void desktopModeToggleChanged( bool value );
 };
 
 } // namespace advsettings

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -98,33 +98,33 @@ MyStackViewPage {
                 text: "Allow External App Chaperone Edits (Danger)"
                 onCheckedChanged: {
                     MoveCenterTabController.setAllowExternalEdits(checked, true)
-                    seatedOldExternalWarning.visible = checked && MoveCenterTabController.oldStyleMotion
+                    //seatedOldExternalWarning.visible = checked && MoveCenterTabController.oldStyleMotion
                 }
             }
 
-            MyToggleButton {
-                id: oldStyleMotionToggle
-                text: "Old-Style Motion (per-frame disk writes)"
-                onCheckedChanged: {
-                    MoveCenterTabController.setOldStyleMotion(checked, true)
-                    seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && checked
-                }
-            }
-            RowLayout{
+//            MyToggleButton {
+//                id: oldStyleMotionToggle
+//                text: "Old-Style Motion (per-frame disk writes)"
+//                onCheckedChanged: {
+//                    MoveCenterTabController.setOldStyleMotion(checked, true)
+//                    //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && checked
+//                }
+//            }
+//            RowLayout{
 
-                MyText {
-                    id: seatedOldExternalWarning
-                    wrapMode: Text.WordWrap
-                    font.pointSize: 20
-                    color: "#FFA500"
-                    text: "WARNING: 'Allow External App Chaperone Edits' + 'Old-Style Motion' + 'Enable Motion Features When in Seated Mode' active together may cause space center misalignment. Load the «Autosaved Profile» in the 'Chaperone' tab to fix."
-                    horizontalAlignment: Text.AlignHCenter
-                    Layout.leftMargin: 20
-                    Layout.rightMargin: 20
-                    Layout.preferredWidth: 900
-                    //Layout.fillWidth: true
-                }
-            }
+//                MyText {
+//                    id: seatedOldExternalWarning
+//                    wrapMode: Text.WordWrap
+//                    font.pointSize: 20
+//                    color: "#FFA500"
+//                    text: "WARNING: 'Allow External App Chaperone Edits' + 'Old-Style Motion' + 'Enable Motion Features When in Seated Mode' active together may cause space center misalignment. Load the «Autosaved Profile» in the 'Chaperone' tab to fix."
+//                    horizontalAlignment: Text.AlignHCenter
+//                    Layout.leftMargin: 20
+//                    Layout.rightMargin: 20
+//                    Layout.preferredWidth: 900
+//                    //Layout.fillWidth: true
+//                }
+//            }
 
             MyToggleButton {
                 id: universeCenteredRotationToggle
@@ -350,7 +350,7 @@ MyStackViewPage {
                 settingsAutoStartToggle.checked = SettingsTabController.autoStartEnabled
 
                 allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
-                oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
+                //oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
 
                 disableCrashRecoveryToggle.checked = !OverlayController.crashRecoveryDisabled
@@ -369,7 +369,7 @@ MyStackViewPage {
                 spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
 
 
-                seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
+                //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
                 reloadChaperoneProfiles()
                 volumeSlider.value = OverlayController.soundVolume
             }
@@ -391,12 +391,12 @@ MyStackViewPage {
             target: MoveCenterTabController
             onAllowExternalEditsChanged: {
                 allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
-                seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
+                //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
             }
-            onOldStyleMotionChanged: {
-                oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
-                seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
-            }
+//            onOldStyleMotionChanged: {
+//                oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
+//                seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
+//            }
             onUniverseCenteredRotationChanged: {
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
             }

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -195,13 +195,6 @@ MyStackViewPage {
                     OverlayController.setExclusiveInputEnabled(this.checked, true)
                 }
             }
-            MyToggleButton {
-                id: spaceAdjustChaperoneToggle
-                text: "Adjust Chaperone"
-                onCheckedChanged: {
-                    MoveCenterTabController.adjustChaperone = this.checked
-                }
-            }
 
             RowLayout {
                 Layout.fillWidth: true
@@ -347,7 +340,6 @@ MyStackViewPage {
                 oculusSdkToggleButton.checked = SettingsTabController.oculusSdkToggle
                 exclusiveInputToggleButton.checked = OverlayController.exclusiveInputEnabled
                 autoApplyChaperoneToggleButton.checked = OverlayController.autoApplyChaperoneEnabled
-                spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
                 desktopModeToggleButton.checked = OverlayController.desktopModeToggle
 
 
@@ -375,9 +367,6 @@ MyStackViewPage {
             }
             onUniverseCenteredRotationChanged: {
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
-            }
-            onAdjustChaperoneChanged:{
-                spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
             }
         }
 

--- a/src/res/qml/SettingsPage.qml
+++ b/src/res/qml/SettingsPage.qml
@@ -92,39 +92,21 @@ MyStackViewPage {
                     SettingsTabController.setAutoStartEnabled(checked, false)
                 }
             }
+            MyToggleButton {
+                id: desktopModeToggleButton
+                text: "Desktop Mode (restart required)"
+                onCheckedChanged: {
+                    OverlayController.setDesktopModeToggle(this.checked, false)
+                }
+            }
 
             MyToggleButton {
                 id: allowExternalEditsToggle
                 text: "Allow External App Chaperone Edits (Danger)"
                 onCheckedChanged: {
                     MoveCenterTabController.setAllowExternalEdits(checked, true)
-                    //seatedOldExternalWarning.visible = checked && MoveCenterTabController.oldStyleMotion
                 }
             }
-
-//            MyToggleButton {
-//                id: oldStyleMotionToggle
-//                text: "Old-Style Motion (per-frame disk writes)"
-//                onCheckedChanged: {
-//                    MoveCenterTabController.setOldStyleMotion(checked, true)
-//                    //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && checked
-//                }
-//            }
-//            RowLayout{
-
-//                MyText {
-//                    id: seatedOldExternalWarning
-//                    wrapMode: Text.WordWrap
-//                    font.pointSize: 20
-//                    color: "#FFA500"
-//                    text: "WARNING: 'Allow External App Chaperone Edits' + 'Old-Style Motion' + 'Enable Motion Features When in Seated Mode' active together may cause space center misalignment. Load the «Autosaved Profile» in the 'Chaperone' tab to fix."
-//                    horizontalAlignment: Text.AlignHCenter
-//                    Layout.leftMargin: 20
-//                    Layout.rightMargin: 20
-//                    Layout.preferredWidth: 900
-//                    //Layout.fillWidth: true
-//                }
-//            }
 
             MyToggleButton {
                 id: universeCenteredRotationToggle
@@ -350,7 +332,6 @@ MyStackViewPage {
                 settingsAutoStartToggle.checked = SettingsTabController.autoStartEnabled
 
                 allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
-                //oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
 
                 disableCrashRecoveryToggle.checked = !OverlayController.crashRecoveryDisabled
@@ -367,9 +348,9 @@ MyStackViewPage {
                 exclusiveInputToggleButton.checked = OverlayController.exclusiveInputEnabled
                 autoApplyChaperoneToggleButton.checked = OverlayController.autoApplyChaperoneEnabled
                 spaceAdjustChaperoneToggle.checked = MoveCenterTabController.adjustChaperone
+                desktopModeToggleButton.checked = OverlayController.desktopModeToggle
 
 
-                //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
                 reloadChaperoneProfiles()
                 volumeSlider.value = OverlayController.soundVolume
             }
@@ -391,12 +372,7 @@ MyStackViewPage {
             target: MoveCenterTabController
             onAllowExternalEditsChanged: {
                 allowExternalEditsToggle.checked = MoveCenterTabController.allowExternalEdits
-                //seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
             }
-//            onOldStyleMotionChanged: {
-//                oldStyleMotionToggle.checked = MoveCenterTabController.oldStyleMotion
-//                seatedOldExternalWarning.visible = MoveCenterTabController.allowExternalEdits && MoveCenterTabController.oldStyleMotion
-//            }
             onUniverseCenteredRotationChanged: {
                 universeCenteredRotationToggle.checked = MoveCenterTabController.universeCenteredRotation
             }
@@ -439,6 +415,9 @@ MyStackViewPage {
             }
             onSoundVolumeChanged:{
                 volumeSlider.value = OverlayController.soundVolume
+            }
+            onDesktopModeToggleChanged:{
+                desktopModeToggleButton.checked = OverlayController.desktopModeToggle
             }
         }
         Connections{

--- a/src/res/qml/motion_page/space_drag/SpaceDragGroupBox.qml
+++ b/src/res/qml/motion_page/space_drag/SpaceDragGroupBox.qml
@@ -89,13 +89,6 @@ GroupBox {
             }
         }
         RowLayout{
-            MyPushButton{
-                text:"Ignore Boundary State"
-                Layout.preferredWidth: 300
-                onClicked:{
-                    MoveCenterTabController.setIgnoreChaperoneState();
-                }
-            }
 
             Item{
                 Layout.fillWidth: true

--- a/src/res/qml/steamvr_page/steamvrmisc/SteamVRMiscGroupBox.qml
+++ b/src/res/qml/steamvr_page/steamvrmisc/SteamVRMiscGroupBox.qml
@@ -35,7 +35,7 @@ GroupBox {
             MyToggleButton {
                 id: steamvrPerformanceGraphToggle
                 text: "Enable Timing Overlay"
-                Layout.preferredWidth: 400
+                Layout.preferredWidth: 300
                 onCheckedChanged: {
                     SteamVRTabController.setPerformanceGraph(this.checked, false)
                 }
@@ -44,32 +44,18 @@ GroupBox {
                 Layout.preferredWidth: 20
                 text: " "
             }
-
             MyToggleButton {
-                id: steamvrSystemButtonToggle
-                Layout.fillWidth: true
-                text: "Enable System Button Binding"
+                id: steamvrNoHMDToggle
+                text: "Require HMD"
+                Layout.preferredWidth: 300
                 onCheckedChanged: {
-                    SteamVRTabController.setSystemButton(this.checked, false)
-                }
-            }
-        }
-        RowLayout {
-            spacing: 16
-
-            MyToggleButton {
-                id: steamvrMultipleDriverToggle
-                Layout.preferredWidth: 400
-                text: "Allow Multiple Drivers"
-                onCheckedChanged: {
-                    SteamVRTabController.setMultipleDriver(this.checked, false)
+                    SteamVRTabController.noHMD(this.checked, false)
                 }
             }
             MyText {
                 Layout.preferredWidth: 20
                 text: " "
             }
-
             MyToggleButton {
                 id: steamvrNoFadeToGridToggle
                 Layout.fillWidth: true
@@ -79,6 +65,31 @@ GroupBox {
                 }
             }
         }
+        RowLayout {
+            spacing: 16
+
+            MyToggleButton {
+                id: steamvrMultipleDriverToggle
+                Layout.preferredWidth: 300
+                text: "Allow Multiple Drivers"
+                onCheckedChanged: {
+                    SteamVRTabController.setMultipleDriver(this.checked, false)
+                }
+            }
+            MyText {
+                Layout.preferredWidth: 20
+                text: " "
+            }
+            MyToggleButton {
+                id: steamvrSystemButtonToggle
+                Layout.fillWidth: true
+                text: "Enable System Button Binding"
+                onCheckedChanged: {
+                    SteamVRTabController.setSystemButton(this.checked, false)
+                }
+            }
+
+        }
 
         RowLayout {
             spacing: 16
@@ -86,7 +97,7 @@ GroupBox {
             MyToggleButton {
                 id: steamvrNotificationToggle
                 text: "Disable Notifications"
-                 Layout.preferredWidth: 400
+                 Layout.preferredWidth: 300
                 onCheckedChanged: {
                     SteamVRTabController.setDND(this.checked, false)
                 }
@@ -94,6 +105,14 @@ GroupBox {
             MyText {
                 Layout.preferredWidth: 20
                 text: " "
+            }
+            MyToggleButton {
+                id: steamvrControllerPowerToggle
+                Layout.fillWidth: true
+                text: "Controller Power Turns on SteamVR"
+                onCheckedChanged: {
+                    SteamVRTabController.setControllerPower(this.checked, false)
+                }
             }
 
         }
@@ -106,6 +125,8 @@ GroupBox {
         steamvrMultipleDriverToggle.checked = SteamVRTabController.multipleDriver
         steamvrNoFadeToGridToggle.checked = SteamVRTabController.noFadeToGrid
         steamvrNotificationToggle.checked = SteamVRTabController.dnd
+        steamvrControllerPowerToggle.checked = SteamVRTabController.controllerPower
+        steamvrNoHMDToggle.checked = SteamVRTabController.noHMD
     }
 
     Connections {
@@ -124,6 +145,12 @@ GroupBox {
         }
         onDNDChanged:{
             steamvrNotificationToggle.checked = SteamVRTabController.dnd
+        }
+        onNoHMDChanged:{
+            steamvrNoHMDToggle.checked = SteamVRTabController.noHMD
+        }
+        onControllerPowerChanged:{
+            steamvrControllerPowerToggle.checked = SteamVRTabController.controllerPower
         }
 
     }

--- a/src/res/qml/steamvr_page/steamvrmisc/SteamVRMiscGroupBox.qml
+++ b/src/res/qml/steamvr_page/steamvrmisc/SteamVRMiscGroupBox.qml
@@ -49,7 +49,7 @@ GroupBox {
                 text: "Require HMD"
                 Layout.preferredWidth: 300
                 onCheckedChanged: {
-                    SteamVRTabController.noHMD(this.checked, false)
+                    SteamVRTabController.setNoHMD(this.checked, false)
                 }
             }
             MyText {

--- a/src/res/qml/utilities_page/UtilitiesPage.qml
+++ b/src/res/qml/utilities_page/UtilitiesPage.qml
@@ -6,6 +6,7 @@ import "media_keys"
 import "alarm_clock"
 import "keyboard_utils"
 import "../common"
+import "misc"
 
 MyStackViewPage {
     headerText: "Utilities"
@@ -23,6 +24,10 @@ MyStackViewPage {
 
         MediaControllerKeys {
             id: mediaKeysGroupBox
+        }
+
+        MiscBox{
+            id:utilMiscGroupBox
         }
 
         Item {

--- a/src/res/qml/utilities_page/misc/MiscBox.qml
+++ b/src/res/qml/utilities_page/misc/MiscBox.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.3
+import ovras.advsettings 1.0
+import "../../common"
+
+GroupBox {
+    id: utilMiscGroupBox
+    Layout.fillWidth: true
+
+    label:
+        MyText {
+        leftPadding: 10
+        text: "Misc:"
+        bottomPadding: -10
+        }
+
+
+    background: Rectangle {
+        color: "transparent"
+        border.color: "#d9dbe0"
+        radius: 8
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        Rectangle {
+            color: "#d9dbe0"
+            height: 1
+            Layout.fillWidth: true
+            Layout.bottomMargin: 5
+        }
+
+        RowLayout {
+            spacing: 16
+
+            MyToggleButton {
+                id: trackerOvlToggle
+                text: "Show Tracker Batteries"
+                Layout.preferredWidth: 250
+                onCheckedChanged: {
+                    UtilitiesTabController.setTrackerOvlEnabled(this.checked, false)
+                }
+            }
+        }
+
+    }
+
+    Component.onCompleted: {
+            trackerOvlToggle.checked = UtilitiesTabController.trackerOvlEnabled
+    }
+
+    Connections {
+        target: UtilitiesTabController
+        onTrackerOvlEnabledChanged:{
+            trackerOvlToggle.checked = UtilitiesTabController.trackerOvlEnabled
+        }
+
+    }
+}
+

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -359,6 +359,10 @@ private:
                           SettingCategory::Utility,
                           QtInfo{ "vrcDebug" },
                           false },
+        BoolSettingValue{ BoolSetting::UTILITY_trackerOverlayEnabled,
+                          SettingCategory::Utility,
+                          QtInfo{ "trackerOverlayEnabled" },
+                          true },
 
         BoolSettingValue{ BoolSetting::VIDEO_brightnessEnabled,
                           SettingCategory::Video,

--- a/src/settings/internal/settings_controller.h
+++ b/src/settings/internal/settings_controller.h
@@ -330,6 +330,11 @@ private:
                           SettingCategory::Application,
                           QtInfo{ "autoApplyChaperoneToggle" },
                           false },
+        BoolSettingValue{ BoolSetting::APPLICATION_desktopModeToggle,
+                          SettingCategory::Application,
+                          QtInfo{ "desktopModeToggle" },
+                          false },
+
         BoolSettingValue{ BoolSetting::AUDIO_pttEnabled,
                           SettingCategory::Audio,
                           QtInfo{ "pttEnabled" },

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -45,6 +45,7 @@ enum class BoolSetting
     UTILITY_alarmEnabled,
     UTILITY_alarmIsModal,
     UTILITY_vrcDebug,
+    UTILITY_trackerOverlayEnabled,
 
     VIDEO_brightnessEnabled,
     VIDEO_isOverlayMethodActive,

--- a/src/settings/settings.h
+++ b/src/settings/settings.h
@@ -36,6 +36,7 @@ enum class BoolSetting
     APPLICATION_crashRecoveryDisabled2,
     APPLICATION_openXRWorkAround,
     APPLICATION_autoApplyChaperone,
+    APPLICATION_desktopModeToggle,
 
     AUDIO_pttEnabled,
     AUDIO_pttShowNotification,

--- a/src/tabcontrollers/ChaperoneTabController.cpp
+++ b/src/tabcontrollers/ChaperoneTabController.cpp
@@ -128,7 +128,8 @@ void ChaperoneTabController::handleChaperoneWarnings( float distance )
                 }
                 m_chaperoneHapticFeedbackActive = true;
                 m_chaperoneHapticFeedbackThread = std::thread(
-                    [&]( ChaperoneTabController* _this ) {
+                    [&]( ChaperoneTabController* _this )
+                    {
                         auto leftIndex
                             = vr::VRSystem()
                                   ->GetTrackedDeviceIndexForControllerRole(

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2604,8 +2604,10 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
     }
 
     // reload from disk if we're at zero offsets and allow external edits
-    if ( allowExternalEdits() && m_oldOffsetX == 0.0f && m_oldOffsetY == 0.0f
-         && m_oldOffsetZ == 0.0f && m_oldRotation == 0 )
+    if ( allowExternalEdits()
+         && ( abs( m_oldOffsetX ) + abs( m_oldOffsetY ) + abs( m_oldOffsetZ )
+              + abs( m_oldRotation ) )
+                == 0 )
     {
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
         vr::VRChaperoneSetup()->CommitWorkingCopy(

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2081,25 +2081,6 @@ void MoveCenterTabController::zAxisLockToggle( bool zAxisLockToggleJustPressed )
 
 // END of other bindings
 
-// space drag update this is never called?
-// void MoveCenterTabController::saveUncommittedChaperone()
-//{
-//    if ( !m_chaperoneCommitted )
-//    {
-//        vr::VRChaperoneSetup()->CommitWorkingCopy(
-//            vr::EChaperoneConfigFile_Live );
-//        vr::VRChaperoneSetup()->HideWorkingSetPreview();
-//        m_chaperoneCommitted = true;
-//        unsigned checkQuadCount = 0;
-//        vr::VRChaperoneSetup()->GetWorkingCollisionBoundsInfo(
-//            nullptr, &checkQuadCount );
-//        if ( checkQuadCount > 0 )
-//        {
-//            parent->chaperoneUtils().loadChaperoneData( false );
-//        }
-//    }
-//}
-
 // NOTE this function will create bad output if User Rotates 180 Degrees in
 // 1/7* frame-rate. (Worst Case 30 fps = ~770 deg/s)
 void MoveCenterTabController::updateHmdRotationCounter(
@@ -2761,69 +2742,8 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
     vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
         &offsetUniverseCenter );
 
-    //    if ( oldStyleMotion() )
-    //    {
-    //        // check if universe center is outside of OpenVR commit bounds
-    //        (1km) if ( abs( offsetUniverseCenterXyz[0] ) >
-    //        k_maxOpenvrCommitOffset )
-    //        {
-    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
-    //            commit "
-    //                           "bounds ( X: "
-    //                        << offsetUniverseCenterXyz[0] << " )";
-    //            vr::HmdMatrix34_t standingZero;
-    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-    //                &standingZero );
-    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-    //            outputLogHmdMatrix( standingZero );
-    //            reset();
-    //            parent->m_chaperoneTabController.applyAutosavedProfile();
-    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-    //            return;
-    //        }
-    //        if ( abs( offsetUniverseCenterXyz[1] ) > k_maxOpenvrCommitOffset )
-    //        {
-    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
-    //            commit "
-    //                           "bounds ( Y: "
-    //                        << offsetUniverseCenterXyz[1] << " )";
-    //            vr::HmdMatrix34_t standingZero;
-    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-    //                &standingZero );
-    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-    //            outputLogHmdMatrix( standingZero );
-    //            reset();
-    //            parent->m_chaperoneTabController.applyAutosavedProfile();
-    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-    //            return;
-    //        }
-    //        if ( abs( offsetUniverseCenterXyz[2] ) > k_maxOpenvrCommitOffset )
-    //        {
-    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
-    //            commit "
-    //                           "bounds ( Z: "
-    //                        << offsetUniverseCenterXyz[2] << " )";
-    //            vr::HmdMatrix34_t standingZero;
-    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-    //                &standingZero );
-    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-    //            outputLogHmdMatrix( standingZero );
-    //            reset();
-    //            parent->m_chaperoneTabController.applyAutosavedProfile();
-    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-    //            return;
-    //        }
-    //        vr::VRChaperoneSetup()->CommitWorkingCopy(
-    //            vr::EChaperoneConfigFile_Live );
-    //        m_chaperoneCommitted = true;
-    //    }
-    //
     vr::VRChaperoneSetup()->ShowWorkingSetPreview();
-    // m_chaperoneCommitted = false;
-    //}
 
-    // loadChaperoneData( false ), false so that we don't load live data,
-    // and reference the working set instead.
     if ( m_collisionBoundsCountForReset > 0 )
     {
         parent->chaperoneUtils().loadChaperoneData( false );

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -957,7 +957,8 @@ void MoveCenterTabController::modOffsetZ( float value, bool notify )
 void MoveCenterTabController::shutdown()
 {
     reset();
-    vr::VRChaperoneSetup()->HideWorkingSetPreview();
+    // vr::VRChaperoneSetup()->HideWorkingSetPreview();
+    vr::VRChaperoneSetup()->RevertWorkingCopy();
 }
 
 void MoveCenterTabController::incomingSeatedReset()
@@ -2323,7 +2324,8 @@ void MoveCenterTabController::updateHandDrag(
         // prevent positional glitches from exceeding max openvr offset
         // clamps. We do this by detecting a drag larger than 100m in a
         // single frame.
-        if ( ( abs( diff[0] ) + abs( diff[1] ) + abs( diff[2] ) ) > 100.0 )
+        if ( abs( diff[0] ) > 100.0 || abs( diff[1] ) > 100.0
+             || abs( diff[2] ) > 100.0 )
         {
             reset();
         }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -855,28 +855,28 @@ void MoveCenterTabController::setAllowExternalEdits( bool value, bool notify )
     }
 }
 
-bool MoveCenterTabController::oldStyleMotion() const
-{
-    return settings::getSetting(
-        settings::BoolSetting::PLAYSPACE_oldStyleMotion );
-}
+// bool MoveCenterTabController::oldStyleMotion() const
+//{
+//     return settings::getSetting(
+//         settings::BoolSetting::PLAYSPACE_oldStyleMotion );
+// }
 
-void MoveCenterTabController::setOldStyleMotion( bool value, bool notify )
-{
-    // detect incoming change to old style, and hide working set
-    if ( value && !oldStyleMotion() )
-    {
-        vr::VRChaperoneSetup()->HideWorkingSetPreview();
-    }
+// void MoveCenterTabController::setOldStyleMotion( bool value, bool notify )
+//{
+//     // detect incoming change to old style, and hide working set
+//     if ( value && !oldStyleMotion() )
+//     {
+//         vr::VRChaperoneSetup()->HideWorkingSetPreview();
+//     }
 
-    settings::setSetting( settings::BoolSetting::PLAYSPACE_oldStyleMotion,
-                          value );
+//    settings::setSetting( settings::BoolSetting::PLAYSPACE_oldStyleMotion,
+//                          value );
 
-    if ( notify )
-    {
-        emit oldStyleMotionChanged( value );
-    }
-}
+//    if ( notify )
+//    {
+//        emit oldStyleMotionChanged( value );
+//    }
+//}
 
 bool MoveCenterTabController::universeCenteredRotation() const
 {
@@ -2271,6 +2271,7 @@ void MoveCenterTabController::updateHandDrag(
     }
 
     vr::TrackedDevicePose_t* movePose;
+    movePose = devicePoses + moveHandId;
     if ( m_seatedModeDetected )
     {
         vr::TrackedDevicePose_t
@@ -2281,10 +2282,6 @@ void MoveCenterTabController::updateHandDrag(
             seatedDevicePoses,
             vr::k_unMaxTrackedDeviceCount );
         movePose = seatedDevicePoses + moveHandId;
-    }
-    else
-    {
-        movePose = devicePoses + moveHandId;
     }
 
     if ( !movePose->bPoseIsValid || !movePose->bDeviceIsConnected
@@ -2327,8 +2324,7 @@ void MoveCenterTabController::updateHandDrag(
         // prevent positional glitches from exceeding max openvr offset
         // clamps. We do this by detecting a drag larger than 100m in a
         // single frame.
-        if ( abs( diff[0] ) > 100.0 || abs( diff[1] ) > 100.0
-             || abs( diff[2] ) > 100.0 )
+        if ( ( abs( diff[0] ) + abs( diff[1] ) + abs( diff[2] ) ) > 100.0 )
         {
             reset();
         }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2532,7 +2532,7 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
     // reload from disk if we're at zero offsets and allow external edits
     if ( allowExternalEdits()
          && ( abs( m_oldOffsetX ) + abs( m_oldOffsetY ) + abs( m_oldOffsetZ )
-              + abs( m_oldRotation ) )
+              + abs( static_cast<float>( m_oldRotation ) ) )
                 == 0 )
     {
         vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -970,7 +970,6 @@ void MoveCenterTabController::incomingSeatedReset()
         LOG( INFO ) << "steamvr center?";
         m_selfRequestedSeatedRecenter = true;
         vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseSeated );
-        vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseStanding );
     }
     else
     {
@@ -1209,7 +1208,7 @@ void MoveCenterTabController::zeroOffsets()
 void MoveCenterTabController::sendSeatedRecenter()
 {
     vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseSeated );
-    vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseStanding );
+    // vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseStanding );
 }
 
 double MoveCenterTabController::getHmdYawTotal()

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -855,29 +855,6 @@ void MoveCenterTabController::setAllowExternalEdits( bool value, bool notify )
     }
 }
 
-// bool MoveCenterTabController::oldStyleMotion() const
-//{
-//     return settings::getSetting(
-//         settings::BoolSetting::PLAYSPACE_oldStyleMotion );
-// }
-
-// void MoveCenterTabController::setOldStyleMotion( bool value, bool notify )
-//{
-//     // detect incoming change to old style, and hide working set
-//     if ( value && !oldStyleMotion() )
-//     {
-//         vr::VRChaperoneSetup()->HideWorkingSetPreview();
-//     }
-
-//    settings::setSetting( settings::BoolSetting::PLAYSPACE_oldStyleMotion,
-//                          value );
-
-//    if ( notify )
-//    {
-//        emit oldStyleMotionChanged( value );
-//    }
-//}
-
 bool MoveCenterTabController::universeCenteredRotation() const
 {
     return settings::getSetting(
@@ -900,23 +877,6 @@ bool MoveCenterTabController::isInitComplete() const
 {
     return m_initComplete;
 }
-
-// bool MoveCenterTabController::simpleRecenter() const
-//{
-//     return settings::getSetting(
-//         settings::BoolSetting::PLAYSPACE_simpleRecenter );
-// }
-
-// void MoveCenterTabController::setSimpleRecenter( bool value, bool notify )
-//{
-//     settings::setSetting( settings::BoolSetting::PLAYSPACE_simpleRecenter,
-//                           value );
-
-//    if ( notify )
-//    {
-//        emit simpleRecenterChanged( value );
-//    }
-//}
 
 void MoveCenterTabController::modOffsetX( float value, bool notify )
 {
@@ -956,9 +916,10 @@ void MoveCenterTabController::modOffsetZ( float value, bool notify )
 
 void MoveCenterTabController::shutdown()
 {
-    reset();
-    // vr::VRChaperoneSetup()->HideWorkingSetPreview();
-    vr::VRChaperoneSetup()->RevertWorkingCopy();
+    vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
+    // reset();
+    //  vr::VRChaperoneSetup()->HideWorkingSetPreview();
+    // vr::VRChaperoneSetup()->RevertWorkingCopy();
 }
 
 void MoveCenterTabController::incomingSeatedReset()
@@ -2769,79 +2730,6 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
         vr::VRChaperoneSetup()->SetWorkingSeatedZeroPoseToRawTrackingPose(
             &offsetSeatedCenter );
     }
-
-    // As of SVR 1.13.1 The Chaperone will follow Universe Center NOT raw
-    // Center as such this should be off by defualt.
-    // As of SVR 1.26.3 The chaperone seems to Have reverted back to
-    // pre 1.13.1 behavior as of SVR 1.26.3 instead of 2x offset we have 1x
-    // offset and universe centerS as of SVR 1.26.4 1.26.3 changes are
-    // reverted as Such Adjust Chaperone Should Not Be Needed We Will leave
-    // in Adjust Chaperone at this point but make sure it defaults to off
-
-    //    if ( adjustChaperone() )
-    //    {
-    //        // outputLogPoses();
-    //        // make a copy of our bounds and
-    //        // reorient relative to new universe center
-
-    //        vr::HmdQuad_t* updatedBounds
-    //            = new vr::HmdQuad_t[m_collisionBoundsCountForReset];
-
-    //        // for every quad in the chaperone bounds...
-    //        for ( unsigned quad = 0; quad < m_collisionBoundsCountForReset;
-    //        quad++ )
-    //        {
-    //            // at every corner in that quad...
-    //            for ( unsigned corner = 0; corner < 4; corner++ )
-    //            {
-    //                // copy the corner's xyz coordinates
-    //                updatedBounds[quad].vCorners[corner].v[0]
-    //                    =
-    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[0];
-
-    //                updatedBounds[quad].vCorners[corner].v[1]
-    //                    =
-    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[1];
-
-    //                updatedBounds[quad].vCorners[corner].v[2]
-    //                    =
-    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[2];
-
-    //                // cancel universe center's xyz offsets to each corner's
-    //                // position and shift over by original center position so
-    //                // that we are mirroring the offset as reflected about the
-    //                // original origin
-    //                updatedBounds[quad].vCorners[corner].v[0]
-    //                    -= offsetUniverseCenter.m[0][3]
-    //                       // - offsetUniverseCenter.m[0][3];
-    //                       - m_universeCenterForReset.m[0][3];
-    //                // but don't touch y=0 values to keep floor corners
-    //                // rooted down
-
-    //                if ( updatedBounds[quad].vCorners[corner].v[1] != 0 )
-    //                {
-    //                    updatedBounds[quad].vCorners[corner].v[1]
-    //                        -= offsetUniverseCenter.m[1][3]
-    //                           //- offsetUniverseCenter.m[1][3];
-    //                           - m_universeCenterForReset.m[1][3];
-    //                }
-    //                updatedBounds[quad].vCorners[corner].v[2]
-    //                    -= offsetUniverseCenter.m[2][3]
-    //                       // - offsetUniverseCenter.m[2][3];
-    //                       - m_universeCenterForReset.m[2][3];
-
-    //                // rotate by universe center's yaw
-    //                rotateFloatCoordinates(
-    //                    updatedBounds[quad].vCorners[corner].v,
-    //                    static_cast<float>( offsetUniverseCenterYaw ) );
-    //            }
-    //        }
-
-    //        // update chaperone working set preview (this does not commit)
-    //        vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(
-    //            updatedBounds, m_collisionBoundsCountForReset );
-    //        delete[] updatedBounds;
-    //    }
 
     // Center Marker for playspace.
     if ( parent->m_chaperoneTabController.m_centerMarkerOverlayNeedsUpdate )

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -901,22 +901,22 @@ bool MoveCenterTabController::isInitComplete() const
     return m_initComplete;
 }
 
-bool MoveCenterTabController::simpleRecenter() const
-{
-    return settings::getSetting(
-        settings::BoolSetting::PLAYSPACE_simpleRecenter );
-}
+// bool MoveCenterTabController::simpleRecenter() const
+//{
+//     return settings::getSetting(
+//         settings::BoolSetting::PLAYSPACE_simpleRecenter );
+// }
 
-void MoveCenterTabController::setSimpleRecenter( bool value, bool notify )
-{
-    settings::setSetting( settings::BoolSetting::PLAYSPACE_simpleRecenter,
-                          value );
+// void MoveCenterTabController::setSimpleRecenter( bool value, bool notify )
+//{
+//     settings::setSetting( settings::BoolSetting::PLAYSPACE_simpleRecenter,
+//                           value );
 
-    if ( notify )
-    {
-        emit simpleRecenterChanged( value );
-    }
-}
+//    if ( notify )
+//    {
+//        emit simpleRecenterChanged( value );
+//    }
+//}
 
 void MoveCenterTabController::modOffsetX( float value, bool notify )
 {
@@ -965,15 +965,19 @@ void MoveCenterTabController::incomingSeatedReset()
     // if we didn't send the request from OVRAS, we need to send another
     // ResetSeatedZeroPose(). It seems that only after this is sent from
     // OVRAS does ReloadFromDisk return valid info on WMR.
-    if ( !m_selfRequestedSeatedRecenter && !simpleRecenter() )
+    if ( !m_selfRequestedSeatedRecenter )
     {
+        LOG( INFO ) << "steamvr center?";
         m_selfRequestedSeatedRecenter = true;
         vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseSeated );
+        vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseStanding );
     }
     else
     {
+        LOG( INFO ) << "not our receneter";
         updateSeatedResetData();
     }
+    // vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseSeated );
 }
 
 void MoveCenterTabController::reset()
@@ -1205,6 +1209,7 @@ void MoveCenterTabController::zeroOffsets()
 void MoveCenterTabController::sendSeatedRecenter()
 {
     vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseSeated );
+    vr::VRChaperone()->ResetZeroPose( vr::TrackingUniverseStanding );
 }
 
 double MoveCenterTabController::getHmdYawTotal()

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -899,11 +899,6 @@ void MoveCenterTabController::modOffsetZ( float value, bool notify )
 
 void MoveCenterTabController::shutdown()
 {
-    // vr::VRChaperoneSetup()->CommitWorkingCopy( vr::EChaperoneConfigFile_Live
-    // );
-    //  vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
-    //   reset();
-    //    vr::VRChaperoneSetup()->HideWorkingSetPreview();
     vr::VRChaperoneSetup()->RevertWorkingCopy();
 }
 
@@ -1067,27 +1062,6 @@ void MoveCenterTabController::zeroOffsets()
             LOG( INFO ) << "-Resetting offsets-";
         }
     }
-
-    // finished checking if out of bounds, proceed with normal zeroing
-    // offsets
-    // auto chaperoneState = vr::VRChaperone()->GetCalibrationState();
-
-    //    if ( chaperoneState < vr::ChaperoneCalibrationState_Error
-    //         || chaperoneState
-    //                == vr::ChaperoneCalibrationState_Error_PlayAreaInvalid
-    //         || m_ignoreChaperoneState )
-    //{
-    //    if ( !m_chaperoneInit )
-    //    {
-    //        m_chaperoneInit = true;
-    //        LOG( INFO ) << "Chaperone Initially Calibrated";
-    //    }
-    //    if ( chaperoneState > vr::ChaperoneCalibrationState_OK )
-    //    {
-    //        LOG( WARNING ) << "Chaperone Cal State Is warning during zero
-    //        offsets: "
-    //                       << chaperoneState;
-    //    }
     m_oldOffsetX = 0.0f;
     m_oldOffsetY = 0.0f;
     m_oldOffsetZ = 0.0f;
@@ -1140,16 +1114,6 @@ void MoveCenterTabController::zeroOffsets()
     }
 
     LOG( INFO ) << "SUCCESS: Chaperone Data Updated and Offsets zeroed out";
-    //}
-    //    else
-    //    {
-    //        if ( !m_pendingZeroOffsets )
-    //        {
-    //            LOG( INFO ) << "PENDING: Chaperone Data Update and Offsets
-    //            zeroing";
-    //        }
-    //        m_pendingZeroOffsets = true;
-    //    }
 }
 
 void MoveCenterTabController::sendSeatedRecenter()

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -454,23 +454,6 @@ void MoveCenterTabController::setFrictionPercent( int value, bool notify )
     }
 }
 
-bool MoveCenterTabController::adjustChaperone() const
-{
-    return settings::getSetting(
-        settings::BoolSetting::PLAYSPACE_adjustChaperone4 );
-}
-
-void MoveCenterTabController::setAdjustChaperone( bool value, bool notify )
-{
-    settings::setSetting( settings::BoolSetting::PLAYSPACE_adjustChaperone4,
-                          value );
-
-    if ( notify )
-    {
-        emit adjustChaperoneChanged( value );
-    }
-}
-
 bool MoveCenterTabController::moveShortcutRight() const
 {
     return settings::getSetting(

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2595,9 +2595,10 @@ void MoveCenterTabController::updateGravity()
 void MoveCenterTabController::updateSpace( bool forceUpdate )
 {
     // Do nothing if all offsets and rotation are still the same...
-    if ( m_offsetX == m_oldOffsetX && m_offsetY == m_oldOffsetY
-         && m_offsetZ == m_oldOffsetZ && m_rotation == m_oldRotation
-         && !forceUpdate )
+    if ( ( abs( m_offsetX - m_oldOffsetX ) + abs( m_offsetY - m_oldOffsetY )
+           + abs( m_offsetZ - m_oldOffsetZ ) )
+             == 0
+         && m_rotation == m_oldRotation && !forceUpdate )
     {
         return;
     }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1120,86 +1120,86 @@ void MoveCenterTabController::zeroOffsets()
 
     // finished checking if out of bounds, proceed with normal zeroing
     // offsets
-    auto chaperoneState = vr::VRChaperone()->GetCalibrationState();
-    if ( chaperoneState < vr::ChaperoneCalibrationState_Error
-         || chaperoneState
-                == vr::ChaperoneCalibrationState_Error_PlayAreaInvalid
-         || m_ignoreChaperoneState )
-    {
-        if ( !m_chaperoneInit )
-        {
-            m_chaperoneInit = true;
-            LOG( INFO ) << "Chaperone Initially Calibrated";
-        }
-        if ( chaperoneState > vr::ChaperoneCalibrationState_OK )
-        {
-            LOG( WARNING )
-                << "Chaperone Cal State Is warning during zero offsets: "
-                << chaperoneState;
-        }
-        m_oldOffsetX = 0.0f;
-        m_oldOffsetY = 0.0f;
-        m_oldOffsetZ = 0.0f;
-        m_oldRotation = 0;
-        m_offsetX = 0.0f;
-        m_offsetY = 0.0f;
-        m_offsetZ = 0.0f;
-        m_rotation = 0;
-        emit offsetXChanged( m_offsetX );
-        emit offsetYChanged( m_offsetY );
-        emit offsetZChanged( m_offsetZ );
-        emit rotationChanged( m_rotation );
-        updateChaperoneResetData();
-        m_pendingZeroOffsets = false;
-        if ( !m_chaperoneBasisAcquired )
-        {
-            m_chaperoneBasisAcquired = true;
-            if ( !m_initComplete )
-            {
-                setTrackingUniverse( vr::VRCompositor()->GetTrackingSpace() );
-                if ( parent->isPreviousShutdownSafe() )
-                {
-                    // all init complete, safe to autosave chaperone profile
-                    parent->m_chaperoneTabController.createNewAutosaveProfile();
-                    m_initComplete = true;
-                }
-                else
-                {
-                    // shutdown was unsafe last session!
-                    LOG( WARNING )
-                        << "DETECTED UNSAFE SHUTDOWN FROM LAST SESSION";
-                    m_initComplete = true;
-                    if ( !parent->crashRecoveryDisabled() )
-                    {
-                        parent->m_chaperoneTabController
-                            .applyAutosavedProfile();
-                        LOG( INFO ) << "Applying last good chaperone "
-                                       "profile autosave";
-                    }
-                }
-                // Now mark previous shutdown as unsafe in case we crash
-                // some time during this session. Previous shutdown will be
-                // marked as being safe once more just before our app shuts
-                // down properly.
-                parent->setPreviousShutdownSafe( false );
-            }
-        }
-        if ( m_roomSetupModeDetected )
-        {
-            LOG( INFO ) << "room setup EXIT detected";
-            m_roomSetupModeDetected = false;
-        }
+    // auto chaperoneState = vr::VRChaperone()->GetCalibrationState();
 
-        LOG( INFO ) << "SUCCESS: Chaperone Data Updated and Offsets zeroed out";
-    }
-    else
+    //    if ( chaperoneState < vr::ChaperoneCalibrationState_Error
+    //         || chaperoneState
+    //                == vr::ChaperoneCalibrationState_Error_PlayAreaInvalid
+    //         || m_ignoreChaperoneState )
+    //{
+    if ( !m_chaperoneInit )
     {
-        if ( !m_pendingZeroOffsets )
-        {
-            LOG( INFO ) << "PENDING: Chaperone Data Update and Offsets zeroing";
-        }
-        m_pendingZeroOffsets = true;
+        m_chaperoneInit = true;
+        LOG( INFO ) << "Chaperone Initially Calibrated";
     }
+    //    if ( chaperoneState > vr::ChaperoneCalibrationState_OK )
+    //    {
+    //        LOG( WARNING ) << "Chaperone Cal State Is warning during zero
+    //        offsets: "
+    //                       << chaperoneState;
+    //    }
+    m_oldOffsetX = 0.0f;
+    m_oldOffsetY = 0.0f;
+    m_oldOffsetZ = 0.0f;
+    m_oldRotation = 0;
+    m_offsetX = 0.0f;
+    m_offsetY = 0.0f;
+    m_offsetZ = 0.0f;
+    m_rotation = 0;
+    emit offsetXChanged( m_offsetX );
+    emit offsetYChanged( m_offsetY );
+    emit offsetZChanged( m_offsetZ );
+    emit rotationChanged( m_rotation );
+    updateChaperoneResetData();
+    m_pendingZeroOffsets = false;
+    if ( !m_chaperoneBasisAcquired )
+    {
+        m_chaperoneBasisAcquired = true;
+        if ( !m_initComplete )
+        {
+            setTrackingUniverse( vr::VRCompositor()->GetTrackingSpace() );
+            if ( parent->isPreviousShutdownSafe() )
+            {
+                // all init complete, safe to autosave chaperone profile
+                parent->m_chaperoneTabController.createNewAutosaveProfile();
+                m_initComplete = true;
+            }
+            else
+            {
+                // shutdown was unsafe last session!
+                LOG( WARNING ) << "DETECTED UNSAFE SHUTDOWN FROM LAST SESSION";
+                m_initComplete = true;
+                if ( !parent->crashRecoveryDisabled() )
+                {
+                    parent->m_chaperoneTabController.applyAutosavedProfile();
+                    LOG( INFO ) << "Applying last good chaperone "
+                                   "profile autosave";
+                }
+            }
+            // Now mark previous shutdown as unsafe in case we crash
+            // some time during this session. Previous shutdown will be
+            // marked as being safe once more just before our app shuts
+            // down properly.
+            parent->setPreviousShutdownSafe( false );
+        }
+    }
+    if ( m_roomSetupModeDetected )
+    {
+        LOG( INFO ) << "room setup EXIT detected";
+        m_roomSetupModeDetected = false;
+    }
+
+    LOG( INFO ) << "SUCCESS: Chaperone Data Updated and Offsets zeroed out";
+    //}
+    //    else
+    //    {
+    //        if ( !m_pendingZeroOffsets )
+    //        {
+    //            LOG( INFO ) << "PENDING: Chaperone Data Update and Offsets
+    //            zeroing";
+    //        }
+    //        m_pendingZeroOffsets = true;
+    //    }
 }
 
 void MoveCenterTabController::sendSeatedRecenter()
@@ -1235,14 +1235,11 @@ void MoveCenterTabController::updateSeatedResetData()
 {
     m_heightToggle = false;
     emit heightToggleChanged( m_heightToggle );
-    m_oldOffsetX = 0.0f;
-    m_oldOffsetY = 0.0f;
-    m_oldOffsetZ = 0.0f;
-    m_oldRotation = 0;
-    m_offsetX = 0.0f;
-    m_offsetY = 0.0f;
-    m_offsetZ = 0.0f;
-    m_rotation = 0;
+
+    m_oldOffsetX = m_oldOffsetY = m_oldOffsetZ = 0.0f;
+    m_oldRotation = m_rotation = 0;
+    m_offsetX = m_offsetY = m_offsetZ = 0.0f;
+
     emit offsetXChanged( m_offsetX );
     emit offsetYChanged( m_offsetY );
     emit offsetZChanged( m_offsetZ );
@@ -2135,23 +2132,24 @@ void MoveCenterTabController::zAxisLockToggle( bool zAxisLockToggleJustPressed )
 
 // END of other bindings
 
-void MoveCenterTabController::saveUncommittedChaperone()
-{
-    if ( !m_chaperoneCommitted )
-    {
-        vr::VRChaperoneSetup()->CommitWorkingCopy(
-            vr::EChaperoneConfigFile_Live );
-        vr::VRChaperoneSetup()->HideWorkingSetPreview();
-        m_chaperoneCommitted = true;
-        unsigned checkQuadCount = 0;
-        vr::VRChaperoneSetup()->GetWorkingCollisionBoundsInfo(
-            nullptr, &checkQuadCount );
-        if ( checkQuadCount > 0 )
-        {
-            parent->chaperoneUtils().loadChaperoneData( false );
-        }
-    }
-}
+// space drag update this is never called?
+// void MoveCenterTabController::saveUncommittedChaperone()
+//{
+//    if ( !m_chaperoneCommitted )
+//    {
+//        vr::VRChaperoneSetup()->CommitWorkingCopy(
+//            vr::EChaperoneConfigFile_Live );
+//        vr::VRChaperoneSetup()->HideWorkingSetPreview();
+//        m_chaperoneCommitted = true;
+//        unsigned checkQuadCount = 0;
+//        vr::VRChaperoneSetup()->GetWorkingCollisionBoundsInfo(
+//            nullptr, &checkQuadCount );
+//        if ( checkQuadCount > 0 )
+//        {
+//            parent->chaperoneUtils().loadChaperoneData( false );
+//        }
+//    }
+//}
 
 // NOTE this function will create bad output if User Rotates 180 Degrees in
 // 1/7* frame-rate. (Worst Case 30 fps = ~770 deg/s)
@@ -2769,74 +2767,76 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
 
     // As of SVR 1.13.1 The Chaperone will follow Universe Center NOT raw
     // Center as such this should be off by defualt.
-    // As of SVR 1.26.3 The chaperone seems to Have reverted back to pre 1.13.1
-    // behavior
-    // as of SVR 1.26.3 instead of 2x offset we have 1x offset and universe
-    // centerS
-    // as of SVR 1.26.4 1.26.3 changes are reverted as Such Adjust Chaperone
-    // Should Not Be Needed We Will leave in Adjust Chaperone at this point but
-    // make sure it defaults to off
+    // As of SVR 1.26.3 The chaperone seems to Have reverted back to
+    // pre 1.13.1 behavior as of SVR 1.26.3 instead of 2x offset we have 1x
+    // offset and universe centerS as of SVR 1.26.4 1.26.3 changes are
+    // reverted as Such Adjust Chaperone Should Not Be Needed We Will leave
+    // in Adjust Chaperone at this point but make sure it defaults to off
 
-    if ( adjustChaperone() )
-    {
-        // outputLogPoses();
-        // make a copy of our bounds and
-        // reorient relative to new universe center
+    //    if ( adjustChaperone() )
+    //    {
+    //        // outputLogPoses();
+    //        // make a copy of our bounds and
+    //        // reorient relative to new universe center
 
-        vr::HmdQuad_t* updatedBounds
-            = new vr::HmdQuad_t[m_collisionBoundsCountForReset];
+    //        vr::HmdQuad_t* updatedBounds
+    //            = new vr::HmdQuad_t[m_collisionBoundsCountForReset];
 
-        // for every quad in the chaperone bounds...
-        for ( unsigned quad = 0; quad < m_collisionBoundsCountForReset; quad++ )
-        {
-            // at every corner in that quad...
-            for ( unsigned corner = 0; corner < 4; corner++ )
-            {
-                // copy the corner's xyz coordinates
-                updatedBounds[quad].vCorners[corner].v[0]
-                    = m_collisionBoundsForOffset[quad].vCorners[corner].v[0];
+    //        // for every quad in the chaperone bounds...
+    //        for ( unsigned quad = 0; quad < m_collisionBoundsCountForReset;
+    //        quad++ )
+    //        {
+    //            // at every corner in that quad...
+    //            for ( unsigned corner = 0; corner < 4; corner++ )
+    //            {
+    //                // copy the corner's xyz coordinates
+    //                updatedBounds[quad].vCorners[corner].v[0]
+    //                    =
+    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[0];
 
-                updatedBounds[quad].vCorners[corner].v[1]
-                    = m_collisionBoundsForOffset[quad].vCorners[corner].v[1];
+    //                updatedBounds[quad].vCorners[corner].v[1]
+    //                    =
+    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[1];
 
-                updatedBounds[quad].vCorners[corner].v[2]
-                    = m_collisionBoundsForOffset[quad].vCorners[corner].v[2];
+    //                updatedBounds[quad].vCorners[corner].v[2]
+    //                    =
+    //                    m_collisionBoundsForOffset[quad].vCorners[corner].v[2];
 
-                // cancel universe center's xyz offsets to each corner's
-                // position and shift over by original center position so
-                // that we are mirroring the offset as reflected about the
-                // original origin
-                updatedBounds[quad].vCorners[corner].v[0]
-                    -= offsetUniverseCenter.m[0][3]
-                       // - offsetUniverseCenter.m[0][3];
-                       - m_universeCenterForReset.m[0][3];
-                // but don't touch y=0 values to keep floor corners
-                // rooted down
+    //                // cancel universe center's xyz offsets to each corner's
+    //                // position and shift over by original center position so
+    //                // that we are mirroring the offset as reflected about the
+    //                // original origin
+    //                updatedBounds[quad].vCorners[corner].v[0]
+    //                    -= offsetUniverseCenter.m[0][3]
+    //                       // - offsetUniverseCenter.m[0][3];
+    //                       - m_universeCenterForReset.m[0][3];
+    //                // but don't touch y=0 values to keep floor corners
+    //                // rooted down
 
-                if ( updatedBounds[quad].vCorners[corner].v[1] != 0 )
-                {
-                    updatedBounds[quad].vCorners[corner].v[1]
-                        -= offsetUniverseCenter.m[1][3]
-                           //- offsetUniverseCenter.m[1][3];
-                           - m_universeCenterForReset.m[1][3];
-                }
-                updatedBounds[quad].vCorners[corner].v[2]
-                    -= offsetUniverseCenter.m[2][3]
-                       // - offsetUniverseCenter.m[2][3];
-                       - m_universeCenterForReset.m[2][3];
+    //                if ( updatedBounds[quad].vCorners[corner].v[1] != 0 )
+    //                {
+    //                    updatedBounds[quad].vCorners[corner].v[1]
+    //                        -= offsetUniverseCenter.m[1][3]
+    //                           //- offsetUniverseCenter.m[1][3];
+    //                           - m_universeCenterForReset.m[1][3];
+    //                }
+    //                updatedBounds[quad].vCorners[corner].v[2]
+    //                    -= offsetUniverseCenter.m[2][3]
+    //                       // - offsetUniverseCenter.m[2][3];
+    //                       - m_universeCenterForReset.m[2][3];
 
-                // rotate by universe center's yaw
-                rotateFloatCoordinates(
-                    updatedBounds[quad].vCorners[corner].v,
-                    static_cast<float>( offsetUniverseCenterYaw ) );
-            }
-        }
+    //                // rotate by universe center's yaw
+    //                rotateFloatCoordinates(
+    //                    updatedBounds[quad].vCorners[corner].v,
+    //                    static_cast<float>( offsetUniverseCenterYaw ) );
+    //            }
+    //        }
 
-        // update chaperone working set preview (this does not commit)
-        vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(
-            updatedBounds, m_collisionBoundsCountForReset );
-        delete[] updatedBounds;
-    }
+    //        // update chaperone working set preview (this does not commit)
+    //        vr::VRChaperoneSetup()->SetWorkingCollisionBoundsInfo(
+    //            updatedBounds, m_collisionBoundsCountForReset );
+    //        delete[] updatedBounds;
+    //    }
 
     // Center Marker for playspace.
     if ( parent->m_chaperoneTabController.m_centerMarkerOverlayNeedsUpdate )
@@ -2885,63 +2885,66 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
     vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
         &offsetUniverseCenter );
 
-    if ( oldStyleMotion() )
-    {
-        // check if universe center is outside of OpenVR commit bounds (1km)
-        if ( abs( offsetUniverseCenterXyz[0] ) > k_maxOpenvrCommitOffset )
-        {
-            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of commit "
-                           "bounds ( X: "
-                        << offsetUniverseCenterXyz[0] << " )";
-            vr::HmdMatrix34_t standingZero;
-            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-                &standingZero );
-            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-            outputLogHmdMatrix( standingZero );
-            reset();
-            parent->m_chaperoneTabController.applyAutosavedProfile();
-            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-            return;
-        }
-        if ( abs( offsetUniverseCenterXyz[1] ) > k_maxOpenvrCommitOffset )
-        {
-            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of commit "
-                           "bounds ( Y: "
-                        << offsetUniverseCenterXyz[1] << " )";
-            vr::HmdMatrix34_t standingZero;
-            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-                &standingZero );
-            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-            outputLogHmdMatrix( standingZero );
-            reset();
-            parent->m_chaperoneTabController.applyAutosavedProfile();
-            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-            return;
-        }
-        if ( abs( offsetUniverseCenterXyz[2] ) > k_maxOpenvrCommitOffset )
-        {
-            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of commit "
-                           "bounds ( Z: "
-                        << offsetUniverseCenterXyz[2] << " )";
-            vr::HmdMatrix34_t standingZero;
-            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-                &standingZero );
-            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
-            outputLogHmdMatrix( standingZero );
-            reset();
-            parent->m_chaperoneTabController.applyAutosavedProfile();
-            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
-            return;
-        }
-        vr::VRChaperoneSetup()->CommitWorkingCopy(
-            vr::EChaperoneConfigFile_Live );
-        m_chaperoneCommitted = true;
-    }
-    else
-    {
-        vr::VRChaperoneSetup()->ShowWorkingSetPreview();
-        m_chaperoneCommitted = false;
-    }
+    //    if ( oldStyleMotion() )
+    //    {
+    //        // check if universe center is outside of OpenVR commit bounds
+    //        (1km) if ( abs( offsetUniverseCenterXyz[0] ) >
+    //        k_maxOpenvrCommitOffset )
+    //        {
+    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
+    //            commit "
+    //                           "bounds ( X: "
+    //                        << offsetUniverseCenterXyz[0] << " )";
+    //            vr::HmdMatrix34_t standingZero;
+    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
+    //                &standingZero );
+    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
+    //            outputLogHmdMatrix( standingZero );
+    //            reset();
+    //            parent->m_chaperoneTabController.applyAutosavedProfile();
+    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
+    //            return;
+    //        }
+    //        if ( abs( offsetUniverseCenterXyz[1] ) > k_maxOpenvrCommitOffset )
+    //        {
+    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
+    //            commit "
+    //                           "bounds ( Y: "
+    //                        << offsetUniverseCenterXyz[1] << " )";
+    //            vr::HmdMatrix34_t standingZero;
+    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
+    //                &standingZero );
+    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
+    //            outputLogHmdMatrix( standingZero );
+    //            reset();
+    //            parent->m_chaperoneTabController.applyAutosavedProfile();
+    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
+    //            return;
+    //        }
+    //        if ( abs( offsetUniverseCenterXyz[2] ) > k_maxOpenvrCommitOffset )
+    //        {
+    //            LOG( INFO ) << "COMMIT FAILED: Raw universe center out of
+    //            commit "
+    //                           "bounds ( Z: "
+    //                        << offsetUniverseCenterXyz[2] << " )";
+    //            vr::HmdMatrix34_t standingZero;
+    //            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
+    //                &standingZero );
+    //            LOG( INFO ) << "GetWorkingStandingZeroPoseToRawTrackingPose";
+    //            outputLogHmdMatrix( standingZero );
+    //            reset();
+    //            parent->m_chaperoneTabController.applyAutosavedProfile();
+    //            LOG( INFO ) << "-Resetting to autosaved chaperone profile-";
+    //            return;
+    //        }
+    //        vr::VRChaperoneSetup()->CommitWorkingCopy(
+    //            vr::EChaperoneConfigFile_Live );
+    //        m_chaperoneCommitted = true;
+    //    }
+    //
+    vr::VRChaperoneSetup()->ShowWorkingSetPreview();
+    // m_chaperoneCommitted = false;
+    //}
 
     // loadChaperoneData( false ), false so that we don't load live data,
     // and reference the working set instead.
@@ -3109,12 +3112,6 @@ void MoveCenterTabController::eventLoopTick(
         }
         updateSpace();
     }
-}
-
-void MoveCenterTabController::setIgnoreChaperoneState()
-{
-    m_ignoreChaperoneState = true;
-    LOG( INFO ) << "Ignoring Chaperone State for Zero Offsets";
 }
 
 } // namespace advsettings

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -899,10 +899,12 @@ void MoveCenterTabController::modOffsetZ( float value, bool notify )
 
 void MoveCenterTabController::shutdown()
 {
-    vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
-    // reset();
-    //  vr::VRChaperoneSetup()->HideWorkingSetPreview();
-    // vr::VRChaperoneSetup()->RevertWorkingCopy();
+    // vr::VRChaperoneSetup()->CommitWorkingCopy( vr::EChaperoneConfigFile_Live
+    // );
+    //  vr::VRChaperoneSetup()->ReloadFromDisk( vr::EChaperoneConfigFile_Live );
+    //   reset();
+    //    vr::VRChaperoneSetup()->HideWorkingSetPreview();
+    vr::VRChaperoneSetup()->RevertWorkingCopy();
 }
 
 void MoveCenterTabController::incomingSeatedReset()
@@ -1075,11 +1077,11 @@ void MoveCenterTabController::zeroOffsets()
     //                == vr::ChaperoneCalibrationState_Error_PlayAreaInvalid
     //         || m_ignoreChaperoneState )
     //{
-    if ( !m_chaperoneInit )
-    {
-        m_chaperoneInit = true;
-        LOG( INFO ) << "Chaperone Initially Calibrated";
-    }
+    //    if ( !m_chaperoneInit )
+    //    {
+    //        m_chaperoneInit = true;
+    //        LOG( INFO ) << "Chaperone Initially Calibrated";
+    //    }
     //    if ( chaperoneState > vr::ChaperoneCalibrationState_OK )
     //    {
     //        LOG( WARNING ) << "Chaperone Cal State Is warning during zero

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -128,15 +128,9 @@ class MoveCenterTabController : public QObject
             setShowLogMatricesButton NOTIFY showLogMatricesButtonChanged )
     Q_PROPERTY( bool allowExternalEdits READ allowExternalEdits WRITE
                     setAllowExternalEdits NOTIFY allowExternalEditsChanged )
-    //    Q_PROPERTY( bool oldStyleMotion READ oldStyleMotion WRITE
-    //    setOldStyleMotion
-    //                    NOTIFY oldStyleMotionChanged )
     Q_PROPERTY(
         bool universeCenteredRotation READ universeCenteredRotation WRITE
             setUniverseCenteredRotation NOTIFY universeCenteredRotationChanged )
-    //    Q_PROPERTY( bool simpleRecenter READ simpleRecenter WRITE
-    //    setSimpleRecenter
-    //                    NOTIFY simpleRecenterChanged )
     Q_PROPERTY(
         float dragMult READ dragMult WRITE setDragMult NOTIFY dragMultChanged )
 
@@ -195,7 +189,6 @@ private:
     bool m_swapDragToRightHandActivated = false;
     bool m_gravityActive = false;
     bool m_gravityReversed = false;
-    // bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_pendingSeatedRecenter = false;
     bool m_selfRequestedSeatedRecenter = false;
@@ -206,8 +199,6 @@ private:
     int m_hmdRotationStatsUpdateCounter = 0;
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
-
-    // bool m_chaperoneInit = true;
 
     // Matrix used For Center Marker
     vr::HmdMatrix34_t m_offsetmatrix = utils::k_forwardUpMatrix;
@@ -355,9 +346,7 @@ public slots:
     void setLockZ( bool value, bool notify = true );
     void setShowLogMatricesButton( bool value, bool notify = true );
     void setAllowExternalEdits( bool value, bool notify = true );
-    // void setOldStyleMotion( bool value, bool notify = true );
     void setUniverseCenteredRotation( bool value, bool notify = true );
-    //    void setSimpleRecenter( bool value, bool notify = true );
 
     void shutdown();
     void reset();
@@ -400,10 +389,7 @@ signals:
     void requireLockZChanged( bool value );
     void showLogMatricesButtonChanged( bool value );
     void allowExternalEditsChanged( bool value );
-    // void oldStyleMotionChanged( bool value );
     void universeCenteredRotationChanged( bool value );
-    //    void simpleRecenterChanged( bool value );
-
     void offsetProfilesUpdated();
 };
 

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -195,7 +195,7 @@ private:
     bool m_swapDragToRightHandActivated = false;
     bool m_gravityActive = false;
     bool m_gravityReversed = false;
-    bool m_chaperoneCommitted = true;
+    // bool m_chaperoneCommitted = true;
     bool m_pendingZeroOffsets = true;
     bool m_pendingSeatedRecenter = false;
     bool m_selfRequestedSeatedRecenter = false;
@@ -236,7 +236,7 @@ private:
     void updateSpace( bool forceUpdate = false );
     void clampVelocity( double* velocity );
     void applyChaperoneResetData();
-    void saveUncommittedChaperone();
+    // void saveUncommittedChaperone();
     void outputLogHmdMatrix( vr::HmdMatrix34_t hmdMatrix );
 
     std::vector<OffsetProfile> m_offsetProfiles;
@@ -293,7 +293,7 @@ public:
     void saveOffsetProfiles();
     Q_INVOKABLE unsigned getOffsetProfileCount();
     Q_INVOKABLE QString getOffsetProfileName( unsigned index );
-    Q_INVOKABLE void setIgnoreChaperoneState();
+    // Q_INVOKABLE void setIgnoreChaperoneState();
 
     // actions:
     void leftHandSpaceDrag( bool leftHandDragActive );

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -130,8 +130,9 @@ class MoveCenterTabController : public QObject
             setShowLogMatricesButton NOTIFY showLogMatricesButtonChanged )
     Q_PROPERTY( bool allowExternalEdits READ allowExternalEdits WRITE
                     setAllowExternalEdits NOTIFY allowExternalEditsChanged )
-    Q_PROPERTY( bool oldStyleMotion READ oldStyleMotion WRITE setOldStyleMotion
-                    NOTIFY oldStyleMotionChanged )
+    //    Q_PROPERTY( bool oldStyleMotion READ oldStyleMotion WRITE
+    //    setOldStyleMotion
+    //                    NOTIFY oldStyleMotionChanged )
     Q_PROPERTY(
         bool universeCenteredRotation READ universeCenteredRotation WRITE
             setUniverseCenteredRotation NOTIFY universeCenteredRotationChanged )
@@ -278,7 +279,7 @@ public:
     bool lockZToggle() const;
     bool showLogMatricesButton() const;
     bool allowExternalEdits() const;
-    bool oldStyleMotion() const;
+    // bool oldStyleMotion() const;
     bool universeCenteredRotation() const;
     //    bool simpleRecenter() const;
     bool isInitComplete() const;
@@ -360,7 +361,7 @@ public slots:
     void setLockZ( bool value, bool notify = true );
     void setShowLogMatricesButton( bool value, bool notify = true );
     void setAllowExternalEdits( bool value, bool notify = true );
-    void setOldStyleMotion( bool value, bool notify = true );
+    // void setOldStyleMotion( bool value, bool notify = true );
     void setUniverseCenteredRotation( bool value, bool notify = true );
     //    void setSimpleRecenter( bool value, bool notify = true );
 
@@ -406,7 +407,7 @@ signals:
     void requireLockZChanged( bool value );
     void showLogMatricesButtonChanged( bool value );
     void allowExternalEditsChanged( bool value );
-    void oldStyleMotionChanged( bool value );
+    // void oldStyleMotionChanged( bool value );
     void universeCenteredRotationChanged( bool value );
     //    void simpleRecenterChanged( bool value );
 

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -89,8 +89,6 @@ class MoveCenterTabController : public QObject
                     NOTIFY smoothTurnRateChanged )
     Q_PROPERTY( int frictionPercent READ frictionPercent WRITE
                     setFrictionPercent NOTIFY frictionPercentChanged )
-    Q_PROPERTY( bool adjustChaperone READ adjustChaperone WRITE
-                    setAdjustChaperone NOTIFY adjustChaperoneChanged )
     Q_PROPERTY( bool moveShortcutRight READ moveShortcutRight WRITE
                     setMoveShortcutRight NOTIFY moveShortcutRightChanged )
     Q_PROPERTY( bool moveShortcutLeft READ moveShortcutLeft WRITE
@@ -258,7 +256,6 @@ public:
     int snapTurnAngle() const;
     int smoothTurnRate() const;
     int frictionPercent() const;
-    bool adjustChaperone() const;
     bool moveShortcutRight() const;
     bool moveShortcutLeft() const;
     bool turnBindRight() const;
@@ -279,9 +276,7 @@ public:
     bool lockZToggle() const;
     bool showLogMatricesButton() const;
     bool allowExternalEdits() const;
-    // bool oldStyleMotion() const;
     bool universeCenteredRotation() const;
-    //    bool simpleRecenter() const;
     bool isInitComplete() const;
     double getHmdYawTotal();
     void resetHmdYawTotal();
@@ -335,7 +330,6 @@ public slots:
     void setSmoothTurnRate( int value, bool notify = true );
     void setFrictionPercent( int value, bool notify = true );
 
-    void setAdjustChaperone( bool value, bool notify = true );
     void setMoveShortcutRight( bool value, bool notify = true );
     void setMoveShortcutLeft( bool value, bool notify = true );
     void setTurnBindRight( bool value, bool notify = true );
@@ -386,7 +380,6 @@ signals:
     void snapTurnAngleChanged( int value );
     void smoothTurnRateChanged( int value );
     void frictionPercentChanged( int value );
-    void adjustChaperoneChanged( bool value );
     void moveShortcutRightChanged( bool value );
     void moveShortcutLeftChanged( bool value );
     void turnBindRightChanged( bool value );

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -207,7 +207,7 @@ private:
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
 
-    bool m_chaperoneInit = true;
+    // bool m_chaperoneInit = true;
 
     // Matrix used For Center Marker
     vr::HmdMatrix34_t m_offsetmatrix = utils::k_forwardUpMatrix;

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -135,8 +135,9 @@ class MoveCenterTabController : public QObject
     Q_PROPERTY(
         bool universeCenteredRotation READ universeCenteredRotation WRITE
             setUniverseCenteredRotation NOTIFY universeCenteredRotationChanged )
-    Q_PROPERTY( bool simpleRecenter READ simpleRecenter WRITE setSimpleRecenter
-                    NOTIFY simpleRecenterChanged )
+    //    Q_PROPERTY( bool simpleRecenter READ simpleRecenter WRITE
+    //    setSimpleRecenter
+    //                    NOTIFY simpleRecenterChanged )
     Q_PROPERTY(
         float dragMult READ dragMult WRITE setDragMult NOTIFY dragMultChanged )
 
@@ -279,7 +280,7 @@ public:
     bool allowExternalEdits() const;
     bool oldStyleMotion() const;
     bool universeCenteredRotation() const;
-    bool simpleRecenter() const;
+    //    bool simpleRecenter() const;
     bool isInitComplete() const;
     double getHmdYawTotal();
     void resetHmdYawTotal();
@@ -361,7 +362,7 @@ public slots:
     void setAllowExternalEdits( bool value, bool notify = true );
     void setOldStyleMotion( bool value, bool notify = true );
     void setUniverseCenteredRotation( bool value, bool notify = true );
-    void setSimpleRecenter( bool value, bool notify = true );
+    //    void setSimpleRecenter( bool value, bool notify = true );
 
     void shutdown();
     void reset();
@@ -407,7 +408,7 @@ signals:
     void allowExternalEditsChanged( bool value );
     void oldStyleMotionChanged( bool value );
     void universeCenteredRotationChanged( bool value );
-    void simpleRecenterChanged( bool value );
+    //    void simpleRecenterChanged( bool value );
 
     void offsetProfilesUpdated();
 };

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -2,6 +2,7 @@
 #include <QQuickWindow>
 #include "../overlaycontroller.h"
 #include "../utils/update_rate.h"
+#include <QDesktopServices>
 
 QT_USE_NAMESPACE
 
@@ -447,6 +448,12 @@ void SteamVRTabController::launchBindingUI()
     {
         LOG( ERROR )
             << "failed to get input handle? is your right controller on?";
+    }
+    if ( parent->isDesktopMode() )
+    {
+        QDesktopServices::openUrl(
+            QUrl( "http://127.0.0.1:27062/dashboard/controllerbinding.html" ) );
+        return;
     }
     auto error = vr::VRInput()->OpenBindingUI(
         application_strings::applicationKey, actionHandle, inputHandle, false );

--- a/src/tabcontrollers/SteamVRTabController.cpp
+++ b/src/tabcontrollers/SteamVRTabController.cpp
@@ -41,6 +41,8 @@ void SteamVRTabController::synchSteamVR()
     setCameraActive( cameraActive() );
     setCameraCont( cameraCont() );
     setCameraBounds( cameraBounds() );
+    setControllerPower( controllerPower() );
+    setNoHMD( noHMD() );
 }
 
 bool SteamVRTabController::performanceGraph() const
@@ -67,6 +69,33 @@ void SteamVRTabController::setPerformanceGraph( const bool value,
         if ( notify )
         {
             emit performanceGraphChanged( m_performanceGraphToggle );
+        }
+    }
+}
+
+bool SteamVRTabController::noHMD() const
+{
+    auto p = ovr_settings_wrapper::getBool(
+        vr::k_pch_SteamVR_Section, vr::k_pch_SteamVR_RequireHmd_String );
+
+    if ( p.first == ovr_settings_wrapper::SettingsError::NoError )
+    {
+        return p.second;
+    }
+    return m_noHMD;
+}
+
+void SteamVRTabController::setNoHMD( const bool value, const bool notify )
+{
+    if ( m_noHMD != value )
+    {
+        m_noHMD = value;
+        ovr_settings_wrapper::setBool( vr::k_pch_SteamVR_Section,
+                                       vr::k_pch_SteamVR_RequireHmd_String,
+                                       m_noHMD );
+        if ( notify )
+        {
+            emit noHMDChanged( m_noHMD );
         }
     }
 }
@@ -125,6 +154,35 @@ void SteamVRTabController::setNoFadeToGrid( const bool value,
         if ( notify )
         {
             emit noFadeToGridChanged( m_noFadeToGridToggle );
+        }
+    }
+}
+
+bool SteamVRTabController::controllerPower() const
+{
+    auto p = ovr_settings_wrapper::getBool(
+        vr::k_pch_Power_Section,
+        vr::k_pch_Power_AutoLaunchSteamVROnButtonPress );
+    if ( p.first == ovr_settings_wrapper::SettingsError::NoError )
+    {
+        return p.second;
+    }
+    return m_controllerPower;
+}
+
+void SteamVRTabController::setControllerPower( const bool value,
+                                               const bool notify )
+{
+    if ( m_controllerPower != value )
+    {
+        m_controllerPower = value;
+        ovr_settings_wrapper::setBool(
+            vr::k_pch_Power_Section,
+            vr::k_pch_Power_AutoLaunchSteamVROnButtonPress,
+            m_controllerPower );
+        if ( notify )
+        {
+            emit controllerPowerChanged( m_controllerPower );
         }
     }
 }

--- a/src/tabcontrollers/SteamVRTabController.h
+++ b/src/tabcontrollers/SteamVRTabController.h
@@ -65,6 +65,9 @@ class SteamVRTabController : public QObject
                     cameraContChanged )
     Q_PROPERTY( bool perAppBindEnabled READ perAppBindEnabled WRITE
                     setPerAppBindEnabled NOTIFY perAppBindEnabledChanged )
+    Q_PROPERTY( bool controllerPower READ controllerPower WRITE
+                    setControllerPower NOTIFY controllerPowerChanged )
+    Q_PROPERTY( bool noHMD READ noHMD WRITE setNoHMD NOTIFY noHMDChanged )
 
 private:
     OverlayController* parent;
@@ -74,6 +77,8 @@ private:
     bool m_noFadeToGridToggle = false;
     bool m_multipleDriverToggle = false;
     bool m_dnd = false;
+    bool m_controllerPower = false;
+    bool m_noHMD = false;
     QNetworkAccessManager m_networkManagerApply;
     QNetworkAccessManager m_networkManagerUrl;
     QNetworkAccessManager m_networkManagerBind;
@@ -112,6 +117,8 @@ public:
     bool multipleDriver() const;
     bool systemButton() const;
     bool dnd() const;
+    bool controllerPower() const;
+    bool noHMD() const;
 
     bool cameraActive() const;
     bool cameraBounds() const;
@@ -163,6 +170,8 @@ public slots:
     void setNoFadeToGrid( bool value, bool notify = true );
     void setMultipleDriver( bool value, bool notify = true );
     void setDND( bool value, bool notify = true );
+    void setControllerPower( bool value, bool notify = true );
+    void setNoHMD( bool value, bool notify = true );
 
     void setCameraActive( bool value, bool notify = true );
     void setCameraBounds( bool value, bool notify = true );
@@ -182,6 +191,8 @@ signals:
     void systemButtonChanged( bool value );
     void noFadeToGridChanged( bool value );
     void dNDChanged( bool value );
+    void controllerPowerChanged( bool value );
+    void noHMDChanged( bool value );
 
     void cameraActiveChanged( bool value );
     void cameraBoundsChanged( bool value );

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -204,6 +204,26 @@ void UtilitiesTabController::setVrcDebug( bool value, bool notify )
     }
 }
 
+bool UtilitiesTabController::trackerOvlEnabled() const
+{
+    return settings::getSetting(
+        settings::BoolSetting::UTILITY_trackerOverlayEnabled );
+}
+
+void UtilitiesTabController::setTrackerOvlEnabled( bool value, bool notify )
+{
+    settings::setSetting( settings::BoolSetting::UTILITY_trackerOverlayEnabled,
+                          value );
+    if ( notify )
+    {
+        emit trackerOvlEnabledChanged( value );
+    }
+    if ( !value )
+    {
+        destroyBatteryOverlays();
+    }
+}
+
 QString getBatteryIconPath( int batteryState )
 {
     constexpr auto batteryPrefix = "/res/img/battery/battery_";
@@ -224,8 +244,9 @@ QString getBatteryIconPath( int batteryState )
     return QString::fromStdString( *batteryPath );
 }
 
-vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index,
-                                            unsigned style = 0 )
+vr::VROverlayHandle_t UtilitiesTabController::createBatteryOverlay(
+    vr::TrackedDeviceIndex_t index,
+    unsigned style )
 {
     vr::VROverlayHandle_t handle = vr::k_ulOverlayHandleInvalid;
     std::string batteryKey = std::string( application_strings::applicationKey )
@@ -273,14 +294,22 @@ vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index,
     return handle;
 }
 
-void UtilitiesTabController::eventLoopTick()
+void UtilitiesTabController::destroyBatteryOverlays()
 {
-    if ( updateRate.shouldSubjectNotRun(
-             UpdateSubject::UtilitiesTabController ) )
+    for ( auto& el : m_batteryOverlayHandles )
     {
-        return;
+        auto err = vr::VROverlay()->DestroyOverlay( el );
+        el = 0;
+        if ( err != vr::VROverlayError_None )
+        {
+            LOG( ERROR ) << "Could not Delete Battery Overlay: "
+                         << vr::VROverlay()->GetOverlayErrorNameFromEnum( err );
+        }
     }
+}
 
+void UtilitiesTabController::handleTrackerBatOvl()
+{
     // attach battery overlay to all tracked devices that aren't a
     // controller or hmd
     for ( vr::TrackedDeviceIndex_t i = 0; i < vr::k_unMaxTrackedDeviceCount;
@@ -361,6 +390,19 @@ void UtilitiesTabController::eventLoopTick()
                 }
             }
         }
+    }
+}
+
+void UtilitiesTabController::eventLoopTick()
+{
+    if ( updateRate.shouldSubjectNotRun(
+             UpdateSubject::UtilitiesTabController ) )
+    {
+        return;
+    }
+    if ( trackerOvlEnabled() )
+    {
+        handleTrackerBatOvl();
     }
 }
 

--- a/src/tabcontrollers/UtilitiesTabController.cpp
+++ b/src/tabcontrollers/UtilitiesTabController.cpp
@@ -298,6 +298,10 @@ void UtilitiesTabController::destroyBatteryOverlays()
 {
     for ( auto& el : m_batteryOverlayHandles )
     {
+        if ( el == 0 )
+        {
+            continue;
+        }
         auto err = vr::VROverlay()->DestroyOverlay( el );
         el = 0;
         if ( err != vr::VROverlayError_None )

--- a/src/tabcontrollers/UtilitiesTabController.h
+++ b/src/tabcontrollers/UtilitiesTabController.h
@@ -21,6 +21,8 @@ class UtilitiesTabController : public QObject
     Q_OBJECT
     Q_PROPERTY(
         bool vrcDebug READ vrcDebug WRITE setVrcDebug NOTIFY vrcDebugChanged )
+    Q_PROPERTY( bool trackerOvlEnabled READ trackerOvlEnabled WRITE
+                    setTrackerOvlEnabled NOTIFY trackerOvlEnabledChanged )
 
 private:
     OverlayController* m_parent;
@@ -31,6 +33,10 @@ private:
         = { 0 };
     int m_batteryState[vr::k_unMaxTrackedDeviceCount];
     bool m_batteryVisible[vr::k_unMaxTrackedDeviceCount];
+    void handleTrackerBatOvl();
+    vr::VROverlayHandle_t createBatteryOverlay( vr::TrackedDeviceIndex_t index,
+                                                unsigned style = 0 );
+    void destroyBatteryOverlays();
 
 public:
     void initStage2( OverlayController* var_parent );
@@ -38,6 +44,7 @@ public:
     void eventLoopTick();
 
     bool vrcDebug() const;
+    bool trackerOvlEnabled() const;
 
 public slots:
     void sendKeyboardInput( QString input );
@@ -76,9 +83,11 @@ public slots:
     Q_INVOKABLE void sendKeyboardThree();
 
     void setVrcDebug( bool value, bool notify = true );
+    void setTrackerOvlEnabled( bool value, bool notify = true );
 
 signals:
     void vrcDebugChanged( bool value );
+    void trackerOvlEnabledChanged( bool value );
 };
 
 } // namespace advsettings

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 8, "patch": 1, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 2, "updateMessage": "", "optionalMessage": "" }

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 5, "patch": 0, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 0, "updateMessage": "", "optionalMessage": "" }

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 8, "patch": 2, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 3, "updateMessage": "", "optionalMessage": "" }

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 8, "patch": 0, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 1, "updateMessage": "", "optionalMessage": "" }


### PR DESCRIPTION
# 5.8.3

## Features
- **Battery Tracker overlay control** - ability in utility tab to now disable the overlay for batteries on trackers if you don't want it.
- **Desktop Mode Improvements**
  - **Steam launch option** on steam there should be an option to launch into desktop mode (this is just the `--desktop-mode` parameter)
  - **Always launch as Desktop Mode** in settings tab you will now have a checkbox to always launch as desktop mode, if the screen is blank I would recommend this as an option as it is fully functional now, just will not be in the SteamVR dashboard.
  - **Bindings Tab on Desktop** this will now open your default browser to the SteamVR binding interface, it varies slightly from overlay version as you will have to navigate to OVRAS instead of being dropped directly on the screen.
- **Added F13-F19** as Keyboard Options via `G3-G9`
- **No HMD Toggle** in SteamVR tab added toggle to change steamvr setting to not require an HMD
- **Power Button launches SteamVR** in SteamVR tab added toggle to change steamvr setting on whether or not controller button will turn on steamVR

## Bug Fixes
- **Space Drag Changes** - Removed some checks to fix an issue where users could not drag out of the box. This fix should mainly effect non Lighthouse users.
- **initialization Changes** - Will now retry SteamVR initialization if it does not work - this may not work 100% as intended and is something to watch, this may fix some of the automatic crashing users were having.

## Misc

- **Removed old-style motion** This was mostly a legacy feature, and with testing I don't think this feature is required any longer
- **Removed adjust chaperone** This Feature is no longer required due to recent-ish changes to chaperone behavior from Valve
- Made Some Minor Changes to Space Drag code to optimize it slightly
- **Removed Simple Recenter** Was not exposed to users, and was just dead code.

## Known Issues
- In some set-ups when you start to "drag" you may "jump" a little bit - this should be same as current behavior, and I'm investigating, creating and applying a chaperone profile fixes this issue if it bothers you
- Closing The Desktop Window **WILL NOT** save settings, either exit VR or exit ovras through settings->shutdown option
- Auto apply chaperone profile causes room setup to pseudo-launch, it will disappear in ~30 seconds, you can close it, or launch games over it, this appears to only be

## WMR support
- Should now be considered deprecated, **Everything will continue to work as is**, It's more a matter of support if specific features break for WMR only they will not be recieving updates.