### PR TITLE
5.8.11

### DIFF
--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.8.9-release
+5.8.10-release

--- a/build_scripts/compile_version_string.txt
+++ b/build_scripts/compile_version_string.txt
@@ -1,1 +1,1 @@
-5.8.10-release
+5.8.11-release

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1359,72 +1359,72 @@ void OverlayController::mainEventLoop()
     }
 }
 
-void OverlayController::AddOffsetToUniverseCenter(
-    vr::ETrackingUniverseOrigin universe,
-    unsigned axisId,
-    float offset,
-    bool adjustBounds,
-    bool commit )
-{
-    float offsetArray[3] = { 0, 0, 0 };
-    offsetArray[axisId] = offset;
-    AddOffsetToUniverseCenter( universe, offsetArray, adjustBounds, commit );
-}
+// void OverlayController::AddOffsetToUniverseCenter(
+//     vr::ETrackingUniverseOrigin universe,
+//     unsigned axisId,
+//     float offset,
+//     bool adjustBounds,
+//     bool commit )
+//{
+//     float offsetArray[3] = { 0, 0, 0 };
+//     offsetArray[axisId] = offset;
+//     AddOffsetToUniverseCenter( universe, offsetArray, adjustBounds, commit );
+// }
 
-void OverlayController::AddOffsetToUniverseCenter(
-    vr::ETrackingUniverseOrigin universe,
-    float offset[3],
-    bool adjustBounds,
-    bool commit )
-{
-    if ( offset[0] != 0.0f || offset[1] != 0.0f || offset[2] != 0.0f )
-    {
-        if ( commit )
-        {
-            vr::VRChaperoneSetup()->HideWorkingSetPreview();
-            vr::VRChaperoneSetup()->RevertWorkingCopy();
-        }
-        vr::HmdMatrix34_t curPos;
-        if ( universe == vr::TrackingUniverseStanding )
-        {
-            vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-                &curPos );
-        }
-        else
-        {
-            vr::VRChaperoneSetup()->GetWorkingSeatedZeroPoseToRawTrackingPose(
-                &curPos );
-        }
-        for ( int i = 0; i < 3; i++ )
-        {
-            curPos.m[0][3] += curPos.m[0][i] * offset[i];
-            curPos.m[1][3] += curPos.m[1][i] * offset[i];
-            curPos.m[2][3] += curPos.m[2][i] * offset[i];
-        }
-        if ( universe == vr::TrackingUniverseStanding )
-        {
-            vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
-                &curPos );
-        }
-        else
-        {
-            vr::VRChaperoneSetup()->SetWorkingSeatedZeroPoseToRawTrackingPose(
-                &curPos );
-        }
-        if ( adjustBounds && universe == vr::TrackingUniverseStanding )
-        {
-            float collisionOffset[] = { -offset[0], -offset[1], -offset[2] };
-            AddOffsetToCollisionBounds( collisionOffset, false );
-        }
-        if ( commit )
-        {
-            vr::VRChaperoneSetup()->CommitWorkingCopy(
-                vr::EChaperoneConfigFile_Live );
-            vr::VRChaperoneSetup()->ReloadFromDisk(
-                vr::EChaperoneConfigFile_Temp );
-        }
-    }
-}
+// void OverlayController::AddOffsetToUniverseCenter(
+//     vr::ETrackingUniverseOrigin universe,
+//     float offset[3],
+//     bool adjustBounds,
+//     bool commit )
+//{
+//     if ( offset[0] != 0.0f || offset[1] != 0.0f || offset[2] != 0.0f )
+//     {
+//         if ( commit )
+//         {
+//             vr::VRChaperoneSetup()->HideWorkingSetPreview();
+//             vr::VRChaperoneSetup()->RevertWorkingCopy();
+//         }
+//         vr::HmdMatrix34_t curPos;
+//         if ( universe == vr::TrackingUniverseStanding )
+//         {
+//             vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
+//                 &curPos );
+//         }
+//         else
+//         {
+//             vr::VRChaperoneSetup()->GetWorkingSeatedZeroPoseToRawTrackingPose(
+//                 &curPos );
+//         }
+//         for ( int i = 0; i < 3; i++ )
+//         {
+//             curPos.m[0][3] += curPos.m[0][i] * offset[i];
+//             curPos.m[1][3] += curPos.m[1][i] * offset[i];
+//             curPos.m[2][3] += curPos.m[2][i] * offset[i];
+//         }
+//         if ( universe == vr::TrackingUniverseStanding )
+//         {
+//             vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
+//                 &curPos );
+//         }
+//         else
+//         {
+//             vr::VRChaperoneSetup()->SetWorkingSeatedZeroPoseToRawTrackingPose(
+//                 &curPos );
+//         }
+//         if ( adjustBounds && universe == vr::TrackingUniverseStanding )
+//         {
+//             float collisionOffset[] = { -offset[0], -offset[1], -offset[2] };
+//             AddOffsetToCollisionBounds( collisionOffset, false );
+//         }
+//         if ( commit )
+//         {
+//             vr::VRChaperoneSetup()->CommitWorkingCopy(
+//                 vr::EChaperoneConfigFile_Live );
+//             vr::VRChaperoneSetup()->ReloadFromDisk(
+//                 vr::EChaperoneConfigFile_Temp );
+//         }
+//     }
+// }
 
 void OverlayController::RotateUniverseCenter(
     vr::ETrackingUniverseOrigin universe,

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -861,23 +861,6 @@ void OverlayController::setExclusiveInputEnabled( bool value, bool notify )
         emit exclusiveInputEnabledChanged( value );
     }
 }
-
-/*void OverlayController::setOpenXRFixEnabled( bool value, bool notify )
-{
-    settings::setSetting( settings::BoolSetting::APPLICATION_openXRWorkAround,
-                          value );
-    if ( notify )
-    {
-        emit openXRFixEnabledChanged( value );
-    }
-}
-
-bool OverlayController::openXRFixEnabled() const
-{
-    return settings::getSetting(
-        settings::BoolSetting::APPLICATION_openXRWorkAround );
-}*/
-
 void OverlayController::setAutoApplyChaperoneEnabled( bool value, bool notify )
 {
     settings::setSetting( settings::BoolSetting::APPLICATION_autoApplyChaperone,
@@ -1363,73 +1346,6 @@ void OverlayController::mainEventLoop()
         }
     }
 }
-
-// void OverlayController::AddOffsetToUniverseCenter(
-//     vr::ETrackingUniverseOrigin universe,
-//     unsigned axisId,
-//     float offset,
-//     bool adjustBounds,
-//     bool commit )
-//{
-//     float offsetArray[3] = { 0, 0, 0 };
-//     offsetArray[axisId] = offset;
-//     AddOffsetToUniverseCenter( universe, offsetArray, adjustBounds, commit );
-// }
-
-// void OverlayController::AddOffsetToUniverseCenter(
-//     vr::ETrackingUniverseOrigin universe,
-//     float offset[3],
-//     bool adjustBounds,
-//     bool commit )
-//{
-//     if ( offset[0] != 0.0f || offset[1] != 0.0f || offset[2] != 0.0f )
-//     {
-//         if ( commit )
-//         {
-//             vr::VRChaperoneSetup()->HideWorkingSetPreview();
-//             vr::VRChaperoneSetup()->RevertWorkingCopy();
-//         }
-//         vr::HmdMatrix34_t curPos;
-//         if ( universe == vr::TrackingUniverseStanding )
-//         {
-//             vr::VRChaperoneSetup()->GetWorkingStandingZeroPoseToRawTrackingPose(
-//                 &curPos );
-//         }
-//         else
-//         {
-//             vr::VRChaperoneSetup()->GetWorkingSeatedZeroPoseToRawTrackingPose(
-//                 &curPos );
-//         }
-//         for ( int i = 0; i < 3; i++ )
-//         {
-//             curPos.m[0][3] += curPos.m[0][i] * offset[i];
-//             curPos.m[1][3] += curPos.m[1][i] * offset[i];
-//             curPos.m[2][3] += curPos.m[2][i] * offset[i];
-//         }
-//         if ( universe == vr::TrackingUniverseStanding )
-//         {
-//             vr::VRChaperoneSetup()->SetWorkingStandingZeroPoseToRawTrackingPose(
-//                 &curPos );
-//         }
-//         else
-//         {
-//             vr::VRChaperoneSetup()->SetWorkingSeatedZeroPoseToRawTrackingPose(
-//                 &curPos );
-//         }
-//         if ( adjustBounds && universe == vr::TrackingUniverseStanding )
-//         {
-//             float collisionOffset[] = { -offset[0], -offset[1], -offset[2] };
-//             AddOffsetToCollisionBounds( collisionOffset, false );
-//         }
-//         if ( commit )
-//         {
-//             vr::VRChaperoneSetup()->CommitWorkingCopy(
-//                 vr::EChaperoneConfigFile_Live );
-//             vr::VRChaperoneSetup()->ReloadFromDisk(
-//                 vr::EChaperoneConfigFile_Temp );
-//         }
-//     }
-// }
 
 void OverlayController::RotateUniverseCenter(
     vr::ETrackingUniverseOrigin universe,

--- a/src/overlaycontroller.cpp
+++ b/src/overlaycontroller.cpp
@@ -1268,6 +1268,11 @@ void OverlayController::mainEventLoop()
                 m_chaperoneUtils.loadChaperoneData();
                 chaperoneDataAlreadyUpdated = true;
             }
+            if ( previousUniverseId == 0
+                 && !m_moveCenterTabController.isInitComplete() )
+            {
+                m_moveCenterTabController.zeroOffsets();
+            }
         }
         break;
         case vr::VREvent_Input_ActionManifestReloaded:

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -200,15 +200,15 @@ public:
                     const std::string& name,
                     const std::string& key = "" );
 
-    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
-                                    unsigned axisId,
-                                    float offset,
-                                    bool adjustBounds = true,
-                                    bool commit = true );
-    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
-                                    float offset[3],
-                                    bool adjustBounds = true,
-                                    bool commit = true );
+    //    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
+    //                                    unsigned axisId,
+    //                                    float offset,
+    //                                    bool adjustBounds = true,
+    //                                    bool commit = true );
+    //    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
+    //                                    float offset[3],
+    //                                    bool adjustBounds = true,
+    //                                    bool commit = true );
     void RotateUniverseCenter( vr::ETrackingUniverseOrigin universe,
                                float yAngle,
                                bool adjustBounds = true,

--- a/src/overlaycontroller.h
+++ b/src/overlaycontroller.h
@@ -200,15 +200,6 @@ public:
                     const std::string& name,
                     const std::string& key = "" );
 
-    //    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
-    //                                    unsigned axisId,
-    //                                    float offset,
-    //                                    bool adjustBounds = true,
-    //                                    bool commit = true );
-    //    void AddOffsetToUniverseCenter( vr::ETrackingUniverseOrigin universe,
-    //                                    float offset[3],
-    //                                    bool adjustBounds = true,
-    //                                    bool commit = true );
     void RotateUniverseCenter( vr::ETrackingUniverseOrigin universe,
                                float yAngle,
                                bool adjustBounds = true,

--- a/src/res/qml/FixFloorPage.qml
+++ b/src/res/qml/FixFloorPage.qml
@@ -93,7 +93,7 @@ MyStackViewPage {
             text: "Apply Space Settings Offsets as Center"
             Layout.preferredHeight: 80
             onClicked: {
-                MoveCenterTabController.zeroOffsets()
+                MoveCenterTabController.addCurOffsetAsCenter()
             }
         }
 

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -302,25 +302,12 @@ void FixFloorTabController::fixFloorClicked()
 void FixFloorTabController::recenterClicked()
 {
     parent->m_moveCenterTabController.sendSeatedRecenter();
-    //    statusMessage = "Fixing ...";
-    //    statusMessageTimeout = 1.0;
-    //    emit statusMessageSignal();
-    //    emit measureStartSignal();
-    //    measurementCount = 0;
-    //    state = 2;
 }
 
 void FixFloorTabController::undoFixFloorClicked()
 {
-    // parent->m_moveCenterTabController.reset();
     float off[3] = { -floorOffsetX, -floorOffsetY, -floorOffsetZ };
     parent->m_moveCenterTabController.addOffset( off );
-    //    parent->AddOffsetToUniverseCenter(
-    //        vr::TrackingUniverseStanding, 0, -floorOffsetX, false );
-    //    parent->AddOffsetToUniverseCenter(
-    //        vr::TrackingUniverseStanding, 1, -floorOffsetY, false );
-    //    parent->AddOffsetToUniverseCenter(
-    //        vr::TrackingUniverseStanding, 2, -floorOffsetZ, false );
     LOG( INFO ) << "Fix Floor: Undo Floor Offset = [" << -floorOffsetX << ", "
                 << -floorOffsetY << ", " << -floorOffsetZ << "]";
     floorOffsetY = 0.0f;

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -207,8 +207,7 @@ void FixFloorTabController::dashboardLoopTick(
                     offset[0] = floorOffsetX;
                     offset[2] = floorOffsetZ;
                 }
-                parent->AddOffsetToUniverseCenter(
-                    vr::TrackingUniverseStanding, offset, true );
+                parent->m_moveCenterTabController.addOffset( offset );
                 statusMessage
                     = ( state == 2 ) ? "Recentering ... Ok" : "Fixing ... OK";
                 statusMessageTimeout = 1.0;
@@ -313,13 +312,15 @@ void FixFloorTabController::recenterClicked()
 
 void FixFloorTabController::undoFixFloorClicked()
 {
-    parent->m_moveCenterTabController.reset();
-    parent->AddOffsetToUniverseCenter(
-        vr::TrackingUniverseStanding, 0, -floorOffsetX, false );
-    parent->AddOffsetToUniverseCenter(
-        vr::TrackingUniverseStanding, 1, -floorOffsetY, false );
-    parent->AddOffsetToUniverseCenter(
-        vr::TrackingUniverseStanding, 2, -floorOffsetZ, false );
+    // parent->m_moveCenterTabController.reset();
+    float off[3] = { -floorOffsetX, -floorOffsetY, -floorOffsetZ };
+    parent->m_moveCenterTabController.addOffset( off );
+    //    parent->AddOffsetToUniverseCenter(
+    //        vr::TrackingUniverseStanding, 0, -floorOffsetX, false );
+    //    parent->AddOffsetToUniverseCenter(
+    //        vr::TrackingUniverseStanding, 1, -floorOffsetY, false );
+    //    parent->AddOffsetToUniverseCenter(
+    //        vr::TrackingUniverseStanding, 2, -floorOffsetZ, false );
     LOG( INFO ) << "Fix Floor: Undo Floor Offset = [" << -floorOffsetX << ", "
                 << -floorOffsetY << ", " << -floorOffsetZ << "]";
     floorOffsetY = 0.0f;

--- a/src/tabcontrollers/FixFloorTabController.cpp
+++ b/src/tabcontrollers/FixFloorTabController.cpp
@@ -302,13 +302,13 @@ void FixFloorTabController::fixFloorClicked()
 
 void FixFloorTabController::recenterClicked()
 {
-    parent->m_moveCenterTabController.reset();
-    statusMessage = "Fixing ...";
-    statusMessageTimeout = 1.0;
-    emit statusMessageSignal();
-    emit measureStartSignal();
-    measurementCount = 0;
-    state = 2;
+    parent->m_moveCenterTabController.sendSeatedRecenter();
+    //    statusMessage = "Fixing ...";
+    //    statusMessageTimeout = 1.0;
+    //    emit statusMessageSignal();
+    //    emit measureStartSignal();
+    //    measurementCount = 0;
+    //    state = 2;
 }
 
 void FixFloorTabController::undoFixFloorClicked()

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1125,15 +1125,18 @@ void MoveCenterTabController::zeroOffsets()
                                       "Creation of Auto-save!: "
                                    << calState;
                 }
-                // all init complete, safe to autosave chaperone profile
-                parent->m_chaperoneTabController.createNewAutosaveProfile();
-                m_initComplete = true;
+                else
+                {
+                    // all init complete, safe to autosave chaperone profile
+                    parent->m_chaperoneTabController.createNewAutosaveProfile();
+                    m_initComplete = true;
+                }
             }
             else
             {
                 // shutdown was unsafe last session!
                 LOG( WARNING ) << "DETECTED UNSAFE SHUTDOWN FROM LAST SESSION";
-                m_initComplete = true;
+                m_initComplete = false;
                 if ( !parent->crashRecoveryDisabled() )
                 {
                     parent->m_chaperoneTabController.applyAutosavedProfile();

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2517,7 +2517,7 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
         return;
     }
     if ( ( abs( m_offsetX ) + abs( m_offsetY ) + abs( m_offsetZ )
-           + abs( m_rotation ) )
+           + abs( static_cast<float>( m_rotation ) ) )
              == 0
          && !forceUpdate )
     {

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -2494,13 +2494,17 @@ void MoveCenterTabController::updateSpace( bool forceUpdate )
              == 0
          && m_rotation == m_oldRotation && !forceUpdate )
     {
+        return;
+    }
+    if ( ( abs( m_offsetX ) + abs( m_offsetY ) + abs( m_offsetZ )
+           + abs( m_rotation ) )
+         == 0 )
+    {
         if ( !m_chaperoneHasCommit )
         {
             m_chaperoneHasCommit = true;
             updateChaperoneResetData();
         }
-
-        return;
     }
     m_chaperoneHasCommit = false;
 

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1119,11 +1119,11 @@ void MoveCenterTabController::zeroOffsets()
             if ( parent->isPreviousShutdownSafe() )
             {
                 auto calState = vr::VRChaperone()->GetCalibrationState();
-                if ( calState > 199 )
+                if ( calState == 200 )
                 {
-                    LOG( WARNING ) << "Calibration state is in Error on "
-                                      "Creation of Auto-save!: "
-                                   << calState;
+                    LOG( WARNING )
+                        << "Chaperone State Does Not Exist Yet, will wait for "
+                           "universe change to finish initialization";
                 }
                 else
                 {

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1123,13 +1123,10 @@ void MoveCenterTabController::zeroOffsets()
                 {
                     LOG( WARNING ) << "Calibration state is in Error on "
                                       "Creation of Auto-save!: "
-                                   << calState << " Skipping Creation!";
+                                   << calState;
                 }
-                else
-                {
-                    // all init complete, safe to autosave chaperone profile
-                    parent->m_chaperoneTabController.createNewAutosaveProfile();
-                }
+                // all init complete, safe to autosave chaperone profile
+                parent->m_chaperoneTabController.createNewAutosaveProfile();
                 m_initComplete = true;
             }
             else
@@ -1196,9 +1193,8 @@ void MoveCenterTabController::updateChaperoneResetData()
     auto cstate = vr::VRChaperone()->GetCalibrationState();
     if ( cstate > 199 )
     {
-        LOG( ERROR ) << "Chaperone Calibration State is error: " << cstate
-                     << " While Trying to Update Reset Data";
-        return;
+        LOG( WARNING ) << "Chaperone Calibration State is error: " << cstate
+                       << " While Trying to Update Reset Data";
     }
     else
     {

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -1908,12 +1908,13 @@ void MoveCenterTabController::resetOffsets( bool resetOffsetsJustPressed )
         auto calState = vr::VRChaperone()->GetCalibrationState();
         LOG( INFO ) << "Calibration State on Reset Offsets is: " << calState;
 
-        if ( calState > 199 && m_initComplete )
-        {
-            LOG( INFO ) << "Chaperone calibration state is error, attempting "
-                           "to apply autosaved profile to fix issue";
-            parent->m_chaperoneTabController.applyAutosavedProfile();
-        }
+        //        if ( calState > 199 && m_initComplete )
+        //        {
+        //            LOG( INFO ) << "Chaperone calibration state is error,
+        //            attempting "
+        //                           "to apply autosaved profile to fix issue";
+        //            parent->m_chaperoneTabController.applyAutosavedProfile();
+        //        }
         // reset();
     }
 }

--- a/src/tabcontrollers/MoveCenterTabController.cpp
+++ b/src/tabcontrollers/MoveCenterTabController.cpp
@@ -136,6 +136,14 @@ void MoveCenterTabController::addOffset( float offset[] )
     updateSpace( true );
 }
 
+void MoveCenterTabController::addCurOffsetAsCenter()
+{
+    float off[3] = { -m_offsetX, m_offsetY, -m_offsetZ };
+    // zeroOffsets();
+    resetOffsets( true );
+    addOffset( off );
+}
+
 void MoveCenterTabController::deleteOffsetProfile( unsigned index )
 {
     if ( index < m_offsetProfiles.size() )

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -356,6 +356,7 @@ public slots:
     void addOffsetProfile( QString name );
     void applyOffsetProfile( unsigned index );
     void deleteOffsetProfile( unsigned index );
+    void addCurOffsetAsCenter();
 
 signals:
     void trackingUniverseChanged( int value );

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -196,7 +196,7 @@ private:
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
     int m_recenterStages = 0;
-    bool m_chaperoneHasCommit = false;
+    int m_chaperoneHasCommit = false;
 
     // Matrix used For Center Marker
     vr::HmdMatrix34_t m_offsetmatrix = utils::k_forwardUpMatrix;
@@ -279,6 +279,8 @@ public:
     void saveOffsetProfiles();
     Q_INVOKABLE unsigned getOffsetProfileCount();
     Q_INVOKABLE QString getOffsetProfileName( unsigned index );
+
+    void addOffset( float offset[3] );
 
     // actions:
     void leftHandSpaceDrag( bool leftHandDragActive );

--- a/src/tabcontrollers/MoveCenterTabController.h
+++ b/src/tabcontrollers/MoveCenterTabController.h
@@ -196,6 +196,7 @@ private:
     unsigned m_dragComfortFrameSkipCounter = 0;
     unsigned m_turnComfortFrameSkipCounter = 0;
     int m_recenterStages = 0;
+    bool m_chaperoneHasCommit = false;
 
     // Matrix used For Center Marker
     vr::HmdMatrix34_t m_offsetmatrix = utils::k_forwardUpMatrix;

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 8, "patch": 10, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 11, "updateMessage": "", "optionalMessage": "" }

--- a/ver/versioncheck.json
+++ b/ver/versioncheck.json
@@ -1,1 +1,1 @@
-{ "major": 5, "minor": 8, "patch": 9, "updateMessage": "", "optionalMessage": "" }
+{ "major": 5, "minor": 8, "patch": 10, "updateMessage": "", "optionalMessage": "" }


### PR DESCRIPTION
## Fixes

- Fixed an issue where space drag would not properly initialize if a user's base stations were asleep
- Fixed an issue preventing third party apps to adjust chaperone properly note: this is the default behavior, but changes will only properly apply when there are no current offsets
- Changed the space fix tab features to be based off of space drag logic